### PR TITLE
Clean up basex

### DIFF
--- a/abel/basex.py
+++ b/abel/basex.py
@@ -43,8 +43,15 @@ from .tools.symmetry import center_image, center_image_asym
 #
 #############################################################################
 
+# functions to conform to naming conventions: contributing.md ----------
 
-def BASEX(data, center, n, 
+def iabel_basex(IM, dr=1.0, **kwargs):
+    """
+    Inverse Abel transform for one-quadrant
+    """
+    return _abel_basex_core(IM, dr=dr, **kwargs)
+
+def _abel_basex_core(data, center='auto', n='auto', 
         nbf='auto',  basis_dir='./', calc_speeds=False, vertical_symmetry=True, dr=1.0, verbose=True):
 
     """ This function that centers the image, performs the BASEX transform (loads or generates basis sets), 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -65,14 +65,16 @@ def _abel_basex_core(data, center='auto', n='auto',
                 Abel inverse transform will be performed on a `n x n` area of the image
             * list in format [n_vert, n_horz] - 
                 Abel inverse transform will be performed on a `n[0] x n[1]` area of the image
+            * if n='auto', it is set to data.shape 
       - nbf: * integer - 
                 number of basis functions. If nbf='auto', it is set to (n//2 + 1).
              * list in format [nbf_vert, nbf_horz] -
-                If nbf='auto', it is set to [n_vert, n_horz//2 + 1]
+             * If nbf='auto', it is set to [n_vert, n_horz//2 + 1]
       - center: * integer - 
                     the center column of the image
                 * tuple (x,y) -
                     the center of the image in (x,y) format
+                * If center='auto', it is set to (data.shape[0]//2, data.shape[1]//2)
       - basis_dir: string
             path to the directory for saving / loading the basis set coefficients.
             If None, the basis set will not be saved to disk. 
@@ -90,6 +92,19 @@ def _abel_basex_core(data, center='auto', n='auto',
        if calc_speeds=True:  the processes images, arrays with the calculated speeds
 
     """
+
+    # make sure that the data is the right shape (1D must be converted to 2D)
+    data = np.atleast_2d(data) # if passed a 1D array convert it to 2D
+    if data.shape[0] == 1:
+        data_ndim = 1
+    elif data.shape[1] == 1:
+        raise ValueError('Wrong input shape for data {0}, should be  (N1, N2) or (1, N), not (N, 1)'.format(data.shape))
+    else:
+        data_ndim = 2
+
+    if n == 'auto': n = list(data.shape)
+    if center =='auto': center = (data.shape[0]//2, data.shape[1]//2)
+
     # make dimension-of-rawdata into list to account for rectangular n
     # Format of n -> n = [n_vert, n_horz]
     if type(n) is not list: 
@@ -101,15 +116,6 @@ def _abel_basex_core(data, center='auto', n='auto',
 
     # make sure n_horz is odd
     n[1] = 2 * (n[1] // 2) + 1 
-
-    # make sure that the data is the right shape (1D must be converted to 2D)
-    data = np.atleast_2d(data) # if passed a 1D array convert it to 2D
-    if data.shape[0] == 1:
-        data_ndim = 1
-    elif data.shape[1] == 1:
-        raise ValueError('Wrong input shape for data {0}, should be  (N1, N2) or (1, N), not (N, 1)'.format(data.shape))
-    else:
-        data_ndim = 2
 
     if vertical_symmetry:
         image = center_image(data, center=center, n=n[1], ndim=data_ndim)

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -7,27 +7,12 @@ import os.path
 import numpy as np
 from numpy.testing import assert_allclose
 
-from abel.tools.io import parse_matlab_basis_sets
 from abel.basex import *   #generate_basis_sets, get_bs_basex_cached, basex_transform
 from abel.tools.analytical import StepAnalytical, GaussianAnalytical
 from abel.benchmark import absolute_ratio_benchmark
 
 
 DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
-
-
-def test_basex_basis_set():
-    """
-    Check that the basis.py returns the same result as the BASIS1.m script
-    """
-    size = 101
-    M_ref, Mc_ref = parse_matlab_basis_sets(os.path.join(DATA_DIR, 'dan_basis100{}_1.bst.gz'))
-
-    M, Mc = generate_basis_sets(size, size//2, verbose=False)
-
-    yield assert_allclose, Mc_ref, Mc, 1e-7, 1e-100
-    yield assert_allclose, M_ref, M, 1e-7, 1e-100
-
 
 def test_basex_basis_sets_cache():
     n = 121


### PR DESCRIPTION
In this PR, 

- @stggh [raised](https://github.com/PyAbel/PyAbel/pull/72#issuecomment-181306117) the issue of core functions within `basex.py` not following the naming conventions of the other transform algorithm functions. To resolve this, I've renamed the main functions within `basex.py` according to the agreed conventions. I tried to follow @stggh's approach with `hansenlaw.py`, but I wasn't completely sure if the "wrapper" function should be named `iabel_basex(...)` (current) or `iabel_basex_transform(...)`. Any advice would be much appreciated.

- The `center` and `n` parameters for the `_abel_basex_core(...)` function (previously `BASEX(...)`) now have sensible default values. Only mandatory parameter is the image to be transformed. Docstrings updated to reflect appropriate changes.

- As discussed in the issue triage meeting, I've removed a legacy basis set test which checked to make sure the PyAbel generated basis sets matched the sets generated using the original matlab code.
