### PR TITLE
Added a list of dependencies

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -32,6 +32,6 @@ class SymStepBenchmark(object):
         """
         st = self.step
         mask2 = np.abs(np.abs(st.r)- 0.5*(st.r1 + st.r2)) < ratio*0.5*(st.r2 - st.r1)
-        err = (st.func/recon)[mask2]
+        err = st.func[mask2]/recon[mask2]
         return np.mean(err), np.std(err), np.sum(mask2)
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ setup(name='PyAbel',
       author='Dan Hickstein',
       packages=find_packages(),
       package_data={'abel': ['tests/data/*' ]},
+      install_requires=[
+              "numpy >= 1.6",
+              "setuptools >= 16.0",
+              "scipy >= 0.15",
+              ],
       test_suite="abel.tests.run_cli"
      )
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='PyAbel',
       install_requires=[
               "numpy >= 1.6",
               "setuptools >= 16.0",
-              "scipy >= 0.15",
+              "scipy >= 0.14",
               ],
       test_suite="abel.tests.run_cli"
      )


### PR DESCRIPTION
Added a list of dependencies 
    ` "numpy >= 1.6"`,   ` "setuptools >= 16.0"`,   ` "scipy >= 0.14"`  
which should not be too constraining and we can lower the version numbers if needed. 

Checked that 

     pip install git+https://github.com/PyAbel/PyAbel.git

works and the current tests pass on Linux and Windows (with conda). Same applies to `python setup.py install`  Pip will also try to install missing dependencies although in the case of numpy/scipy this might not be very desirable (compiling from sources is long).