### PR TITLE
Making Hansen-Law transform work for non-square images

### DIFF
--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -72,9 +72,10 @@ def iabel_hansenlaw_transform(IM):
                  +--------+      --------+
                               
     """
+    IM   = np.atleast_2d(IM)
     N    = np.shape(IM)  # length of pixel row, note in this case N = n/2
-    AImg = np.zeros(N)   # the inverse Abel transformed pixel row
-    
+    AImg = np.zeros(N)   # the inverse Abel transformed image
+
     nrows,ncols = N      # number of rows, number of columns
 
     # constants listed in Table 1.
@@ -160,7 +161,10 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
     """  
     verboseprint = print if verbose else lambda *a, **k: None
     
-    (N,M) = np.shape(np.atleast_2d(data))
+    if data.ndim == 1:
+            raise ValueError('Data must be 2-dimensional. To transform a single row, use iabel_hansenlaw_transform().')
+        
+    (N,M) = np.shape(data)
     verboseprint ("HL: Calculating inverse Abel transform:",
                       " image size {:d}x{:d}".format(N,M))
 

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -59,20 +59,19 @@ def iabel_hansenlaw_transform(IM):
 
         Parameters:
         ----------
-         - IM: a nRows/2 x n/2 numpy vector = one row of one quadrant of the image
+         - IM: a rows x cols numpy array = one row of one quadrant of the image
            |       orientated top/left
-           |     +--------+              --------+ 
-           \=>   |      * |               *      |
-                 |   *    |                  *   |
-                 |  *     |                   *  |
-                 +--------+              --------+
-                               |  *     |     *  |
-                               |   *    |    *   |
-                               |     *  | *      |
-                               +--------+--------+
-            
+           |     +--------+      --------+ 
+           \=>   |      * |       *      |
+                 |   *    |          *   |
+                 |  *     |           *  |
+                 +--------+      --------+
+                 |  *     |           *  |
+                 |   *    |          *   |
+                 |     *  |       *      |
+                 +--------+      --------+
+                              
     """
-
     N    = np.shape(IM)  # length of pixel row, note in this case N = n/2
     AImg = np.zeros(N)   # the inverse Abel transformed pixel row
     
@@ -93,10 +92,13 @@ def iabel_hansenlaw_transform(IM):
     X = np.zeros((nrows,K))
 
     # g' - derivative of the intensity profile
+    
+    if nrows>1:
+        gp = np.gradient(IM)[1]  # take the second element which is the gradient along the columns
+    else: # If there is only one row
+        gp = np.atleast_2d(np.gradient(IM[0]))
 
-    gp = np.gradient(IM)[1]  # take the second element which is the gradient along the columns
-
-    # iterate along the column, starting at the outer edge to the image center
+    # iterate along the columns, starting at the outer edge (left) to the image center
     for col in range(ncols-1):       
         Nm = (ncols-col)/(ncols-col-1.0)    # R0/R 
         
@@ -105,7 +107,7 @@ def iabel_hansenlaw_transform(IM):
             
         AImg[:,col] = X.sum(axis=1)
 
-    AImg[ncols-1] = AImg[ncols-2]  # special case for the center pixel
+    AImg[:,ncols-1] = AImg[:,ncols-2]  # special case for the center pixel
     
     return -AImg
 
@@ -157,8 +159,8 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
           - verbose: boolean, more output, timings etc.
     """  
     verboseprint = print if verbose else lambda *a, **k: None
-
-    (N,M) = data.shape
+    
+    (N,M) = np.shape(np.atleast_2d(data))
     verboseprint ("HL: Calculating inverse Abel transform:",
                       " image size {:d}x{:d}".format(N,M))
 

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -59,7 +59,7 @@ def iabel_hansenlaw_transform(IM):
 
         Parameters:
         ----------
-         - IM: a rows x cols numpy array = one row of one quadrant of the image
+         - IM: a rows x cols numpy array = one quadrant of the image
            |       orientated top/left
            |     +--------+      --------+ 
            \=>   |      * |       *      |

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -161,7 +161,7 @@ def iabel_hansenlaw (data,quad=(True,True,True,True),calc_speeds=True,verbose=Tr
     """  
     verboseprint = print if verbose else lambda *a, **k: None
     
-    if data.ndim == 1:
+    if data.ndim == 1 or np.shape(data)[0] <= 2:
             raise ValueError('Data must be 2-dimensional. To transform a single row, use iabel_hansenlaw_transform().')
         
     (N,M) = np.shape(data)


### PR DESCRIPTION
Following the discussion in https://github.com/PyAbel/PyAbel/pull/49, this PR fixes the second-to-last line in the ``iabel_hansenlaw_transform`` function in order to allow the transform to work with non-square images. 

I am actually not sure if this line is even necessary. The center few pixels are noisy in either case, and I cannot really tell if there is a difference by eye. @stggh, does this line serve a specific purpose?

___

Also, I added a ``np.atleast_2d()`` statement to make ``iabel_hansenlaw_transform`` work if it's passed an array that is 1D (also changed the ``np.gradient`` to work for 1D). 

Does it make sense for ``iabel_hansenlaw`` to also work with 1D images? It will require a little bit of extra hacking, since the up/down quadrants concept doesn't apply. Right now, ``iabel_hansenlaw`` does not produce the right result when passed a 1D array due to the quadrants, so I made it throw an error if it gets a 1D array.