### PR TITLE
Add unit tests for the centering function

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -7,6 +7,48 @@ from __future__ import unicode_literals
 
 import numpy as np
 
+from .tools import get_image_quadrants
+
+
+def is_symmetric(arr, i_sym=True, j_sym=True):
+    """
+    Takes in an array of shape (n, m) and check if it is symmetric
+
+    Parameters:
+       - arr: 1D or 2D array
+       - i_sym: array is symmetric with respect to the 1st axis
+       - j_sym: array is symmetric with respect to the 2nd axis
+
+    Returns:
+       an binary array with correspoding conditions.
+       The global validity can be checked with all(array)
+
+    Note: if both i_sym=True and i_sym=True, the input array is checked
+    for polar symmetry.
+
+    See https://github.com/PyAbel/PyAbel/issues/34#issuecomment-160344809 for
+    the defintion of a center of the image.
+    """
+
+    Q0, Q1, Q2, Q3 = get_image_quadrants(arr)
+
+
+    if i_sym and not j_sym:
+        valid_flag = [ np.allclose(np.fliplr(Q1), Q0),
+                       np.allclose(np.fliplr(Q2), Q3) ]
+    elif not i_sym and j_sym:
+        valid_flag = [ np.allclose(np.flipud(Q1), Q2),
+                       np.allclose(np.flipud(Q0), Q3) ]
+    elif i_sym and j_sym:
+        valid_flag = [ np.allclose(np.flipud(np.fliplr(Q1)), Q3),
+                       np.allclose(np.flipud(np.fliplr(Q0)), Q2) ]
+    else:
+        raise ValueError('Checking for symmetry with both i_sym=False and j_sym=False'\
+                         'does not make sens!') 
+
+    return np.array(valid_flag)
+
+
 
 def absolute_ratio_benchmark(analytical, recon):
     """

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -20,8 +20,8 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
        - j_sym: array is symmetric with respect to the 2nd axis
 
     Returns:
-       an binary array with correspoding conditions.
-       The global validity can be checked with all(array)
+       a binary array with the symmetry condition for the corresponding quadrants.
+       The global validity can be checked with `array.all()`
 
     Note: if both i_sym=True and i_sym=True, the input array is checked
     for polar symmetry.

--- a/abel/tests/test_benchmarks.py
+++ b/abel/tests/test_benchmarks.py
@@ -4,14 +4,47 @@ from __future__ import print_function
 
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from abel.analytical import StepAnalytical, GaussianAnalytical
-from abel.benchmark import absolute_ratio_benchmark
+from abel.benchmark import absolute_ratio_benchmark, is_symmetric
 
 
-def assert_equal(x, y, message):
+def assert_allclose_msg(x, y, message):
     assert np.allclose(x, y), message
+
+
+def test_symmetry_function():
+    # Check the consistency of abel.benchmark.is_symmetric
+
+    # checking all combination of odd and even images
+    for n, m in [(11, 11),
+                 (10, 10),
+                 (10, 12),
+                 (11, 12),
+                 (10, 13),
+                 (11, 13)
+                 ]:
+        x = np.linspace(-np.pi, np.pi, n)
+        y = np.linspace(-np.pi, np.pi, m)
+
+        XX, YY = np.meshgrid(x, y)
+
+
+        f1 = np.cos(XX)*np.cos(YY)
+        yield assert_equal, is_symmetric(f1, i_sym=True, j_sym=True), True,\
+              'Checking f1 function for polar symmetry n={},m={}'.format(n,m)
+
+        f2 = np.cos(XX)*np.sin(YY)
+        yield assert_equal, is_symmetric(f2, i_sym=True, j_sym=False), True,\
+              'Checking f2 function for i symmetry n={},m={}'.format(n,m)
+
+        f3 = np.sin(XX)*np.cos(YY)
+        yield assert_equal, is_symmetric(f3, i_sym=False, j_sym=True), True, \
+              'Checking f3 function for j symmetry n={},m={}'.format(n,m)
+
+        yield assert_equal, is_symmetric(f3, i_sym=True, j_sym=False), False, \
+              'Checking that f3 function does not have i symmetry n={},m={}'.format(n,m)
 
 
 def test_absolute_ratio_benchmark():
@@ -31,5 +64,7 @@ def test_absolute_ratio_benchmark():
             backend_name = type(ref).__name__
 
 
-            yield assert_equal, ratio_mean, 1.0, "Sanity test, sym={}: {}: ratio == 1.0".format(symmetric, backend_name)
-            yield assert_equal, ratio_std, 0.0,   "Sanity test, sym={}: {}: std == 0.0".format(symmetric, backend_name)
+            yield assert_allclose_msg, ratio_mean, 1.0,\
+                    "Sanity test, sym={}: {}: ratio == 1.0".format(symmetric, backend_name)
+            yield assert_allclose_msg, ratio_std, 0.0,\
+                    "Sanity test, sym={}: {}: std == 0.0".format(symmetric, backend_name)

--- a/abel/tests/test_benchmarks.py
+++ b/abel/tests/test_benchmarks.py
@@ -46,6 +46,12 @@ def test_symmetry_function():
         yield assert_equal, is_symmetric(f3, i_sym=True, j_sym=False), False, \
               'Checking that f3 function does not have i symmetry n={},m={}'.format(n,m)
 
+    for n in [10, 11]:
+        x = np.linspace(-np.pi, np.pi, n)
+        f1 = np.cos(x)
+        yield assert_equal, is_symmetric(f1, i_sym=True, j_sym=False), True,\
+              'Checking f1 function for symmetry in 1D n={},m={}'.format(n,m)
+
 
 def test_absolute_ratio_benchmark():
     # Mostly sanity to check that Analytical functions don't have typos

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -5,16 +5,17 @@ from __future__ import print_function
 import os.path
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
-from abel.tools import calculate_speeds
+from abel.tools import calculate_speeds, center_image
 
 
 
 DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
 
-def assert_equal(x, y, message, rtol=1e-5):
+def assert_allclose_msg(x, y, message, rtol=1e-5):
     assert np.allclose(x, y, rtol=1e-5), message
+
 
 def test_speeds():
     # This very superficial test checks that calculate_speeds is able to
@@ -27,6 +28,14 @@ def test_speeds():
     calculate_speeds(IM, n)
 
 
-def test_centering_function():
-    pass
-
+def test_centering_function_shape():
+    # ni -> original shape
+    # n  -> result of the centering function
+    for (ni, n) in [(20, 10), # crop image
+                    (20, 11),
+                    (4, 10),  # pad image
+                    (4, 11)]:
+        data = np.zeros((ni, ni))
+        res = center_image(data, (ni//2, ni//2), n)
+        yield assert_equal, res.shape, (n, n),\
+                    'Centering preserves shapes for ni={}, n={}'.format(ni, n)

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from abel.tools import calculate_speeds, center_image
+from abel.benchmark import is_symmetric
 
 
 
@@ -39,3 +40,30 @@ def test_centering_function_shape():
         res = center_image(data, (ni//2, ni//2), n)
         yield assert_equal, res.shape, (n, n),\
                     'Centering preserves shapes for ni={}, n={}'.format(ni, n)
+
+
+def test_centering_function():
+    # ni -> original shape of the data is (ni, ni)
+    # n_c  -> the image center is (n_c, n_c)
+    # n  -> after the centering function, the array has a shape (n, n)
+
+    for (ni, n_c, n) in [(9, 5, 3),
+                         (9, 5, 4),
+                         ]:
+        arr = np.zeros((ni, ni))
+
+        if n % 2 == 1:
+            arr[n_c-1:n_c+2,n_c-1:n_c+2] = 1
+        else:
+            arr[n_c-1:n_c+1,n_c-1:n_c+1] = 1
+
+        res = center_image(arr, (n_c, n_c), n)
+        # The print statements  below can be commented after we fix the centering issue
+        print('Original array')
+        print(arr)
+        print('Centered array')
+        print(res)
+
+        yield assert_equal, is_symmetric(res), True,\
+            'Validating the centering function for ni={}, n_c={}, n={}'.format(ni, n_c, n)
+

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -25,3 +25,8 @@ def test_speeds():
     IM = np.random.randn(n, n)
 
     calculate_speeds(IM, n)
+
+
+def test_centering_function():
+    pass
+

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -34,6 +34,8 @@ def get_image_quadrants(img):
     Given an image (m,n) reuturn its 4 quadratnts Q0, Q1, Q2, Q3
     as defined in abel.hansenlaw.iabel_hansenlaw
     """
+    img = np.atleast_2d(img)
+
     n, m = img.shape
 
     if n % 2 == 1:

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -29,24 +29,21 @@ def calculate_speeds(IM, n):
     return speeds
 
 
-def get_image_quadrants(img):
+def get_image_quadrants(img, reorientate=False):
     """
-    Given an image (m,n) reuturn its 4 quadratnts Q0, Q1, Q2, Q3
+    Given an image (m,n) reuturn its 4 quadrants Q0, Q1, Q2, Q3
     as defined in abel.hansenlaw.iabel_hansenlaw
+
+    Parameters:
+      - img: 1D or 2D array
+      - reorientate: reorientate image as required by abel.hansenlaw.iabel_hansenlaw
     """
     img = np.atleast_2d(img)
 
     n, m = img.shape
 
-    if n % 2 == 1:
-        n_c = n//2 + 1
-    else:
-        n_c = n//2
-
-    if m % 2 == 1:
-        m_c = m//2 + 1
-    else:
-        m_c = m//2
+    n_c = n//2 + n%2
+    m_c = m//2 + m % 2
 
     # define 4 quadrants of the image
     # see definition in abel.hansenlaw.iabel_hansenlaw
@@ -54,6 +51,11 @@ def get_image_quadrants(img):
     Q2 = img[-n_c:, :m_c]
     Q0 = img[:n_c, -m_c:]
     Q3 = img[-n_c:, -m_c:]
+
+    if reorientate:
+        Q0 = np.fliplr(Q0)
+        Q2 = np.flipud(Q2)
+        Q3 = np.fliplr(np.flipud(Q3))
 
     return Q0, Q1, Q2, Q3
 

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -29,6 +29,33 @@ def calculate_speeds(IM, n):
     return speeds
 
 
+def get_image_quadrants(img):
+    """
+    Given an image (m,n) reuturn its 4 quadratnts Q0, Q1, Q2, Q3
+    as defined in abel.hansenlaw.iabel_hansenlaw
+    """
+    n, m = img.shape
+
+    if n % 2 == 1:
+        n_c = n//2 + 1
+    else:
+        n_c = n//2
+
+    if m % 2 == 1:
+        m_c = m//2 + 1
+    else:
+        m_c = m//2
+
+    # define 4 quadrants of the image
+    # see definition in abel.hansenlaw.iabel_hansenlaw
+    Q1 = img[:n_c, :m_c]
+    Q2 = img[-n_c:, :m_c]
+    Q0 = img[:n_c, -m_c:]
+    Q3 = img[-n_c:, -m_c:]
+
+    return Q0, Q1, Q2, Q3
+
+
 def center_image(data, center, n, ndim=2):
     """ This centers the image at the given center and makes it of size n by n"""
     


### PR DESCRIPTION
This PR adds unit tests for the centering function as to solve the issue discussed in issue #34 . 

It adds following functions,
   -  `abel.tools.get_quadrants` :  a helper function to get the 4 quadrants of the image, as defined by @stggh implementation of Hassen&Law. The code is a bit different, but the result should be the same.
   - `abel.benchmark.is_symmetric`: checks that an image is symmetric, with respect to its center (both for odd and even images). The symmetry center is defined in the discussion of the issue #34.
   - `abel.tests.test_benchmark.test_symmetry_function`: some consistency tests for `is_symmetric`
   - `abel.tests.test_tools.test_centering_function_shape`: check that `center_image` preserves shape (for odd and even images)
   -  `abel.tests.test_tools.test_centering_function`: check that `center_image` centers the image correctly for both odd and even images.

With the current code base, 4 tests for the centering function do not pass (both in `test_centering_function_shape` and in `test_centering_function`), as can be seen in the [Travis CI logs](  https://travis-ci.org/PyAbel/PyAbel/jobs/93969224). This PR should be merged before PR #37, and those 4 failing tests should then be fixed by PR #37.