### PR TITLE
Implementing Three-point Abel - another inverse Abel transformation algorithm

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -26,6 +26,7 @@ class AbelTiming(object):
         from .hansenlaw import iabel_hansenlaw
         from timeit import Timer
         from .direct import fabel_direct, iabel_direct, cython_ext
+        from .three_point import iabel_three_point
 
 
         self.n = n
@@ -57,7 +58,8 @@ class AbelTiming(object):
 
             res_iabel['HansenLaw']['tr'].append(
                 Timer(lambda: iabel_hansenlaw(x, verbose=False)).timeit(number=NREPEAT)/NREPEAT)
-
+            res_iabel['Three_point']['tr'].append(
+                Timer(lambda: iabel_three_point(x)).timeit(number=NREPEAT)/NREPEAT)
             res_iabel['direct_Python']['tr'].append(
                 Timer(lambda: iabel_direct(x, correction=False, backend='Python')).timeit(number=NREPEAT)/NREPEAT)
             res_fabel['direct_Python']['tr'].append(

--- a/abel/dasch.py
+++ b/abel/dasch.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from itertools import product
+
+def iable_dasch_transform(IM):
+    """ Inverse Abel transformation using the algorithm of: 
+        Dasch, Applied Optics, Vol. 31, No. 8, 1146-1152 (1992).
+
+        Parameters:
+        ----------
+         - IM: a rows x cols numpy array 
+
+         Returns:
+         --------
+         - inv_IM: a rows x cols numpy array containing the Abel inversion of IM
+    """
+    IM = np.atleast_2d(IM)
+    row, col = IM.shape
+    D = np.zeros((col, col))
+
+    for i,j in product(range(col), range(col)):
+        D[i,j] = OP_D(i,j)
+
+    inv_IM = np.zeros_like(IM)
+
+    for i, P in enumerate(IM):
+        F = np.zeros(col)
+        for j,k in product(range(col), range(col)):
+            F[j] += D[j,k] * P[k]
+
+        inv_IM[i] = F
+
+    return inv_IM
+
+def OP_D(i,j):
+    """
+    Calculate three-point abel inversion operator Di,j
+    The formula followed Dasch 1992 (Applied Optics) which contains several typos.
+    One correction is done in function OP1 follow Martin's PhD thesis
+    """
+    
+    if j < i-1:
+        D = 0.0
+    elif j == i-1:
+        D = OP0(i,j+1) - OP1(i,j+1)
+    elif j == i:
+        D = OP0(i,j+1) - OP1(i,j+1) + 2*OP1(i,j)
+    elif i == 0 and j == 1:
+        D = OP0(i,j+1) - OP1(i,j+1) + 2*OP1(i,j) - 2*OP1(i,j-1)
+    elif j >= i+1:
+        D = OP0(i,j+1) - OP1(i,j+1) + 2*OP1(i,j) - OP0(i,j-1) - OP1(i,j-1)
+    else:
+        raise(ValueError)    
+    
+    return D
+
+def OP0(i,j):
+    
+    if j < i or (j == i and i == 0):
+        I0 = 0
+    elif j == i and i != 0:
+        I0 = np.log((((2*j+1)**2 - 4*i**2)**0.5 + 2*j+1)/(2*j))/(2*np.pi)
+    elif j > i:
+        I0 = np.log((((2*j+1)**2 - 4*i**2)**0.5 + 2*j+1)/(((2*j-1)**2 - 
+                                                           4*i**2)**0.5 + 2*j-1))/(2*np.pi)
+    else:
+        raise(ValueError)
+        
+    return I0
+
+def OP1(i,j):
+    if j < i:
+        I1 = 0
+    elif j == i:
+        I1 = ((2*j+1)**2 - 4*i**2)**0.5/(2*np.pi) - 2*j*OP0(i,j)
+    elif j > i:
+        I1 = (((2*j+1)**2 - 4*i**2)**0.5 - ((2*j-1)**2 - 4*i**2)**0.5)/(2*np.pi) - 2*j*OP0(i,j)
+    else:
+        raise(ValueError)
+        
+    return I1

--- a/abel/tests/test_three_point.py
+++ b/abel/tests/test_three_point.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+import numpy as np
+from numpy.testing import assert_allclose
+from abel.three_point import iabel_three_point_transform, OP_D, OP0, OP1, iabel_three_point
+from abel.analytical import GaussianAnalytical
+from abel.benchmark import absolute_ratio_benchmark
+
+def test_three_point_step_ratio():
+    """Check a gaussian solution for three_point"""
+
+    n = 51
+    r_max = 25
+
+    ref = GaussianAnalytical(n, r_max, symmetric=True,  sigma=10)
+    tr = np.tile(ref.abel[None, :], (n, 1)) # make a 2D array from 1D
+
+    recon = iabel_three_point(tr, 25)
+    recon1d = recon[n//2 + n%2]
+
+    ratio = absolute_ratio_benchmark(ref, recon1d)
+
+    assert_allclose( ratio , 1.0, rtol=3e-2, atol=0)

--- a/abel/tests/test_three_point.py
+++ b/abel/tests/test_three_point.py
@@ -4,12 +4,27 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os.path
 
 import numpy as np
 from numpy.testing import assert_allclose
-from abel.three_point import iabel_three_point_transform, OP_D, OP0, OP1, iabel_three_point
+from abel.three_point import iabel_three_point_transform, iabel_three_point, get_bs_three_point_cached
 from abel.analytical import GaussianAnalytical
 from abel.benchmark import absolute_ratio_benchmark
+
+DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
+
+def test_three_point_basis_sets_cache_asym():
+    n = 121
+    file_name = os.path.join(DATA_DIR, "three_point_basis_{}_{}.npy".format(n, n))
+    if os.path.exists(file_name):
+        os.remove(file_name)
+    # 1st call generate and save
+    get_bs_three_point_cached(n, basis_dir=DATA_DIR, verbose=False)
+    # 2nd call load from file
+    get_bs_three_point_cached(n, basis_dir=DATA_DIR, verbose=False)
+    if os.path.exists(file_name):
+        os.remove(file_name)
 
 def test_three_point_step_ratio():
     """Check a gaussian solution for three_point"""
@@ -20,7 +35,7 @@ def test_three_point_step_ratio():
     ref = GaussianAnalytical(n, r_max, symmetric=True,  sigma=10)
     tr = np.tile(ref.abel[None, :], (n, 1)) # make a 2D array from 1D
 
-    recon = iabel_three_point(tr, 25)
+    recon = iabel_three_point(tr, 25, basis_dir=None, verbose=False)
     recon1d = recon[n//2 + n%2]
 
     ratio = absolute_ratio_benchmark(ref, recon1d)

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -26,13 +26,7 @@ def iabel_three_point_transform(IM, basis_dir='.', verbose=False):
     inv_IM = np.zeros_like(IM)
 
     for i, P in enumerate(IM):
-        F = np.zeros(col)
-        for j,k in product(range(col), range(col)):
-            # Deconvoluting projection data P to give field distribution F
-            # See Eq (1) in Dasch 1992.
-            F[j] += D[j,k] * P[k] 
-
-        inv_IM[i] = F
+        inv_IM[i] = np.dot(D, P)
 
     return inv_IM
 

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -83,3 +83,43 @@ def OP1(i,j):
         raise(ValueError)
         
     return I1
+
+def iabel_three_point(data, center, dr = 1.0):  
+    """ This function splits the image into two halves, 
+        sends each half to iabel_three_point_transform(), 
+        stitches the output back together,
+        and returns the full transform to the user.
+
+    Parameters:
+    -----------
+        - data:   NxM numpy array
+                  The raw data is presumed to be symmetric about the vertical axis. 
+        - center: * integer - 
+                    The location of the symmetry axis (center column index of the image). 
+                  * tuple (x,y) - 
+                    The center of the image in (x,y) format.
+        - dr:     float - 
+                  Size of one pixel in the radial direction
+    """
+
+    # sanity checks for center
+
+    # cut data in half
+    # each half has the center column at one edge
+    left_half, right_half = data[:,0:center+1], data[:,center:]
+
+    # mirror left half
+    left_half = np.fliplr(left_half)
+
+    # transform both halves
+    inv_left = iabel_three_point_transform(left_half)
+    inv_right = iabel_three_point_transform(right_half)
+
+    # undo mirroring of left half
+    inv_left = np.fliplr(inv_left)
+
+    # stitch both halves back together
+    # (extra) center column is excluded from left half
+    inv_IM = np.hstack((inv_left[:,:-1], inv_right))
+
+    return inv_IM

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -20,7 +20,7 @@ def iabel_three_point_transform(IM):
     """
     IM = np.atleast_2d(IM)
     row, col = IM.shape
-    D = np.zeros((col, col))
+    D = np.zeros((col, col)) # Empty D_ij matrix
 
     for i,j in product(range(col), range(col)):
         D[i,j] = OP_D(i,j)
@@ -30,7 +30,9 @@ def iabel_three_point_transform(IM):
     for i, P in enumerate(IM):
         F = np.zeros(col)
         for j,k in product(range(col), range(col)):
-            F[j] += D[j,k] * P[k]
+            # Deconvoluting projection data P to give field distribution F
+            # See Eq (1) in Dasch 1992.
+            F[j] += D[j,k] * P[k] 
 
         inv_IM[i] = F
 
@@ -38,8 +40,9 @@ def iabel_three_point_transform(IM):
 
 def OP_D(i,j):
     """
-    Calculate three-point abel inversion operator Di,j
-    The formula followed Dasch 1992 (Applied Optics) which contains several typos.
+    Calculates three-point abel inversion operator D_ij, 
+    following Eq (6) in Dasch 1992 (Applied Optics).
+    The original reference contains several typos.
     One correction is done in function OP1 following Karl Martin's PhD thesis
     See here: https://www.lib.utexas.edu/etd/d/2002/martinkm07836/martinkm07836.pdf
     """
@@ -60,7 +63,9 @@ def OP_D(i,j):
     return D
 
 def OP0(i,j):
-    
+    """
+    This is the I_ij(0) function in Dasch 1992, pg 1147, Eq (7)
+    """
     if j < i or (j == i and i == 0):
         I0 = 0
     elif j == i and i != 0:
@@ -74,6 +79,9 @@ def OP0(i,j):
     return I0
 
 def OP1(i,j):
+    """
+    This is the I_ij(1) function in Dasch 1992, pg 1147, Eq (7)
+    """
     if j < i:
         I1 = 0
     elif j == i:

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import numpy as np
 from itertools import product
 
-def iable_dasch_transform(IM):
+def iabel_three_point_transform(IM):
     """ Inverse Abel transformation using the algorithm of: 
         Dasch, Applied Optics, Vol. 31, No. 8, 1146-1152 (1992).
 

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -103,6 +103,20 @@ def iabel_three_point(data, center, dr = 1.0):
     """
 
     # sanity checks for center
+    # 1. If center is tuple, only take the second value inside it
+    if isinstance(center, int):
+        pass
+    elif isinstance(center, tuple):
+        _,center = center # extracting y from (x,y)
+    else:
+        raise ValueError('Center must be an integer or tuple.')
+
+    # 2. center index must be >= 0 (possibly >= 2 for the transform)
+    # 3. center index must be < # of columns in raw data
+    data = np.atleast_2d(data)
+    row, col = data.shape
+    if not 0 <= center <= col-1:
+        raise ValueError('Center column index invalid.')    
 
     # cut data in half
     # each half has the center column at one edge

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os.path
+
 import numpy as np
 from itertools import product
 
@@ -130,10 +132,10 @@ def get_bs_three_point_cached(col, basis_dir='.', verbose=False):
             print("A suitable operator matrix was not found.",
                   "A new operator matrix will be generated.",
                   "This may take a few minutes.", end=" ")
-        if basis_dir is not None:
-            print("But don\'t worry, it will be saved to disk for future use.\n")
-        else:
-            pass
+            if basis_dir is not None:
+                print("But don\'t worry, it will be saved to disk for future use.\n")
+            else:
+                pass
         
         D = np.zeros((col, col))
 

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -40,7 +40,8 @@ def OP_D(i,j):
     """
     Calculate three-point abel inversion operator Di,j
     The formula followed Dasch 1992 (Applied Optics) which contains several typos.
-    One correction is done in function OP1 follow Martin's PhD thesis
+    One correction is done in function OP1 following Karl Martin's PhD thesis
+    See here: https://www.lib.utexas.edu/etd/d/2002/martinkm07836/martinkm07836.pdf
     """
     
     if j < i-1:

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -139,4 +139,8 @@ def iabel_three_point(data, center, dr = 1.0):
     # scale output by dr
     inv_IM = inv_IM/dr
 
+    # if data is 1-dimensional, output ought to be 1-dimensional
+    if row == 1:
+        inv_IM = inv_IM[0]
+
     return inv_IM

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -136,4 +136,7 @@ def iabel_three_point(data, center, dr = 1.0):
     # (extra) center column is excluded from left half
     inv_IM = np.hstack((inv_left[:,:-1], inv_right))
 
+    # scale output by dr
+    inv_IM = inv_IM/dr
+
     return inv_IM


### PR DESCRIPTION
As discussed in #61, this pull request adds the 3-point Abel inversion technique to the repertoire of inversion algorithms available under PyAbel.

This technique was developed by [Dasch, 1992](https://www.osapublishing.org/ao/abstract.cfm?uri=ao-31-8-1146) (Applied Optics, Vol 31, No 8, March 1992, Pg 1146-1152). This algorithm exploits the observation that the value of the Abel inverted data at any radial position `r` is primarily determined from changes in the projection data in the neighborhood of `r`. 
From the paper: *the Abel integral is broken into segments around each point r<sub>j</sub>. In the neighborhood of each point,* the line-of-sight data *is expanded as a quadratic function of r - r<sub>j</sub>. Then each integral segment is integrated analytically. This method is called the 3-point Abel deconvolution since the quadratic expansion uses only the projections adjacent to r<sub>j</sub>.*

The original algorithm (with correction of typographical errors) was [implemented in Matlab](https://gist.github.com/DhrubajyotiDas/16d9381a78352f93bdfe) by Prof. Marshall Long's group at Yale. This PR is mostly a direct port of that code without any attempted optimizations (which are coming soon *hopefully*). 

In addition to the transform code, a new unit test checking the `three_point` transform against an analytical Gaussian is also included. The agreement between the two is essentially identical. 

    import numpy as np
    import matplotlib.pyplot as plt
    from abel.three_point import iabel_three_point

    n = 101
    r_max = 4
    r = np.linspace(-1*r_max, r_max, n)
    dr = r[1]-r[0]

    fig, axes = plt.subplots(ncols = 2)
    fig.set_size_inches(8,4)

    axes[0].set_xlabel("Lateral position, x")
    axes[0].set_ylabel("F(x)")
    axes[0].set_title("Original LOS signal")
    axes[1].set_xlabel("Radial position, r")
    axes[1].set_ylabel("f(r)")
    axes[1].set_title("Inverted radial signal")

    Mat = np.sqrt(np.pi)*np.exp(-1*r*r)
    AnalyticAbelMat = np.exp(-1*r*r)
    DaschAbelMat = iabel_three_point(Mat, 50, dr)

    axes[0].plot(r, Mat, 'r', label = r'$\sqrt{\pi}e^{-r^2}$')
    axes[0].legend()

    axes[1].plot(r, AnalyticAbelMat, 'k', lw = 1.5, alpha = 0.5, label = r'$e^{-r^2}$')
    axes[1].plot(r, DaschAbelMat, 'r--', lw = 1.5, label = '3-pt Abel')

    box = axes[1].get_position()
    axes[1].set_position([box.x0, box.y0, box.width * 0.8, box.height])
    axes[1].legend(loc='center left', bbox_to_anchor=(1, 0.5))
    fig.tight_layout()

![dasch 3pt abel](https://cloud.githubusercontent.com/assets/6530840/12135164/b8c3d21a-b405-11e5-8112-28ff6f6bda65.png)



