### PR TITLE
Hansen and Law algorithm updates

### DIFF
--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -193,7 +193,8 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
         verboseprint('Generating speed distribution ...')
         t1 = time()
 
-        speeds = calculate_speeds(recon,(N2-0.5,N2-0.5))
+        image_centre = (N2,N2) if N2%2 else (N2-0.5,N2-0.5)
+        speeds = calculate_speeds(recon,origin=image_centre)
 
         verboseprint('{:.2f} seconds'.format(time() - t1))
         return recon, speeds

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -9,7 +9,8 @@ import numpy as np
 import multiprocessing as mp 
 from time import time
 from math import exp, log, pow, pi
-from abel.tools import calculate_speeds, get_image_quadrants
+from abel.tools import calculate_speeds, get_image_quadrants,\
+                       put_image_quadrants
 
 ###########################################################################
 # hasenlaw - a recursive method inverse Abel transformation algorithm 
@@ -157,7 +158,7 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
 
     t0=time()
     # split image into quadrants
-    Q = get_image_quadrants(data, reorientate=True)
+    Q = get_image_quadrants(data, reorient=True)
     (N2,M2) = Q[0].shape   # quadrant size
 
     AQ = []  # empty reconstructed image
@@ -184,15 +185,8 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
            AQ.append(pool.map(iabel_hansenlaw_transform,\
                      [Q[q][row] for row in range(N2)]))
 
-    # for odd-pixel image trim off 1-pixel from end (centre)
-    if N2%2:
-        for q in (1,2,3):
-            AQ[q] = AQ[q][:,:-1]
-
     # reform image
-    Top    = np.concatenate ((AQ[1],np.fliplr(AQ[0])),axis=1)
-    Bottom = np.flipud(np.concatenate ((AQ[2],np.fliplr(AQ[3])),axis=1))
-    recon  = np.concatenate ((Top,Bottom),axis=0)
+    recon = put_image_quadrants(AQ,odd_size=N%2)
             
     verboseprint ("{:.2f} seconds".format(time()-t0))
 

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -169,7 +169,6 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
 
         Qcombined = Q[0]*quad[0]+Q[1]*quad[1]+Q[2]*quad[2]+Q[3]*quad[3]
         Q = (Qcombined,)    # one combined quadrant
-
     else:
         verboseprint ("HL: Individual quadrants")
 
@@ -194,7 +193,7 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
         verboseprint('Generating speed distribution ...')
         t1 = time()
 
-        speeds = calculate_speeds(recon)
+        speeds = calculate_speeds(recon,(N2-0.5,N2-0.5))
 
         verboseprint('{:.2f} seconds'.format(time() - t1))
         return recon, speeds

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import numpy as np
 from scipy.ndimage import map_coordinates
 
-def calculate_speeds(IM):
+def calculate_speeds(IM,origin=None):
     """ This performs an angular integration of the image and returns the one-dimentional intensity profile 
         as a function of the radial coordinate. It assumes that the image is properly centered. 
         
@@ -21,7 +21,7 @@ def calculate_speeds(IM):
       - speeds: a 1D array of the integrated intensity versus the radial coordinate.
      """
     
-    polarIM, ri, thetai = reproject_image_into_polar(IM)
+    polarIM, ri, thetai = reproject_image_into_polar(IM,origin)
 
     speeds = np.sum(polarIM, axis=1)
     

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -32,21 +32,21 @@ def calculate_speeds(IM):
     return speeds
 
 
-def get_image_quadrants(img, reorientate=False):
+def get_image_quadrants(img, reorient=False):
     """
-    Given an image (m,n) reuturn its 4 quadrants Q0, Q1, Q2, Q3
+    Given an image (m,n) return its 4 quadrants Q0, Q1, Q2, Q3
     as defined in abel.hansenlaw.iabel_hansenlaw
 
     Parameters:
       - img: 1D or 2D array
-      - reorientate: reorientate image as required by abel.hansenlaw.iabel_hansenlaw
+      - reorient: reorient image as required by abel.hansenlaw.iabel_hansenlaw
     """
     img = np.atleast_2d(img)
 
     n, m = img.shape
 
     n_c = n//2 + n%2
-    m_c = m//2 + m % 2
+    m_c = m//2 + m%2
 
     # define 4 quadrants of the image
     # see definition in abel.hansenlaw.iabel_hansenlaw
@@ -55,13 +55,42 @@ def get_image_quadrants(img, reorientate=False):
     Q0 = img[:n_c, -m_c:]
     Q3 = img[-n_c:, -m_c:]
 
-    if reorientate:
+    if reorient:
         Q0 = np.fliplr(Q0)
         Q2 = np.flipud(Q2)
         Q3 = np.fliplr(np.flipud(Q3))
 
     return Q0, Q1, Q2, Q3
 
+def put_image_quadrants (Q,odd_size=False):
+    """
+    Reassemble image from 4 quadrants Q = (Q0, Q1, Q2, Q3)
+    The reverse process to get_image_quadrants()
+    Qi defined in abel.hansenlaw.iabel_hansenlaw
+    
+    Parameters:
+      - Q: tuple of N2xN2 numpy array quadrants
+      - even_size: boolean, whether final image is even or odd pixel size
+                   odd size requires trimming 1 row from Q1, Q0, and
+                                              1 column from Q1, Q2
+
+    Returns:  
+      - NxN numpy array - the reassembled image
+    """
+
+
+    if not odd_size:
+        Top    = np.concatenate ((Q[1],np.fliplr(Q[0])),axis=1)
+        Bottom = np.flipud(np.concatenate ((Q[2],np.fliplr(Q[3])),axis=1))
+    else:
+        # odd size image remove extra row/column added in get_image_quadrant()
+        Top    = np.concatenate ((Q[1][:-1,:-1],np.fliplr(Q[0][:-1,:])),axis=1)
+        Bottom = np.flipud(np.concatenate ((Q[2][:,:-1],np.fliplr(Q[3])),axis=1))
+
+    img = np.concatenate ((Top,Bottom),axis=0)
+
+    return img
+ 
 
 def center_image(data, center, n, ndim=2):
     """ This centers the image at the given center and makes it of size n by n"""

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -49,7 +49,7 @@ print ('image size {:d}x{:d}'.format(n,m))
 print('Performing Hansen and Law inverse Abel transform:')
 
 # quad = (True ... => combine the 4 quadrants into one
-recon, speeds = iabel_hansenlaw (im,quad=(False,False,False,False),verbose=True,freecpus=1)
+recon, speeds = iabel_hansenlaw (im,quad=(True,True,True,True),verbose=True,freecpus=1)
 
 # save the transform in 8-bit format:
 scipy.misc.imsave(output_image,recon)


### PR DESCRIPTION
The main issue is that ```reproject_into_polar()``` does not appear to handle even pixel sized images, due to the use of (integer,integer) coordinate centre, and associated ```np.meshgrid()```, as discussed in issue #39.  Edit: I take it back ```index_coords()``` accepts origin=(x,y). Just need to pass origin=(x,y) via tools.calculate_speeds()```, I think.

NB ```iabel_hansenlaw()``` performs the correct inverse Abel transform, so the code is still good to merge, with a caveat on the speed distribution, that is nearly correct.