### PR TITLE
Added a scaling factor to BASEX

### DIFF
--- a/abel/core.py
+++ b/abel/core.py
@@ -51,9 +51,9 @@ from .io import parse_matlab
 
 class BASEX(object):
 
-    def __init__(self, n=501, nbf=250, basis_dir='./', use_basis_set=None,
-                    calc_speeds=False, pixel_size=1.0, correct_scaling=True,
-                    verbose=True):
+    def __init__(self, n=501, nbf=250, basis_dir='./',
+                    use_basis_set=None, verbose=True, calc_speeds=False,
+                    pixel_size=1.0, scaling_correction=True):
         """ Initalize the BASEX class, preloading or generating the basis set.
 
         Parameters:
@@ -70,7 +70,7 @@ class BASEX(object):
                   Gzip compressed text files are accepted.
           - calc_speeds: determines if the speed distribution should be calculated
           - pixel_size: size of one pixel in the radial direction (optional)
-          - correct_scaling: correct the result by a heuristic scaling factor
+          - scaling_correction: correct the result by a heuristic scaling factor
                             as to be consistent with the analytical inverse Abel transform.
                             This requires to set pixel_size to the correct value.
           - verbose: Set to True to see more output for debugging
@@ -80,7 +80,7 @@ class BASEX(object):
 
         self.verbose = verbose
         self.calc_speeds = calc_speeds
-        self.correct_scaling = correct_scaling
+        self.scaling_correction = scaling_correction
         self.pixel_size = pixel_size
 
         self.n = n
@@ -173,7 +173,8 @@ class BASEX(object):
 
     def _get_scaling_factor(self):
 
-        return 1./self.pixel_size
+        MAGIC_NUMBER = 8.053   # see https://github.com/PyAbel/PyAbel/issues/4
+        return MAGIC_NUMBER/self.pixel_size
 
 
 
@@ -241,7 +242,7 @@ class BASEX(object):
         if self.ndim == 1:
             recon = recon[0, :] # taking one row, since they are all the same anyway
 
-        if self.correct_scaling:
+        if self.scaling_correction:
             recon *= self._get_scaling_factor()
 
         if self.calc_speeds:


### PR DESCRIPTION
Following the issue #4 , this PR adds a fixed scaling factor of `8.053` on the output of the BASEX algorithm as to match the analytical results.

Here, I used the symmetric step function example (see PR #16 )  that depends on a number of parameters, including:
 - `n` : number of points along the r axis
 - `r_max`: range of the symmetric r interval
 - `r1`, `r2`: bounds of the step function for (r > 0)
 - A0:  height of the step

So the test code I used is accessible here https://gist.github.com/rth/9885931342bf8a5ad056 ( requires PR #16). Essentially, it calculates the ratio between the height of the reconstructed signal to the original one (e.i. the scaling factor). Then sweeps along different input parameters are performed in order to determine which ones influence the scaling factor. 

The original result is here:  http://pastebin.com/EWsRVhMB  where we want to have `ratio_mean == 1` if the scaling is correct. 

So by normalizing the output by `8.053/pixel_size` we do obtain the correct scaling in all the tested cases: http://pastebin.com/S6FtmR4m (up to a precision given by `ratio_std` as there is some noise in the reconstructed signal). 

@DhrubajyotiDas I have also tried the [scaling value you used](https://github.com/DhrubajyotiDas/pyroBASEX/blob/master/BASEX/core.py#L160) of `1.1122` (note that you scaled the `Ci` matrix, while I scale the output signal). So this would be equivalent of scaling the output signal by  `1.1122*n` I think? In any case I was not able to get good agreement for all tested parameters with this value (see results at http://pastebin.com/1Zj5EwAS )

Anyway, this is a bit weird, at some point somebody would need to look up what factor is missing in the math, but for now I guess that's all we can do...