### PR TITLE
Small improvements to get the docs to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ examples/*.dat
 *.c
 *.so
 
-docs/_build/
+doc/_build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,14 @@ or, from any folder with,
     
     python  -c "import abel.tests; abel.tests.run_cli(coverage=True)"
 
-which performs an equivalent call. 
-  
+which performs an equivalent call.
 
+Note that this requires that you have [Nose](nose.readthedocs.org) and (optionally) [Coverage](coverage.readthedocs.org) installed. You can install these with:
+
+	pip install nose
+	pip install coverage
+	
+  
 ##### Dependencies
 
 The current list of dependencies can be found in [`setup.py`](https://github.com/PyAbel/PyAbel/blob/master/setup.py). Please refrain from adding new dependencies, unless it cannot be avoided.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,16 @@ which performs an equivalent call.
 The current list of dependencies can be found in [`setup.py`](https://github.com/PyAbel/PyAbel/blob/master/setup.py). Please refrain from adding new dependencies, unless it cannot be avoided.
 
 
+##### Documentation
+
+PyAbel uses Sphinx and [Napoleon](http://sphinxcontrib-napoleon.readthedocs.org/en/latest/index.html) to process Numpy style docstrings, and is synchronized to [pyabel.readthedocs.org](http://pyabel.readthedocs.org/). To build the documentation locally, you will need Sphinx, the [`recommonmark`](https://github.com/rtfd/recommonmark) package, and the [`sphinx_rtd_theme`](https://github.com/snide/sphinx_rtd_theme/). Then, you can build the documentation using
+
+	 cd PyAbel/doc/
+	 make html
+ 
+See the discussion on [PR #69](https://github.com/PyAbel/PyAbel/pull/69) for more information. 
+
+
 ##### Before merging
 
 If possible, before merging your pull request please rebase your fork on the last master on PyAbel. This could be done  [as explained in this post](https://stackoverflow.com/questions/7244321/how-to-update-a-github-forked-repository),

--- a/abel/__init__.py
+++ b/abel/__init__.py
@@ -5,13 +5,9 @@ from __future__ import unicode_literals
 
 from ._version import __version__
 
-# from .tools import io
-# #from . import basex
-# from .tools import math
-
-from . import basex
-from . import benchmark
-from . import direct
-from . import hansenlaw
-from . import three_point
-from . import tools
+# from . import basex
+# from . import benchmark
+# from . import direct
+# from . import hansenlaw
+# from . import three_point
+# from . import tools

--- a/abel/__init__.py
+++ b/abel/__init__.py
@@ -5,6 +5,13 @@ from __future__ import unicode_literals
 
 from ._version import __version__
 
-from .tools import io
-#from . import basex
-from .tools import math
+# from .tools import io
+# #from . import basex
+# from .tools import math
+
+from . import basex
+from . import benchmark
+from . import direct
+from . import hansenlaw
+from . import three_point
+from . import tools

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,7 @@ from recommonmark.parser import CommonMarkParser
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../'))
 
 # Scipy and Numpy packages cannot be installed in on readthedocs.org
 # https://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
@@ -37,8 +37,8 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
-MOCK_MODULES = ['numpy', 'scipy', 'scipy.special', 'numpy.linalg', 'scipy.ndimage', 
-        'scipy.linalg', 'scipy.integrate']
+MOCK_MODULES = ['numpy', 'scipy', 'scipy.special', 'numpy.linalg', 'scipy.ndimage', 'scipy.ndimage.interpolation',
+        'scipy.linalg', 'scipy.integrate', 'scipy.optimize']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 


### PR DESCRIPTION
I tweaked conf.py to allow Sphinx to find the packages. Also, I included a few more libraries in the  “MOCK_MODULES” in conf.py

Finally, I added a brief section in CONTRIBUTING.md about how to build the documentation, since I had to look it up, so I figure that other people may have forgotten as well :).