### PR TITLE
Preliminary format for abel.iabel and abel.fabel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ examples/*.pdf
 examples/*.png
 examples/*basex_basis*
 examples/*.dat
-*basex_basis*
+*basis*
 *.coverage
 *.c
 *.so

--- a/abel/tools/__init__.py
+++ b/abel/tools/__init__.py
@@ -4,3 +4,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from . import io
+from . import analytical

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -54,6 +54,15 @@ def get_image_quadrants(IM, reorient=False, vertical_symmetry=False,
     Q1 = IM[:n_c, :m_c]
     Q2 = IM[-n_c:, :m_c]
     Q3 = IM[-n_c:, -m_c:]
+    
+    if reorient:
+        Q1 = np.fliplr(Q1)
+        Q3 = np.flipud(Q3)
+        Q2 = np.fliplr(np.flipud(Q2))
+    
+    if vertical_symmetry and horizontal_symmetry and not reorient:
+        raise ValueError('In order to add quadrants (i.e., to apply horizontal or vertical symmetry),' 
+                         'you must reorient the image.')
 
     if vertical_symmetry:   # co-add quadrants
         Q0 = Q1 = Q0*use_quadrants[0]+Q1*use_quadrants[1]
@@ -63,11 +72,6 @@ def get_image_quadrants(IM, reorient=False, vertical_symmetry=False,
         Q1 = Q2 = Q1*use_quadrants[1]+Q2*use_quadrants[2]
         Q0 = Q3 = Q0*use_quadrants[0]+Q3*use_quadrants[3]
 
-    if reorient:
-        Q1 = np.fliplr(Q1)
-        Q3 = np.flipud(Q3)
-        Q2 = np.fliplr(np.flipud(Q2))
-
     return Q0, Q1, Q2, Q3
 
 
@@ -75,8 +79,10 @@ def put_image_quadrants (Q, odd_size=True, vertical_symmetry=False,
                          horizontal_symmetry=False):
     """
     Reassemble image from 4 quadrants Q = (Q0, Q1, Q2, Q3)
-    The reverse process to get_image_quadrants()
+    The reverse process to get_image_quadrants(reorient=True)
     Qi defined in abel/hansenlaw.py
+    
+    Note: the quadrants should all be oriented as Q0, the upper right quadrant
     
     Parameters
     ----------
@@ -101,6 +107,8 @@ def put_image_quadrants (Q, odd_size=True, vertical_symmetry=False,
         Reassembled image of shape (rows, cols) 
     """
 
+    Q0, Q1, Q2, Q3 = Q
+    
     if vertical_symmetry:
         Q0 = Q1
         Q3 = Q2 
@@ -110,12 +118,12 @@ def put_image_quadrants (Q, odd_size=True, vertical_symmetry=False,
         Q3 = Q0 
 
     if not odd_size:
-        Top    = np.concatenate((np.fliplr(Q[1]), Q[0]), axis=1)
-        Bottom = np.flipud(np.concatenate((np.fliplr(Q[2]), Q[3]), axis=1))
+        Top    = np.concatenate((np.fliplr(Q0), Q1), axis=1)
+        Bottom = np.flipud(np.concatenate((np.fliplr(Q2), Q3), axis=1))
     else:
         # odd size image remove extra row/column added in get_image_quadrant()
-        Top    = np.concatenate((np.fliplr(Q[1][:-1,:-1]), Q[0][:-1,:]), axis=1)
-        Bottom = np.flipud(np.concatenate((np.fliplr(Q[2][:,:-1]), Q[3]), axis=1))
+        Top    = np.concatenate((np.fliplr(Q1[:-1,:-1]), Q0[:-1,:]), axis=1)
+        Bottom = np.flipud(np.concatenate((np.fliplr(Q2[:,:-1]), Q3), axis=1))
 
     IM = np.concatenate((Top,Bottom), axis=0)
 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -12,7 +12,7 @@ from scipy.ndimage.interpolation import shift
 from scipy.optimize import curve_fit, minimize
 
 
-def calculate_speeds(IM, origin=None, Jacobian=False, dr=1, dt=None):
+def calculate_speeds(IM, origin=None, Jacobian=True, dr=1, dt=None):
     """ Angular integration of the image.
 
         Returning the one-dimentional intensity profile as a function of the 

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -9,7 +9,7 @@ import abel
 import time
 
 class abel_transform(object):
-    def __init__(self,IM,direction=None,method='hansenlaw',integrate=True,verbose=True,
+    def __init__(self,IM,direction=None,method='three_point',integrate=True,verbose=True,
                  vertical_symmetry=True,horizontal_symmetry=True,use_quadrants=(True,True,True,True),
                  transform_options=()):
                         
@@ -36,11 +36,31 @@ class abel_transform(object):
                              vertical_symmetry=vertical_symmetry, horizontal_symmetry=horizontal_symmetry)
 
         def selected_transform(IM):
+            
             if method == 'hansenlaw':
                 if direction == 'forward':
                     return abel.hansenlaw.fabel_hansenlaw_transform(IM, *transform_options)
                 if direction == 'inverse':
                     return abel.hansenlaw.iabel_hansenlaw_transform(IM, *transform_options)
+            
+            if method == 'three_point':
+                if direction == 'forward':
+                    raise ValueError('Forward three-point not implemented')
+                if direction == 'inverse':
+                    return abel.three_point.iabel_three_point_transform(IM, *transform_options)
+            
+            if method == 'basex':
+                if direction == 'forward':
+                    raise ValueError('Forward basex not implemented')
+                if direction == 'inverse':
+                    raise ValueError('Coming soon...')
+            
+            if method == 'direct':
+                if direction == 'forward':
+                    raise ValueError('Coming soon...')
+                if direction == 'inverse':
+                    raise ValueError('Coming soon...')
+                    
 
         AQ0 = AQ1 = AQ2 = AQ3 = None
         # Inverse Abel transform for quadrant 1 (all include Q1)
@@ -93,7 +113,7 @@ class iabel(abel_transform):
 def main():
     import matplotlib.pyplot as plt
     IM0 = abel.tools.analytical.sample_image_dribinski(n=361)
-    trans1 = fabel(IM0)
+    trans1 = fabel(IM0,method='hansenlaw')
     IM1 = trans1.transform
     trans2 = iabel(IM1)
     IM2 = trans2.transform
@@ -104,7 +124,6 @@ def main():
     axs[0,1].imshow(IM1)
     axs[0,2].imshow(IM2)
     
-    print(trans1.angular_integration())
     axs[1,0].plot(*abel.tools.vmi.calculate_speeds(IM0)[::-1])
     axs[1,1].plot(*trans1.angular_integration())
     axs[1,2].plot(*trans2.angular_integration())

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import abel
+import time
+
+class abel_transform(object):
+    def __init__(self,IM,direction=None,method='hansenlaw',integrate=True,verbose=True,
+                 vertical_symmetry=True,horizontal_symmetry=True,use_quadrants=(True,True,True,True),
+                 transform_options=()):
+                        
+        verboseprint = print if verbose else lambda *a, **k: None
+        
+        self.IM = IM
+    
+        if IM.ndim == 1 or np.shape(IM)[0] <= 2:
+                raise ValueError('Data must be 2-dimensional.'
+                                 'To transform a single row, use'
+                                 'iabel_hansenlaw_transform().')
+
+        if not np.any(use_quadrants): raise ValueError('No image quadrants selected to use')
+        
+        rows, cols = np.shape(IM)
+        
+        verboseprint('Calculating {0} Abel transform using {1} method -'.format(direction,method),
+                     'image size: {:d}x{:d}'.format(rows, cols))
+        
+        t0 = time.time()
+
+        # split image into quadrants
+        Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(IM, reorient=True,
+                             vertical_symmetry=vertical_symmetry, horizontal_symmetry=horizontal_symmetry)
+
+        def selected_transform(IM):
+            if method == 'hansenlaw':
+                if direction == 'forward':
+                    return abel.hansenlaw.fabel_hansenlaw_transform(IM, *transform_options)
+                if direction == 'inverse':
+                    return abel.hansenlaw.iabel_hansenlaw_transform(IM, *transform_options)
+
+        AQ0 = AQ1 = AQ2 = AQ3 = None
+        # Inverse Abel transform for quadrant 1 (all include Q1)
+        AQ1 = selected_transform(Q1)
+
+        if vertical_symmetry:
+            AQ2 = selected_transform(Q2)
+
+        if horizontal_symmetry:
+            AQ0 = selected_transform(Q0)
+
+        if not vertical_symmetry and not horizontal_symmetry:
+            AQ0 = selected_transform(Q0)
+            AQ2 = selected_transform(Q2)
+            AQ3 = selected_transform(Q3)
+
+            # reassemble image
+        self.transform = abel.tools.symmetry.put_image_quadrants((AQ0, AQ1, AQ2, AQ3), odd_size=cols % 2,
+                                    vertical_symmetry=vertical_symmetry,
+                                    horizontal_symmetry=horizontal_symmetry)
+
+        verboseprint("{:.2f} seconds".format(time.time()-t0))
+        
+        
+    def angular_integration(self,*args,**kwargs):
+        self.radial_intensity, self.radial_coordinate = abel.tools.vmi.calculate_speeds(self.transform, *args, **kwargs)
+        return self.radial_coordinate, self.radial_intensity
+        
+    def calculate_anisotropy(self):
+        print('Anisotropy not yet implemented!')
+        return 1
+    
+    def residual(self):
+        print('Not yet implemented')
+        # in some cases, like basex, we can recover the projection while we are performing the inverse transform
+        # in that case, we can: return self.IM - self.proj 
+        
+        
+        
+class fabel(abel_transform):
+    def __init__(self, *args, **kwargs):
+        super(fabel, self).__init__(*args,direction='forward', **kwargs)
+
+class iabel(abel_transform):
+    def __init__(self, *args, **kwargs):
+        super(iabel, self).__init__(*args,direction='inverse', **kwargs)
+        
+        
+        
+def main():
+    import matplotlib.pyplot as plt
+    IM0 = abel.tools.analytical.sample_image_dribinski(n=361)
+    trans1 = fabel(IM0)
+    IM1 = trans1.transform
+    trans2 = iabel(IM1)
+    IM2 = trans2.transform
+    
+    fig, axs = plt.subplots(2,3,figsize=(10,6))
+    
+    axs[0,0].imshow(IM0)
+    axs[0,1].imshow(IM1)
+    axs[0,2].imshow(IM2)
+    
+    print(trans1.angular_integration())
+    axs[1,0].plot(*abel.tools.vmi.calculate_speeds(IM0)[::-1])
+    axs[1,1].plot(*trans1.angular_integration())
+    axs[1,2].plot(*trans2.angular_integration())
+    
+    plt.show()
+    
+    
+if __name__ == "__main__":
+    main()
+    
+    

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -32,7 +32,7 @@ class AbelTransform(object):
                  integrate=True,transform_options=()):
         """__init__
 
-        This performs the forward or reverse Abel transform using a user selected method.
+        This performs the forward or reverse Abel transform using a user-selected method.
         
         Transform Methods
         --------
@@ -57,11 +57,9 @@ class AbelTransform(object):
             'direct' - a naive implementation of the analytical formula by Roman Yurchuk. 
             'three_point' - the three-point transform of Dasch and co-workers
             
-        center : 
-        
-        ...will finish this later...
-    
-        
+        center : tuple or str
+            This specifies the image center in (x,y) format (if a tuple is provided)
+            or, if a string is provided, an automatic centering algorithm is used
 
         """
     

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -8,7 +8,7 @@ import numpy as np
 import abel
 import time
 
-class abel_transform(object):
+class AbelTransform(object):
     def __init__(self,IM,direction=None,method='three_point',integrate=True,verbose=True,
                  vertical_symmetry=True,horizontal_symmetry=True,use_quadrants=(True,True,True,True),
                  transform_options=()):
@@ -40,25 +40,25 @@ class abel_transform(object):
             if method == 'hansenlaw':
                 if direction == 'forward':
                     return abel.hansenlaw.fabel_hansenlaw_transform(IM, *transform_options)
-                if direction == 'inverse':
+                elif direction == 'inverse':
                     return abel.hansenlaw.iabel_hansenlaw_transform(IM, *transform_options)
             
-            if method == 'three_point':
+            elif method == 'three_point':
                 if direction == 'forward':
                     raise ValueError('Forward three-point not implemented')
-                if direction == 'inverse':
+                elif direction == 'inverse':
                     return abel.three_point.iabel_three_point_transform(IM, *transform_options)
             
-            if method == 'basex':
+            elif method == 'basex':
                 if direction == 'forward':
                     raise ValueError('Forward basex not implemented')
-                if direction == 'inverse':
+                elif direction == 'inverse':
                     raise ValueError('Coming soon...')
             
-            if method == 'direct':
+            elif method == 'direct':
                 if direction == 'forward':
                     raise ValueError('Coming soon...')
-                if direction == 'inverse':
+                elif direction == 'inverse':
                     raise ValueError('Coming soon...')
                     
 
@@ -77,14 +77,14 @@ class abel_transform(object):
             AQ2 = selected_transform(Q2)
             AQ3 = selected_transform(Q3)
 
-            # reassemble image
+        # reassemble image
         self.transform = abel.tools.symmetry.put_image_quadrants((AQ0, AQ1, AQ2, AQ3), odd_size=cols % 2,
                                     vertical_symmetry=vertical_symmetry,
                                     horizontal_symmetry=horizontal_symmetry)
 
         verboseprint("{:.2f} seconds".format(time.time()-t0))
         
-        
+    
     def angular_integration(self,*args,**kwargs):
         self.radial_intensity, self.radial_coordinate = abel.tools.vmi.calculate_speeds(self.transform, *args, **kwargs)
         return self.radial_coordinate, self.radial_intensity
@@ -97,16 +97,18 @@ class abel_transform(object):
         print('Not yet implemented')
         # in some cases, like basex, we can recover the projection while we are performing the inverse transform
         # in that case, we can: return self.IM - self.proj 
-        
-        
-class fabel(abel_transform):
-    def __init__(self, *args, **kwargs):
-        super(fabel, self).__init__(*args,direction='forward', **kwargs)
+    
+    @classmethod
+    def iabel(cls, *args, **kwargs):
+        return cls(*args,direction='inverse', **kwargs)
+    
+    @classmethod
+    def fabel(cls, *args, **kwargs):
+        return cls(*args,direction='forward', **kwargs)
 
-class iabel(abel_transform):
-    def __init__(self, *args, **kwargs):
-        super(iabel, self).__init__(*args,direction='inverse', **kwargs)
-        
+
+iabel = AbelTransform.iabel
+fabel = AbelTransform.fabel
         
 def main():
     import matplotlib.pyplot as plt

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -99,7 +99,6 @@ class abel_transform(object):
         # in that case, we can: return self.IM - self.proj 
         
         
-        
 class fabel(abel_transform):
     def __init__(self, *args, **kwargs):
         super(fabel, self).__init__(*args,direction='forward', **kwargs)
@@ -107,7 +106,6 @@ class fabel(abel_transform):
 class iabel(abel_transform):
     def __init__(self, *args, **kwargs):
         super(iabel, self).__init__(*args,direction='inverse', **kwargs)
-        
         
         
 def main():

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -9,9 +9,62 @@ import abel
 import time
 
 class AbelTransform(object):
-    def __init__(self,IM,direction=None,method='three_point',integrate=True,verbose=True,
+    """AbelTransform class
+    
+    This class provides a conveinent way to call all of transform functions
+    as well as the preprocessing (centering) and post processing 
+    (integration) functions. 
+    
+    
+    Attributes
+        ----------
+        IM : NxM numpy array
+            the original 2D image supplied
+        transform : NxM numpy array
+            the transformed (either forward or inverse) image
+        
+    
+
+    """
+    
+    def __init__(self,IM,direction=None,method='three_point',center=(None,None),verbose=True,
                  vertical_symmetry=True,horizontal_symmetry=True,use_quadrants=(True,True,True,True),
-                 transform_options=()):
+                 integrate=True,transform_options=()):
+        """__init__
+
+        This performs the forward or reverse Abel transform using a user selected method.
+        
+        Transform Methods
+        --------
+        # here we should provide a description of the various methods, complete with references.
+       
+
+        Parameters
+        ----------
+        IM : a NxM numpy array
+            This is the image to be transformed
+        direction : 'forward' or 'inverse'
+            The type of Abel transform to be performed. 
+            A 'forward' Abel transform takes a (2D) slice of a 3D image and returns the 2D projection.
+            An 'inverse' Abel transform takes a 2D projection and reconstructs a 2D slice of the 3D image.
+        method : str
+            The method specifies which numerical approximation to the Abel transform should be employed.
+            All the the methods should produce similar results, but depending on the level and type of noise
+            found in the image, certain methods may perform better than others.
+            The options are:
+            'hansenlaw' - the recursive algorithm described by Hansen and Law
+            'basex' - the Gaussian "basis set expansion" method of Dribinski et al.
+            'direct' - a naive implementation of the analytical formula by Roman Yurchuk. 
+            'three_point' - the three-point transform of Dasch and co-workers
+            
+        center : 
+        
+        ...will finish this later...
+    
+        
+
+        """
+    
                         
         verboseprint = print if verbose else lambda *a, **k: None
         
@@ -30,6 +83,8 @@ class AbelTransform(object):
                      'image size: {:d}x{:d}'.format(rows, cols))
         
         t0 = time.time()
+        
+        # add code to center the image here!!
 
         # split image into quadrants
         Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(IM, reorient=True,

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -8,7 +8,7 @@
 import numpy as np
 
 from abel.hansenlaw import iabel_hansenlaw
-from abel.basex import BASEX
+import abel.basex
 from abel.onion import iabel_onion_peeling
 from abel.direct import iabel_direct
 from abel.three_point import iabel_three_point
@@ -40,7 +40,7 @@ from matplotlib.pyplot import imread
 def basex_wrapper(IM):
     rows, cols = IM.shape
     center = (rows//2 + rows % 2, cols//2 + cols % 2)
-    return BASEX(IM, center=center, n=rows) 
+    return abel.basex.basex_iabel(IM, center=center, n=rows) 
 
 
 def three_point_wrapper(IM):


### PR DESCRIPTION
Here is a rough sketch of what the `abel.iabel` and `abel.fabel` classes could look like. They are both currently at `abel.transform.iabel` and `abel.transform.fabel`, but we could import them to `abel.iabel` in `abel/__init__.py`. 

Both the `abel.iabel` and `abel.fabel` classes are just child classes of the `abel.transform.abel_transform` class, so there is minimal code repetition. As you can see, all of the quadrants code has been shipped into this class, so it no longer needs to appear in the individual transform functions. 

@PyAbel/developers, have a look and see if this works for you. Let me know your suggestions.

@rth, I imagine that you may have already come up with something better, so I have no problem with you re-writing or replacing this PR. I just wanted to get the conversation started with something concrete.

(Sorry for the undocumented code - I need to head to work, so I didn't finish polishing this.) 

Also, I found that the `put_` and `get_ image_quadrants()` did not work correctly when the `vertical_symmetry` and `horizontal_symmetry` keywords were used. I think that I made these work. I think that it might be less confusing if we just made the `get_image_quadrants()` function always re-orient the images. The `put_image_quadrants()` function implicitly assumes this anyway.