### PR TITLE
Numpy compatibility

### DIFF
--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -67,8 +67,8 @@ def test_centering_function():
         assert_equal( is_symmetric(res), True,\
             'Validating the centering function for ni={}, n_c={}, n={}'.format(ni, n_c, n))
 
- def test_speeds_non_integer_center():  
-     # ensures that the rest speeds function can work with a non-integer center
-     n  = 101
-     IM = np.random.randn(n, n)
-     calculate_speeds(IM, origin=(50.5, 50.5))
+def test_speeds_non_integer_center():  
+    # ensures that the rest speeds function can work with a non-integer center
+    n  = 101
+    IM = np.random.randn(n, n)
+    calculate_speeds(IM, origin=(50.5, 50.5))

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -67,3 +67,8 @@ def test_centering_function():
         assert_equal( is_symmetric(res), True,\
             'Validating the centering function for ni={}, n_c={}, n={}'.format(ni, n_c, n))
 
+ def test_speeds_non_integer_center():  
+     # ensures that the rest speeds function can work with a non-integer center
+     n  = 101
+     IM = np.random.randn(n, n)
+     calculate_speeds(IM, origin=(50.5, 50.5))

--- a/abel/tools.py
+++ b/abel/tools.py
@@ -175,7 +175,9 @@ def index_coords(data, origin=None):
         origin_x, origin_y = nx // 2, ny // 2
     else:
         origin_x, origin_y = origin
-    x, y = np.meshgrid(np.arange(nx), np.arange(ny))
+    
+    x, y = np.meshgrid(np.arange(float(nx)), np.arange(float(ny)))
+    
     x -= origin_x
     y -= origin_y
     return x, y


### PR DESCRIPTION
This allows compatibility with the latest version of numpy (1.10.1), as discussed in https://github.com/PyAbel/PyAbel/issues/51. Only change was to explicitly cast ``nx`` and ``ny`` to floats in ``index_coords``. I think that they were being automatically being cast to floats previously, so the behavior should be the same.