### PR TITLE
Fixed centering function

### DIFF
--- a/abel/tools.py
+++ b/abel/tools.py
@@ -78,24 +78,20 @@ def center_image(data, center, n, ndim=2):
     elif ndim == 2:
         cx, cy = np.asarray(center, dtype='int')
         
-        #make an array of zeros that is large enough for cropping or padding:
+        # Make an array of zeros that is large enough for cropping or padding:
         sz = 2*np.round(n + np.max((Nw, Nh)))
         im = np.zeros((sz, sz))
+        
+        # Set center of "zeros image" to be the data
         im[sz//2-cy:sz//2-cy+Nh, sz//2-cx:sz//2-cx+Nw] = data
         
-        im = im[ sz//2-n_2:n_2+sz//2+1, sz//2-n_2:n_2+sz//2+1]
+        # Crop padded image to size n 
+        # note the n%2 which return the appropriate image size for both 
+        # odd and even images
+        im = im[ sz//2-n_2:n_2+sz//2+n%2, sz//2-n_2:n_2+sz//2+n%2]
         
-        #print(np.shape(im))
     else:
         raise ValueError
-
-    if n%2==0: # if n is odd
-        return im[:-1,:-1]
-        
-    else:      # if n is even
-        return im
-
-
 
 
 

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -88,10 +88,12 @@ def center_image(data, center, n, ndim=2):
         # Crop padded image to size n 
         # note the n%2 which return the appropriate image size for both 
         # odd and even images
-        im = im[ sz//2-n_2:n_2+sz//2+n%2, sz//2-n_2:n_2+sz//2+n%2]
+        im = im[sz//2-n_2:n_2+sz//2+n%2, sz//2-n_2:n_2+sz//2+n%2]
         
     else:
         raise ValueError
+    
+    return im
 
 
 

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -89,7 +89,11 @@ def center_image(data, center, n, ndim=2):
     else:
         raise ValueError
 
-    return im
+    if n%2==0: # if n is odd
+        return im[:-1,:-1]
+        
+    else:      # if n is even
+        return im
 
 
 

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -52,12 +52,7 @@ def center_image(data, center, n, ndim=2):
         im = np.zeros((sz, sz))
         im[sz//2-cy:sz//2-cy+Nh, sz//2-cx:sz//2-cx+Nw] = data
         
-        if n%2==0:
-            # If the image size is even, use lower left of the central 4 pixels as center
-            im = im[ sz//2-n_2-1:n_2+sz//2, sz//2-n_2-1:n_2+sz//2]
-        if n%2==1:
-            # If the image size is odd, set the central pixel to be exactly center
-            im = im[ sz//2-n_2:n_2+sz//2+1, sz//2-n_2:n_2+sz//2+1]
+        im = im[ sz//2-n_2:n_2+sz//2+1, sz//2-n_2:n_2+sz//2+1]
         
         #print(np.shape(im))
     else:

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -51,7 +51,14 @@ def center_image(data, center, n, ndim=2):
         sz = 2*np.round(n + np.max((Nw, Nh)))
         im = np.zeros((sz, sz))
         im[sz//2-cy:sz//2-cy+Nh, sz//2-cx:sz//2-cx+Nw] = data
-        im = im[ sz//2-n_2-1:n_2+sz//2, sz//2-n_2-1:n_2+sz//2] #not sure if this exactly preserves the center
+        
+        if n%2==0:
+            # If the image size is even, use lower left of the central 4 pixels as center
+            im = im[ sz//2-n_2-1:n_2+sz//2, sz//2-n_2-1:n_2+sz//2]
+        if n%2==1:
+            # If the image size is odd, set the central pixel to be exactly center
+            im = im[ sz//2-n_2:n_2+sz//2+1, sz//2-n_2:n_2+sz//2+1]
+        
         #print(np.shape(im))
     else:
         raise ValueError


### PR DESCRIPTION
We will need to think more about centering, but in the short run, this PR fixes the bug where the center was shifted by one pixel for odd-sized imaged. The behavior is also correct for even-sized images (using the convention discussed in https://github.com/PyAbel/PyAbel/issues/34 if we return ``im[:-1,:-1]`` (Currently we are returning an odd-sized image even if we get an even sized image in. This seems good for what we currently know about basex, but in the long run we should change it to allow both even and odd images.)

Here is some code I used for testing:
```python
import numpy as np
import matplotlib.pyplot as plt
import abel

# # Odd:

n=5
data = np.zeros((n,n))

data[2,2]=1


# # # Even:
# n=4
# data = np.zeros((n,n))
#
# data[2,2]=1
# data[2,1]=1
# data[1,1]=1
# data[1,2]=1

center = (2,2)

fig = plt.figure(figsize=(12,6))
ax1 = plt.subplot(121)
ax2 = plt.subplot(122)

d2 = abel.tools.center_image(data,center=center,n=n)

ax1.imshow(data,interpolation='nearest',origin='lower')
ax2.imshow(d2,  interpolation='nearest',origin='lower')

ax1.set_title('Raw data')
ax2.set_title('Center=(%i,%i)'%(center[0],center[1]))

plt.show()
```

![image](https://cloud.githubusercontent.com/assets/1107796/11460773/6b33fc98-96c1-11e5-9d09-e30e22bcd234.png)

![image](https://cloud.githubusercontent.com/assets/1107796/11460775/744d13a0-96c1-11e5-85db-f77d5020b8c0.png)
