### PR TITLE
hansenlaw changes to process 1/2 image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build/
 *.egg-info/
 *.npy 
 examples/data/Xenon_800_nm*
+examples/*.pdf
+examples/*.png
+examples/*basis*
+examples/*.dat

--- a/README.md
+++ b/README.md
@@ -2,23 +2,36 @@
 
 [![Build Status](https://travis-ci.org/PyAbel/PyAbel.svg?branch=master)](https://travis-ci.org/PyAbel/PyAbel)
 
-PyAbel is a Python package for performing Abel and (primarily) inverse Abel transforms. The Abel transform takes a 3D object and finds the 2D projection of that object. The more difficult problem -- the inverse Abel transform -- takes the 2D projection and finds the central slice of the 3D object by assuming cylindrical symmetry in the vertical direction.
+PyAbel is a Python package for performing Abel and (primarily) inverse Abel transforms. The Abel transform takes a cylindrically symmetric 3D object and finds the 2D projection of that object. The more difficult problem -- the inverse Abel transform -- takes the 2D projection and finds the central slice of the 3D object by assuming cylindrical symmetry in the vertical direction.
 
-Currently, this package only uses the BASEX algorithm creared by Dribinski, Ossadtchi, Mandelshtam, and Reisler [[Rev. Sci. Instrum. 73 2634, (2002)](http://dx.doi.org/10.1063/1.1482156)], but we hope to include more algorithms for the inverse Abel transform in the future! 
+The PyAbel package offers several options for completing the inverse Abel transform:
 
-The BASEX implementation uses Gaussian basis functions to find the transform instead of analytically solving the inverse Abel transform or applying the Fourier-Hankel method, as both the analytical solution and the Fourier-Hankel methods provide lower quality transforms when applied to real-world datasets (see the RSI paper). The BASEX implementation is quick, robust, and is probably the most common method used to transform velocity-map-imaging (VMI) datasets.
+1) The BASEX algorithm creared by Dribinski, Ossadtchi, Mandelshtam, and Reisler [[Rev. Sci. Instrum. 73 2634, (2002)](http://dx.doi.org/10.1063/1.1482156)]. The BASEX implementation uses Gaussian basis functions to find the transform instead of analytically solving the inverse Abel transform.
 
-In this code, the axis of cylindrical symmetry is in assumed to be in the vertical direction. If this is not the case for your data, the `numpy.rot90` function may be useful.
+2) The "Hansen and Law" recursive method described in [[J. Opt. Soc. Am A 2 (4) 510 (1985)](dx.doi.org/10.1364/JOSAA.2.000510)]
+
+3) In the future, we hope to have more options for the forward and inverse abel transforms.
+
+### Symmetry
+
+In this code, the axis of cylindrical symmetry is in assumed to be in the vertical direction. If this is not the case for your data, the `numpy.rot90` function can be used to rotate your dataset.
 
 ### Installation notes
 
 This module requires Python 2.7 or 3.3-3.5. It can be installed with
 
     python setup.py install --user
-	
+
+Or, if you wish to edit the PyAbel code without re-installing each time (advanced users):
+
+    python setup.py develop
 
 ### Example of use
 
-See an  example in `examples/example_main.py`.
+See several example in `examples` folder.
+
+### Contributing
+
+We welcome new implementations of the inverse Abel transform or other code improvements. Please feel free to submit an issue or make a pull request.
 
 Have fun!

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 #from numba import jit
 import numpy as np
-import multiprocessing as mp 
 from time import time
 from math import exp, log, pow, pi
 from abel.tools import calculate_speeds, get_image_quadrants,\
@@ -31,10 +30,9 @@ from abel.tools import calculate_speeds, get_image_quadrants,\
 #
 ###########################################################################
 
-#@jit
-def iabel_hansenlaw_transform (ImgRow):
+def iabel_hansenlaw_transform(IM):
     """ Inverse Abel transformation using the algorithm of: 
-        Hansen and Law J. Opt. Soc. Am A2, 510-520 (1985).
+        Hansen and Law J. Opt. Soc. Am. A 2, 510-520 (1985).
                         
                        ∞                
                        ⌠                
@@ -58,8 +56,8 @@ def iabel_hansenlaw_transform (ImgRow):
 
         Parameters:
         ----------
-         - ImgRow: a n/2 numpy vector = one row of one quadrant of the image
-           |       orientated top/left
+         - Img: a n/2 x n/2 numpy array = one quadrant of the image
+           |    oriented top/left
            |     +--------+              --------+ 
            \=>   |      * |               *      |
                  |   *    |                  *   |
@@ -72,35 +70,45 @@ def iabel_hansenlaw_transform (ImgRow):
             
     """
 
-    N = np.size(ImgRow)     # length of pixel row, note in this case N = n/2
-    AImgRow = np.zeros(N)   # the inverse Abel transformed pixel row
+    N    = np.shape(IM)  # length of pixel row, note in this case N = n/2
+    AImg = np.zeros(N)   # the inverse Abel transformed pixel row
+    
+    nrows,ncols = N      # number of rows, number of columns
 
     # constants listed in Table 1.
     h   = [0.318,0.19,0.35,0.82,1.8,3.9,8.3,19.6,48.3]
     lam = [0.0,-2.1,-6.2,-22.4,-92.5,-414.5,-1889.4,-8990.9,-47391.1]
 
-    # Eq. (18)
-    Gamma = lambda Nm, lam: (1.0-pow(Nm,lam))/(pi*lam)\
-            if lam < -1 else -np.log(Nm)/pi         
+    # Eq. (18)            
+    def Gamma(Nm,lam):   
+        if lam < -1:
+            return (1.0-pow(Nm,lam))/(pi*lam)
+        else:
+            return -np.log(Nm)/pi    
 
     K = np.size(h)
-    X = np.zeros(K)
+    X = np.zeros((nrows,K))
 
     # g' - derivative of the intensity profile
-    gp = np.gradient (ImgRow)   
 
-    # iterate along the pixel row, starting at the outer edge to the image centre
-    for n in range(N-1):       
-        Nm = (N-n)/(N-n-1.0)    # R0/R 
-        for k in range(K):
-            X[k] = pow(Nm,lam[k])*X[k] + h[k]*Gamma(Nm,lam[k])*gp[n] # Eq. (17)
-        AImgRow[n] = X.sum()
+    gp = np.gradient(IM)[1]  # take the second element which is the gradient along the columns
 
-    AImgRow[N-1] = AImgRow[N-2]  # special case for N=N-1
-    return -AImgRow
+    # iterate along the column, starting at the outer edge to the image center
+    for col in range(ncols-1):       
+        Nm = (ncols-col)/(ncols-col-1.0)    # R0/R 
+        
+        for k in range(K): # Iterate over k, the eigenvectors?
+            X[:,k] = pow(Nm,lam[k])*X[:,k] + h[k]*Gamma(Nm,lam[k])*gp[:,col] # Eq. (17)            
+            
+        AImg[:,col] = X.sum(axis=1)
 
 
-def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=True,freecpus=1):
+    AImg[ncols-1] = AImg[ncols-2]  # special case for the center pixel
+    
+    return -AImg
+
+
+def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=True):
     """ Helper function for Hansen Law inverse Abel transform.
         (1) split image into quadrants
             (optional) exploit symmetry and co-add selected quadrants together
@@ -145,18 +153,15 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
 
           - calc_speeds: boolean, evaluate speed profile
           - verbose: boolean, more output, timings etc.
-          - freecpus: integer, parallel processing, use all cpus - freecpus (default 1)
     """  
     verboseprint = print if verbose else lambda *a, **k: None
-    
-    # parallel processing set pool = mp.Pool(1) if any multiprocessor issues
-    pool = mp.Pool(processes=mp.cpu_count()-freecpus) 
 
     (N,M) = data.shape
     verboseprint ("HL: Calculating inverse Abel transform:",
                       " image size {:d}x{:d}".format(N,M))
 
     t0=time()
+    
     # split image into quadrants
     Q = get_image_quadrants(data, reorient=True)
     (N2,M2) = Q[0].shape   # quadrant size
@@ -173,16 +178,16 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
         verboseprint ("HL: Individual quadrants")
 
     verboseprint ("HL: Calculating inverse Abel transform ... ")
-    # HL inverse Abel transform for quadrant Q0
-    AQ.append(pool.map(iabel_hansenlaw_transform,\
-                       [Q[0][row] for row in range(N2)]))
+    
+    # HL inverse Abel transform for quadrant 0
+    AQ.append(iabel_hansenlaw_transform(Q[0]))
 
-    if np.all(quad):
-       for q in (1,2,3): AQ.append(AQ[0])   # all quadrants the same
+    if np.any(quad):
+       for q in (1,2,3): AQ.append(AQ[0])   # if symmetry is applied, all quadrants the same
     else:
-       for q in (1,2,3):   # inverse Abel transform remaining quadrants
-           AQ.append(pool.map(iabel_hansenlaw_transform,\
-                     [Q[q][row] for row in range(N2)]))
+       # otherwise, take the inverse Abel transform of the remaining quadrants individually 
+       for q in (1,2,3):   
+           AQ.append(iabel_hansenlaw_transform(Q[q]))
 
     # reform image
     recon = put_image_quadrants(AQ,odd_size=N%2)

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 #from numba import jit
 import numpy as np
-import multiprocessing as mp 
 from time import time
 from math import exp, log, pow, pi
 from abel.tools import calculate_speeds, get_image_quadrants,\
@@ -28,13 +27,15 @@ from abel.tools import calculate_speeds, get_image_quadrants,\
 #    Molecule Dissociation", Flinders University, 2000.
 #
 # Implemented in Python, with image quadrant co-adding, by Steve Gibson
-#
+# 2015-12-03: Vectorization and code improvements Dan Hickstein and Roman Yurchak
+#             Previously the algorithm iterated over the rows of the image
+#             now all of the rows are calculated simultaneously, which provides
+#             the same result, but speeds up processing considerably.
 ###########################################################################
 
-#@jit
-def iabel_hansenlaw_transform (ImgRow):
+def iabel_hansenlaw_transform(IM):
     """ Inverse Abel transformation using the algorithm of: 
-        Hansen and Law J. Opt. Soc. Am A2, 510-520 (1985).
+        Hansen and Law J. Opt. Soc. Am. A 2, 510-520 (1985).
                         
                        ∞                
                        ⌠                
@@ -58,8 +59,8 @@ def iabel_hansenlaw_transform (ImgRow):
 
         Parameters:
         ----------
-         - Img: a n/2 x n/2 numpy array = one quadrant of the image
-           |    oriented top/left
+         - IM: a n/2 x n/2 numpy array = one quadrant of the image
+           |       oriented top/left
            |     +--------+              --------+ 
            \=>   |      * |               *      |
                  |   *    |                  *   |
@@ -72,35 +73,44 @@ def iabel_hansenlaw_transform (ImgRow):
             
     """
 
-    N = np.size(ImgRow)     # length of pixel row, note in this case N = n/2
-    AImgRow = np.zeros(N)   # the inverse Abel transformed pixel row
+    N    = np.shape(IM)  # length of pixel row, note in this case N = n/2
+    AImg = np.zeros(N)   # the inverse Abel transformed pixel row
+    
+    nrows,ncols = N      # number of rows, number of columns
 
     # constants listed in Table 1.
     h   = [0.318,0.19,0.35,0.82,1.8,3.9,8.3,19.6,48.3]
     lam = [0.0,-2.1,-6.2,-22.4,-92.5,-414.5,-1889.4,-8990.9,-47391.1]
 
-    # Eq. (18)
-    Gamma = lambda Nm, lam: (1.0-pow(Nm,lam))/(pi*lam)\
-            if lam < -1 else -np.log(Nm)/pi         
+    # Eq. (18)            
+    def Gamma(Nm,lam):   
+        if lam < -1:
+            return (1.0-pow(Nm,lam))/(pi*lam)
+        else:
+            return -np.log(Nm)/pi    
 
     K = np.size(h)
-    X = np.zeros(K)
+    X = np.zeros((nrows,K))
 
     # g' - derivative of the intensity profile
-    gp = np.gradient (ImgRow)   
 
-    # iterate along the pixel row, starting at the outer edge to the image centre
-    for n in range(N-1):       
-        Nm = (N-n)/(N-n-1.0)    # R0/R 
-        for k in range(K):
-            X[k] = pow(Nm,lam[k])*X[k] + h[k]*Gamma(Nm,lam[k])*gp[n] # Eq. (17)
-        AImgRow[n] = X.sum()
+    gp = np.gradient(IM)[1]  # take the second element which is the gradient along the columns
 
-    AImgRow[N-1] = AImgRow[N-2]  # special case for N=N-1
-    return -AImgRow
+    # iterate along the column, starting at the outer edge to the image center
+    for col in range(ncols-1):       
+        Nm = (ncols-col)/(ncols-col-1.0)    # R0/R 
+        
+        for k in range(K): # Iterate over k, the eigenvectors?
+            X[:,k] = pow(Nm,lam[k])*X[:,k] + h[k]*Gamma(Nm,lam[k])*gp[:,col] # Eq. (17)            
+            
+        AImg[:,col] = X.sum(axis=1)
+
+    AImg[ncols-1] = AImg[ncols-2]  # special case for the center pixel
+    
+    return -AImg
 
 
-def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=True,freecpus=1):
+def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=True):
     """ Helper function for Hansen Law inverse Abel transform.
         (1) split image into quadrants
             (optional) exploit symmetry and co-add selected quadrants together
@@ -145,18 +155,15 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
 
           - calc_speeds: boolean, evaluate speed profile
           - verbose: boolean, more output, timings etc.
-          - freecpus: integer, parallel processing, use all cpus - freecpus (default 1)
     """  
     verboseprint = print if verbose else lambda *a, **k: None
-    
-    # parallel processing set pool = mp.Pool(1) if any multiprocessor issues
-    pool = mp.Pool(processes=mp.cpu_count()-freecpus) 
 
     (N,M) = data.shape
     verboseprint ("HL: Calculating inverse Abel transform:",
                       " image size {:d}x{:d}".format(N,M))
 
     t0=time()
+    
     # split image into quadrants
     Q = get_image_quadrants(data, reorient=True)
     (N2,M2) = Q[0].shape   # quadrant size
@@ -173,16 +180,16 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
         verboseprint ("HL: Individual quadrants")
 
     verboseprint ("HL: Calculating inverse Abel transform ... ")
-    # HL inverse Abel transform for quadrant Q0
-    AQ.append(pool.map(iabel_hansenlaw_transform,\
-                       [Q[0][row] for row in range(N2)]))
+    
+    # HL inverse Abel transform for quadrant 0
+    AQ.append(iabel_hansenlaw_transform(Q[0]))
 
-    if np.all(quad):
-       for q in (1,2,3): AQ.append(AQ[0])   # all quadrants the same
+    if np.any(quad):
+       for q in (1,2,3): AQ.append(AQ[0])   # if symmetry is applied, all quadrants the same
     else:
-       for q in (1,2,3):   # inverse Abel transform remaining quadrants
-           AQ.append(pool.map(iabel_hansenlaw_transform,\
-                     [Q[q][row] for row in range(N2)]))
+       # otherwise, take the inverse Abel transform of the remaining quadrants individually 
+       for q in (1,2,3):   
+           AQ.append(iabel_hansenlaw_transform(Q[q]))
 
     # reform image
     recon = put_image_quadrants(AQ,odd_size=N%2)

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 #from numba import jit
 import numpy as np
+import multiprocessing as mp 
 from time import time
 from math import exp, log, pow, pi
 from abel.tools import calculate_speeds, get_image_quadrants,\
@@ -30,9 +31,10 @@ from abel.tools import calculate_speeds, get_image_quadrants,\
 #
 ###########################################################################
 
-def iabel_hansenlaw_transform(IM):
+#@jit
+def iabel_hansenlaw_transform (ImgRow):
     """ Inverse Abel transformation using the algorithm of: 
-        Hansen and Law J. Opt. Soc. Am. A 2, 510-520 (1985).
+        Hansen and Law J. Opt. Soc. Am A2, 510-520 (1985).
                         
                        ∞                
                        ⌠                
@@ -70,45 +72,35 @@ def iabel_hansenlaw_transform(IM):
             
     """
 
-    N    = np.shape(IM)  # length of pixel row, note in this case N = n/2
-    AImg = np.zeros(N)   # the inverse Abel transformed pixel row
-    
-    nrows,ncols = N      # number of rows, number of columns
+    N = np.size(ImgRow)     # length of pixel row, note in this case N = n/2
+    AImgRow = np.zeros(N)   # the inverse Abel transformed pixel row
 
     # constants listed in Table 1.
     h   = [0.318,0.19,0.35,0.82,1.8,3.9,8.3,19.6,48.3]
     lam = [0.0,-2.1,-6.2,-22.4,-92.5,-414.5,-1889.4,-8990.9,-47391.1]
 
-    # Eq. (18)            
-    def Gamma(Nm,lam):   
-        if lam < -1:
-            return (1.0-pow(Nm,lam))/(pi*lam)
-        else:
-            return -np.log(Nm)/pi    
+    # Eq. (18)
+    Gamma = lambda Nm, lam: (1.0-pow(Nm,lam))/(pi*lam)\
+            if lam < -1 else -np.log(Nm)/pi         
 
     K = np.size(h)
-    X = np.zeros((nrows,K))
+    X = np.zeros(K)
 
     # g' - derivative of the intensity profile
+    gp = np.gradient (ImgRow)   
 
-    gp = np.gradient(IM)[1]  # take the second element which is the gradient along the columns
+    # iterate along the pixel row, starting at the outer edge to the image centre
+    for n in range(N-1):       
+        Nm = (N-n)/(N-n-1.0)    # R0/R 
+        for k in range(K):
+            X[k] = pow(Nm,lam[k])*X[k] + h[k]*Gamma(Nm,lam[k])*gp[n] # Eq. (17)
+        AImgRow[n] = X.sum()
 
-    # iterate along the column, starting at the outer edge to the image center
-    for col in range(ncols-1):       
-        Nm = (ncols-col)/(ncols-col-1.0)    # R0/R 
-        
-        for k in range(K): # Iterate over k, the eigenvectors?
-            X[:,k] = pow(Nm,lam[k])*X[:,k] + h[k]*Gamma(Nm,lam[k])*gp[:,col] # Eq. (17)            
-            
-        AImg[:,col] = X.sum(axis=1)
-
-
-    AImg[ncols-1] = AImg[ncols-2]  # special case for the center pixel
-    
-    return -AImg
+    AImgRow[N-1] = AImgRow[N-2]  # special case for N=N-1
+    return -AImgRow
 
 
-def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=True):
+def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=True,freecpus=1):
     """ Helper function for Hansen Law inverse Abel transform.
         (1) split image into quadrants
             (optional) exploit symmetry and co-add selected quadrants together
@@ -153,15 +145,18 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
 
           - calc_speeds: boolean, evaluate speed profile
           - verbose: boolean, more output, timings etc.
+          - freecpus: integer, parallel processing, use all cpus - freecpus (default 1)
     """  
     verboseprint = print if verbose else lambda *a, **k: None
+    
+    # parallel processing set pool = mp.Pool(1) if any multiprocessor issues
+    pool = mp.Pool(processes=mp.cpu_count()-freecpus) 
 
     (N,M) = data.shape
     verboseprint ("HL: Calculating inverse Abel transform:",
                       " image size {:d}x{:d}".format(N,M))
 
     t0=time()
-    
     # split image into quadrants
     Q = get_image_quadrants(data, reorient=True)
     (N2,M2) = Q[0].shape   # quadrant size
@@ -178,16 +173,16 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
         verboseprint ("HL: Individual quadrants")
 
     verboseprint ("HL: Calculating inverse Abel transform ... ")
-    
-    # HL inverse Abel transform for quadrant 0
-    AQ.append(iabel_hansenlaw_transform(Q[0]))
+    # HL inverse Abel transform for quadrant Q0
+    AQ.append(pool.map(iabel_hansenlaw_transform,\
+                       [Q[0][row] for row in range(N2)]))
 
-    if np.any(quad):
-       for q in (1,2,3): AQ.append(AQ[0])   # if symmetry is applied, all quadrants the same
+    if np.all(quad):
+       for q in (1,2,3): AQ.append(AQ[0])   # all quadrants the same
     else:
-       # otherwise, take the inverse Abel transform of the remaining quadrants individually 
-       for q in (1,2,3):   
-           AQ.append(iabel_hansenlaw_transform(Q[q]))
+       for q in (1,2,3):   # inverse Abel transform remaining quadrants
+           AQ.append(pool.map(iabel_hansenlaw_transform,\
+                     [Q[q][row] for row in range(N2)]))
 
     # reform image
     recon = put_image_quadrants(AQ,odd_size=N%2)

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -32,66 +32,38 @@ def calculate_speeds(IM,origin=None):
     return speeds
 
 
-def get_image_quadrants(img, reorient=False):
+def add_image_col (im):
     """
-    Given an image (m,n) return its 4 quadrants Q0, Q1, Q2, Q3
-    as defined in abel.hansenlaw.iabel_hansenlaw
-
-    Parameters:
-      - img: 1D or 2D array
-      - reorient: reorient image as required by abel.hansenlaw.iabel_hansenlaw
-    """
-    img = np.atleast_2d(img)
-
-    n, m = img.shape
-
-    n_c = n//2 + n%2
-    m_c = m//2 + m%2
-
-    # define 4 quadrants of the image
-    # see definition in abel.hansenlaw.iabel_hansenlaw
-    Q1 = img[:n_c, :m_c]
-    Q2 = img[-n_c:, :m_c]
-    Q0 = img[:n_c, -m_c:]
-    Q3 = img[-n_c:, -m_c:]
-
-    if reorient:
-        Q0 = np.fliplr(Q0)
-        Q2 = np.flipud(Q2)
-        Q3 = np.fliplr(np.flipud(Q3))
-
-    return Q0, Q1, Q2, Q3
-
-def put_image_quadrants (Q,odd_size=False):
-    """
-    Reassemble image from 4 quadrants Q = (Q0, Q1, Q2, Q3)
-    The reverse process to get_image_quadrants()
-    Qi defined in abel.hansenlaw.iabel_hansenlaw
+    Add 1 column at image centre
+    increases image shape to (rows,columns+1)
     
-    Parameters:
-      - Q: tuple of N2xN2 numpy array quadrants
-      - even_size: boolean, whether final image is even or odd pixel size
-                   odd size requires trimming 1 row from Q1, Q0, and
-                                              1 column from Q1, Q2
-
-    Returns:  
-      - NxN numpy array - the reassembled image
+    Basex basis calculation requires odd size image
+    Hansen and Law operates on quadrants, an even size image
     """
+    rows,cols = im.shape
+    n2 = cols//2 + cols%2  # mid point
+    # add centre row
+    #im = np.concatenate((im[:n2],im[n2-1:n2],im[n2:]),axis=0)
+    # add centre column
+    im = np.concatenate((im[:,:n2],im[:,n2-1:n2],im[:,n2:]),axis=1)
+    return im
 
-
-    if not odd_size:
-        Top    = np.concatenate ((Q[1],np.fliplr(Q[0])),axis=1)
-        Bottom = np.flipud(np.concatenate ((Q[2],np.fliplr(Q[3])),axis=1))
-    else:
-        # odd size image remove extra row/column added in get_image_quadrant()
-        Top    = np.concatenate ((Q[1][:-1,:-1],np.fliplr(Q[0][:-1,:])),axis=1)
-        Bottom = np.flipud(np.concatenate ((Q[2][:,:-1],np.fliplr(Q[3])),axis=1))
-
-    img = np.concatenate ((Top,Bottom),axis=0)
-
-    return img
- 
-
+def delete_image_col (im):
+    """
+    Delete 1 column at image centre
+    decreases image shape to (rows,columns-1)
+    
+    Basex basis calculation requires odd size image width
+    Hansen and Law splits image into quadrants => an even size image width
+    """
+    rows,cols = im.shape
+    n2 = cols//2
+    # delete centre row
+    #im = np.concatenate((im[:n2],im[n2+1:]),axis=0)
+    # delete centre column
+    im = np.concatenate((im[:,:n2],im[:,n2+1:]),axis=1)
+    return im
+    
 def center_image(data, center, n, ndim=2):
     """ This centers the image at the given center and makes it of size n by n"""
     

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -30,10 +30,7 @@ import scipy.misc
 #   + ---+----+
 
 # Specify the path to the file
-#filename = 'data/O2-ANU1024.txt.bz2'
-#filename = 'data/O2-27M13CM2048.txt.bz2'
-#filename = 'data/O2-26J13CMI2048.txt.bz2'
-filename = 'data/O-28M23CMM8192.txt.bz2'
+filename = 'data/O2-ANU1024.txt.bz2'
 
 # Name the output files
 name = filename.split('.')[0].split('/')[1]
@@ -52,11 +49,7 @@ print ('image size {:d}x{:d}'.format(n,m))
 print('Performing Hansen and Law inverse Abel transform:')
 
 # quad = (True ... => combine the 4 quadrants into one
-<<<<<<< HEAD
-recon, speeds = iabel_hansenlaw (im,quad=(True,True,True,True),verbose=True)
-=======
 recon, speeds = iabel_hansenlaw (im,quad=(False,False,False,False),verbose=True)
->>>>>>> upstream/master
 
 # save the transform in 8-bit format:
 scipy.misc.imsave(output_image,recon)

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -36,7 +36,7 @@ import scipy.misc
 filename = 'data/O-28M23CMM8192.txt.bz2'
 
 # Name the output files
-name = filename.split('.')[0]
+name = filename.split('.')[0].split('/')[1]
 output_image = name + '_inverse_Abel_transform_HansenLaw.png'
 output_text  = name + '_speeds_HansenLaw.dat'
 output_plot  = name + '_comparison_HansenLaw.pdf'
@@ -52,7 +52,11 @@ print ('image size {:d}x{:d}'.format(n,m))
 print('Performing Hansen and Law inverse Abel transform:')
 
 # quad = (True ... => combine the 4 quadrants into one
+<<<<<<< HEAD
 recon, speeds = iabel_hansenlaw (im,quad=(True,True,True,True),verbose=True)
+=======
+recon, speeds = iabel_hansenlaw (im,quad=(False,False,False,False),verbose=True)
+>>>>>>> upstream/master
 
 # save the transform in 8-bit format:
 scipy.misc.imsave(output_image,recon)

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -10,7 +10,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from abel.hansenlaw import *
-from abel.io import load_raw
 import scipy.misc
 
 # This example demonstrates Hansen and Law inverse Abel transform
@@ -48,8 +47,7 @@ print ('image size {:d}x{:d}'.format(n,m))
 # Step 2: perform the Hansen & Law transform!
 print('Performing Hansen and Law inverse Abel transform:')
 
-# quad = (True ... => combine the 4 quadrants into one
-recon, speeds = iabel_hansenlaw (im,quad=(False,False,False,False),verbose=True)
+recon, speeds = iabel_hansenlaw (im,calc_speeds=True,verbose=True,quad=(False,False,False,False))
 
 # save the transform in 8-bit format:
 scipy.misc.imsave(output_image,recon)

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -30,7 +30,10 @@ import scipy.misc
 #   + ---+----+
 
 # Specify the path to the file
-filename = 'data/O2-ANU1024.txt.bz2'
+#filename = 'data/O2-ANU1024.txt.bz2'
+#filename = 'data/O2-27M13CM2048.txt.bz2'
+#filename = 'data/O2-26J13CMI2048.txt.bz2'
+filename = 'data/O-28M23CMM8192.txt.bz2'
 
 # Name the output files
 name = filename.split('.')[0]
@@ -49,7 +52,7 @@ print ('image size {:d}x{:d}'.format(n,m))
 print('Performing Hansen and Law inverse Abel transform:')
 
 # quad = (True ... => combine the 4 quadrants into one
-recon, speeds = iabel_hansenlaw (im,quad=(True,True,True,True),verbose=True,freecpus=1)
+recon, speeds = iabel_hansenlaw (im,quad=(True,True,True,True),verbose=True)
 
 # save the transform in 8-bit format:
 scipy.misc.imsave(output_image,recon)

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -50,7 +50,7 @@ print ('image size {:d}x{:d}'.format(n,m))
 print('Performing Hansen and Law inverse Abel transform:')
 
 # quad = (True ... => combine the 4 quadrants into one
-reconH, speedsH = iabel_hansenlaw (im,quad=(False,False,False,False),verbose=True,freecpus=1)
+reconH, speedsH = iabel_hansenlaw (im,quad=(False,False,False,False),verbose=True)
 
 # Basex inverse Abel transform
 print('Performing basex inverse Abel transform:')

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -34,7 +34,7 @@ import scipy.misc
 filename = 'data/O2-ANU1024.txt.bz2'
 
 # Name the output files
-name = filename.split('.')[0]
+name = filename.split('.')[0].split('/')[1]
 output_image = name + '_inverse_Abel_transform_HansenLaw.png'
 output_text  = name + '_speeds_HansenLaw.dat'
 output_plot  = name + '_comparison_HansenLaw.pdf'


### PR DESCRIPTION
In my attempt process the 649x519 Xe photoelectron image, I realised that the HL quadrant processing assumes a square image, when it need not. The treatment of odd/even width sized images requires only an addition of a pixel column. Hence, I removed ```get/put_image_quadrants``` from abel.tools, replaced with ```add_image_col, delete_image_col```. Any quadrant stuff is, specific to and is, handled by hansenlaw. Hansenlaw now handles odd and even images. Basex should call add_image_col(image) for even images, and delete_image_col(recon) after reconstruction, before the speed calculation. (see the example_hansenlaw files).

Agreement, between HL and basex is now excellent:
![example_hansenlaw_basex](https://cloud.githubusercontent.com/assets/10932229/11611993/2318a100-9c3b-11e5-88da-bcb5bb9cbc69.png)

The Xe spectrum also looks good:
![example_hansenlaw_xe](https://cloud.githubusercontent.com/assets/10932229/11611997/341ddf92-9c3b-11e5-9bb1-b39adc3870e7.png)

I am having problems rebasing with git mergetool, will try at ANU tomorrow.