### PR TITLE
Make abel.transform return a dictionary

### DIFF
--- a/abel/__init__.py
+++ b/abel/__init__.py
@@ -12,4 +12,5 @@ from . import hansenlaw
 from . import three_point
 from . import tools
 from . import transform
-from .transform import iabel, fabel
+from .transform import transform
+from .tools.center import center_image

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -272,7 +272,7 @@ def _bs_basex(n_vert=1001, n_horz = 501,
     gammaln_0o5 = gammaln(0.5) 
 
     if verbose:
-        print('Generating horizontal BASEX basis sets for n_horz = {}, nbf_horz = {}:\n'.format(n_horz, nbf_horz))
+        print('Generating horizontal BASEX basis sets for n_horz = {}, nbf_vert = {}:\n'.format(n_horz, nbf_vert))
         sys.stdout.write('0')
         sys.stdout.flush()
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -17,7 +17,6 @@ from numpy.linalg import inv
 from scipy.ndimage import median_filter, gaussian_filter, center_of_mass
 
 from ._version import __version__
-from .tools.vmi import calculate_speeds
 from .tools.symmetry import center_image_asym, updown_symmetry_rawdata
 from .tools.center import find_center
 
@@ -28,6 +27,9 @@ from .tools.center import find_center
 # V. Dribinski, A. Ossadtchi, V. A. Mandelshtam, and H. Reisler,
 # Review of Scientific Instruments 73, 2634 (2002).
 #
+# Version 0.7 - 2016-02-17
+#   Major reformatting - removed up/down symmetic version and 
+#   made basex work with only one quadrant.
 # Version 0.6 - 2015-12-01
 #   Another major code reformatting
 # Version 0.5 - 2015-11-16
@@ -44,144 +46,72 @@ from .tools.center import find_center
 #
 #############################################################################
 
-# functions to conform to naming conventions: contributing.md ----------
-
-def iabel_basex(IM, dr=1.0, **kwargs):
-    """
-    Inverse Abel transform for top-left quadrant
-    """
-    IM = np.atleast_2d(IM)
-    h, w = IM.shape
-    full_image = np.hstack((np.fliplr(IM), IM[:,1:]))
-    full_recon = _abel_basex_core(full_image, center=w-1, dr=dr, **kwargs)
-    if h == 1: return full_recon[w-1:]
-    else: return full_recon[:,w-1:]
-
-def _abel_basex_core(data, center='image_center', n='auto', 
-        nbf='auto',  basis_dir='./', calc_speeds=False, vertical_symmetry=False, dr=1.0, verbose=True):
+def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True):
     """ This function that centers the image, performs the BASEX transform (loads or generates basis sets), 
         and (optionally) calculates the radial integration of the image (calc_speeds)
 
-    Parameters:
-    -----------
-      - data:  a NxM numpy array
-            If data is smaller than the size of the basis set, zeros will be padded on the edges.
-      - n:  * odd integer -
-                Abel inverse transform will be performed on a `n x n` area of the image
-            * list in format [n_vert, n_horz] - 
-                Abel inverse transform will be performed on a `n[0] x n[1]` area of the image
-            * if n='auto', it is set to data.shape
 
-      - nbf: * integer - 
-                number of basis functions. If nbf='auto', it is set to (n//2 + 1).
-             * list in format [nbf_vert, nbf_horz] -
-             * If nbf='auto', it is set to [n_vert, n_horz//2 + 1]
-      - center: * integer - 
-                    the center column of the image
-                * tuple (x,y) -
-                    the center of the image in (x,y) format
-                * If center='image_center', it is set to (data.shape[1]//2, data.shape[0]//2)
-                * if center='com', it is set to the center of mass of data
-      - basis_dir: string
-            path to the directory for saving / loading the basis set coefficients.
-            If None, the basis set will not be saved to disk. 
-      - dr: float
-            size of one pixel in the radial direction
-      - calc_speeds: True/False
-            determines if the speed distribution should be calculated
-      - vertical_symmetry: True/False
-            determines if the data has up/down symmetry 
-      - verbose: True/False
-            Set to True to see more output for debugging
-
-    Returns:
-       if calc_speeds=False: the processed image
-       if calc_speeds=True:  the processes images, arrays with the calculated speeds
+    Parameters
+    --------
+    data : a NxM numpy array
+        If data is smaller than the size of the basis set, zeros will be padded on the edges.
+    nbf : str or list
+        number of basis functions. If nbf='auto', it is set to (n//2 + 1).
+        This is what you should use, since basex does not work reliable in other situations
+        In the future, you could use
+        list, in format [nbf_vert, nbf_horz]
+    basis_dir : str
+        path to the directory for saving / loading the basis set coefficients.
+        If None, the basis set will not be saved to disk. 
+    dr : float
+        size of one pixel in the radial direction
+    verbose : boolean
+        Determins if statements should be printed.
+            
+            
+    Returns
+    --------
+       recon : NxN numpy array
+            the transformed image
 
     """
-
     # make sure that the data is the right shape (1D must be converted to 2D)
     data = np.atleast_2d(data)
+    h, w = data.shape
+    
+
     if data.shape[0] == 1: data_ndim = 1
     elif data.shape[1] == 1:
         raise ValueError('Wrong input shape for data {0}, should be  (N1, N2) or (1, N), not (N, 1)'.format(data.shape))
     else: data_ndim = 2
 
-    # If center is any of the special options ('image_center', 'com', etc.)
-    if type(center) == str or type(center) == unicode:
-        center = find_center(data, method=center, verbose=verbose)
+    full_image = np.hstack((np.fliplr(data), data[:,1:]))
+    n = full_image.shape
 
-    if type(center) == tuple: cx, cy = center
-    elif type(center) == int or type(center) == long: 
-        cx, cy = center, "image_center"
-    else: raise ValueError("Center specified incorrectly. Must be tuple (x,y) or integer (column)")
-
-    if vertical_symmetry: # Average top and bottom halves of rawdata
-        data = updown_symmetry_rawdata(data, center_row = cy)
-
-    # make dimension-of-rawdata into list to account for rectangular n
-    # Format of n -> n = [n_vert, n_horz]
-    if n == 'auto': n = list(data.shape)
-    if type(n) is not list: 
-        if type(n) is int: n = [ n ] 
-        else: n = list(n)
-
-    # duplicate elements of n if n is single-valued (rawdata is square)
-    if len(n) < 2: n = n*2
-
-    # make sure n_horz is odd
-    n[1] = 2 * (n[1] // 2) + 1 
-
-    image = center_image_asym(data, center_column = cx, n_vert = n[0], n_horz = n[1], verbose = verbose)
-
-    if verbose:
-        t1 = time()
-
+    # load the basis sets:
     M_vert, M_horz, Mc_vert, Mc_horz, vert_left, horz_right = get_bs_basex_cached(n_vert = n[0], n_horz = n[1], nbf = nbf, basis_dir = basis_dir, verbose = verbose)
-
-    if verbose:
-        print('{:.2f} seconds'.format((time() - t1)))
-
-    #Do the actual transform
-    if verbose:
-        print('Reconstructing image...         ')
-        t1 = time()
-
-    recon = basex_transform(image, M_vert, M_horz, Mc_vert, Mc_horz, vert_left, horz_right, dr)
-
-    if verbose:
-        print('%.2f seconds' % (time() - t1))
+    
+    #Do the actual transform:
+    recon = basex_transform(full_image, M_vert, M_horz, Mc_vert, Mc_horz, vert_left, horz_right, dr)
 
     if data_ndim == 1: # taking the middle row, since the rest are zeroes
         recon = recon[recon.shape[0] - recon.shape[0]//2 - 1] 
-
-    # -------------------------------------------------
-    # asymmetric speeds calculation not implemented yet
-    # -------------------------------------------------
-    # if calc_speeds:
-    #     if verbose:
-    #         print('Generating speed distribution...')
-    #         t1 = time()
-
-    #     speeds = calculate_speeds(recon, n)
-
-    #     if verbose:
-    #         print('%.2f seconds' % (time() - t1))
-    #     return recon, speeds
-    # else:
-    #     return recon
-
-    return recon
+    
+    if h == 1: 
+        return recon[w-1:]
+    else: 
+        return recon[:,w-1:]
 
 def basex_transform(rawdata, M_vert, M_horz, Mc_vert, Mc_horz, vert_left, horz_right, dr=1.0):
     """ This is the internal function that does the actual BASEX transform for the no-up/down-symmetry case.
      Parameters
      ----------
-      - rawdata: 
-            a N_vert x N_horz numpy array of the raw image.
-      - M_vert, M_horz, Mc_vert, Mc_horz, vert_left, horz_right: 
-            2D arrays given by the basis set calculation function
-      - dr: float: pixel size
+      rawdata : NxM numpy array 
+          the raw image.
+      M_vert, M_horz, Mc_vert, Mc_horz, vert_left, horz_right : 
+          2D arrays given by the basis set calculation function
+      dr : float
+          pixel size. This only affects the absolute scaling of the output.
 
      Returns
      -------

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -17,8 +17,6 @@ from numpy.linalg import inv
 from scipy.ndimage import median_filter, gaussian_filter, center_of_mass
 
 from ._version import __version__
-from .tools.symmetry import center_image_asym, updown_symmetry_rawdata
-from .tools.center import find_center
 
 #############################################################################
 # This is adapted from the BASEX Matlab code provided by the Reisler group.

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -7,8 +7,6 @@ from __future__ import unicode_literals
 import numpy as np
 from time import time
 from math import exp, log, pow, pi
-from abel.tools.vmi import calculate_speeds
-from abel.tools.symmetry import get_image_quadrants, put_image_quadrants
 
 ###############################################################################
 # hansenlaw - a recursive method forward/inverse Abel transform algorithm 

--- a/abel/tests/test_hansenlaw.py
+++ b/abel/tests/test_hansenlaw.py
@@ -11,7 +11,7 @@ from abel.hansenlaw import iabel_hansenlaw, fabel_hansenlaw
 
 from abel.tools.analytical import sample_image_dribinski
 from abel.tools.symmetry import get_image_quadrants
-from abel.tools.vmi import calculate_speeds
+from abel.tools.vmi import angular_integration
 
 from abel.tools.analytical import GaussianAnalytical
 from abel.benchmark import absolute_ratio_benchmark
@@ -135,9 +135,9 @@ def test_hansenlaw_with_dribinski_image():
     ifQ0 = iabel_hansenlaw(fQ0)
     
     # speed distribution
-    orig_speed, orig_radial = calculate_speeds(Q0, origin=(0,0), Jacobian=True)
+    orig_speed, orig_radial = angular_integration(Q0, origin=(0,0), Jacobian=True)
 
-    speed, radial_coords = calculate_speeds(ifQ0, origin=(0,0), Jacobian=True)
+    speed, radial_coords = angular_integration(ifQ0, origin=(0,0), Jacobian=True)
 
     orig_speed /= orig_speed[50:125].max()
     speed /= speed[50:125].max()

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -7,7 +7,7 @@ import os.path
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
-from abel.tools.vmi import calculate_speeds
+from abel.tools.vmi import angular_integration
 from abel.tools.symmetry import  center_image
 from abel.benchmark import is_symmetric
 
@@ -20,14 +20,14 @@ def assert_allclose_msg(x, y, message, rtol=1e-5):
 
 
 def test_speeds():
-    # This very superficial test checks that calculate_speeds is able to
+    # This very superficial test checks that angular_integration is able to
     # execute (no syntax errors)
 
     n = 101
 
     IM = np.random.randn(n, n)
 
-    calculate_speeds(IM)
+    angular_integration(IM)
 
 
 def test_centering_function_shape():
@@ -72,4 +72,4 @@ def test_speeds_non_integer_center():
     # ensures that the rest speeds function can work with a non-integer center
     n  = 101
     IM = np.random.randn(n, n)
-    calculate_speeds(IM, origin=(50.5, 50.5))
+    angular_integration(IM, origin=(50.5, 50.5))

--- a/abel/tools/__init__.py
+++ b/abel/tools/__init__.py
@@ -3,5 +3,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from . import io
 from . import analytical
+from . import center
+from . import io
+from . import math
+from . import polar
+from . import symmetry
+from . import vmi

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -4,7 +4,8 @@ from .math import fit_gaussian
 import warnings
 import scipy.ndimage
 
-def center_image(data, center = 'com', verbose=False):
+def center_image(data, center='com', verbose=False):
+    # center is in y,x (row column) format!
     if isinstance(center, str) or isinstance(center, unicode):
         center = find_center(data, center, verbose=verbose)
     
@@ -41,7 +42,7 @@ def find_center(data, method='image_center', verbose=True, **kwargs):
 
 def find_center_by_center_of_mass(data, verbose=True, round_output=False, **kwargs):
     com = center_of_mass(data)
-    center = com[1], com[0]
+    center = com[0], com[1]
     
     if verbose:
         to_print = "Center of mass at ({0}, {1})".format(center[0], center[1])
@@ -66,7 +67,7 @@ def find_center_by_gaussian_fit(data, verbose=True, round_output=True, **kwargs)
     y = np.sum(data, axis=1)
     xc = fit_gaussian(x)[1]
     yc = fit_gaussian(y)[1]
-    center = (xc, yc)
+    center = (yc, xc)
     
     if verbose:
         to_print = "Gaussian center at ({0}, {1})".format(center[0], center[1])

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -2,8 +2,44 @@ import numpy as np
 from scipy.ndimage import center_of_mass
 from .math import fit_gaussian
 import warnings
+import scipy.ndimage
 
-def find_center_by_center_of_mass(data, verbose=True, round_output=True, **kwargs):
+def center_image(data, center = 'com', verbose=False):
+    if isinstance(center, str) or isinstance(center, unicode):
+        center = find_center(data, center, verbose=verbose)
+    
+    centered_data = set_center(data, center, verbose=verbose)
+    return centered_data
+
+def set_center(data, center, crop='maintain_size', verbose=True):
+    c0,c1 = center
+    if isinstance(c0,(int,long)) and isinstance(c1,(int,long)):
+        warnings.warn('Integer center detected, but not respected.'
+                      'treating center as float and interpolating!')
+        # need to include code here to treat integer centers
+        # probably can use abel.tools.symmetry.center_image_asym(),
+        # but this function lacks the ability to set the vertical center
+        
+    old_shape  = data.shape
+    old_center = data.shape[0]/2.0, data.shape[1]/2.0
+    delta0 = old_center[0] - center[0] 
+    delta1 = old_center[1] - center[1] 
+    centered_data = scipy.ndimage.interpolation.shift(data, (delta0,delta1))
+    
+    if crop == 'maintain_size':
+        return centered_data
+    elif crop == 'valid_region':
+        # crop to region containing data
+        raise ValueError('Not implemented')
+    elif crop == 'maintain_data':
+        # pad the image so that the center can be moved without losing any of the original data
+        # we need to pad the image with zeros before using the shift() function
+        raise ValueError('Not implemented')
+
+def find_center(data, method='image_center', verbose=True, **kwargs):
+    return func_method[method](data, verbose=verbose, **kwargs)
+
+def find_center_by_center_of_mass(data, verbose=True, round_output=False, **kwargs):
     com = center_of_mass(data)
     center = com[1], com[0]
     
@@ -25,7 +61,7 @@ def find_center_by_center_of_image(data, verbose=True, **kwargs):
     return (data.shape[1] // 2 + data.shape[1]%2, data.shape[0] // 2 + data.shape[0]%2)
 
 
-def find_center_by_fit_gaussian(data, verbose=True, round_output=True, **kwargs):
+def find_center_by_gaussian_fit(data, verbose=True, round_output=True, **kwargs):
     x = np.sum(data, axis=0)
     y = np.sum(data, axis=1)
     xc = fit_gaussian(x)[1]
@@ -48,9 +84,9 @@ def find_center_by_fit_gaussian(data, verbose=True, round_output=True, **kwargs)
 func_method = {
     "image_center": find_center_by_center_of_image,
     "com": find_center_by_center_of_mass,
-    "gaussian": find_center_by_fit_gaussian,
+    "gaussian": find_center_by_gaussian_fit,
 }
 
 
-def find_center(data, method='image_center', verbose=True, **kwargs):
-    return func_method[method](data, verbose=verbose, **kwargs)
+
+

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -174,7 +174,9 @@ def put_image_quadrants (Q, odd_size=True, vertical_symmetry=False,
 
 
 def center_image(data, center, n, ndim=2):
-    """ This centers the image at the given center and makes it of size n by n"""
+    """ This centers the image at the given center and makes it of size n by n
+        THIS FUNCTION IS DEPRECIATED. All centering functions should be moves to abel.tools.center"""
+
     
     Nh,Nw = data.shape
     n_2 = n//2
@@ -210,7 +212,8 @@ def center_image(data, center, n, ndim=2):
 
 
 def center_image_asym(data, center_column, n_vert, n_horz, verbose=False):
-    """ This centers a (rectangular) image at the given center_column and makes it of size n_vert by n_horz"""
+    """ This centers a (rectangular) image at the given center_column and makes it of size n_vert by n_horz
+    THIS FUNCTION IS DEPRECIATED. All centering functions should be moves to abel.tools.center"""
 
     if data.ndim > 2:
         raise ValueError("Array to be centered must be 1- or 2-dimensional")
@@ -277,7 +280,9 @@ def center_image_asym(data, center_column, n_vert, n_horz, verbose=False):
 
     return c_im
 
-def updown_symmetry_rawdata(IM, center_row='image_center', **kwargs): 
+def updown_symmetry_rawdata(IM, center_row='image_center', **kwargs):
+    """
+    This function is probably not necessary. This should be taken care of by the quadrant function."""
     if type(center_row) == str or type(center_row) == unicode:
         center_row, center_column = find_center(IM, method=center_row, verbose=verbose)
     

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -279,25 +279,3 @@ def center_image_asym(data, center_column, n_vert, n_horz, verbose=False):
         raise ValueError('Input data dimensions incompatible with chosen basis set.')
 
     return c_im
-
-def updown_symmetry_rawdata(IM, center_row='image_center', **kwargs):
-    """
-    This function is probably not necessary. This should be taken care of by the quadrant function."""
-    if type(center_row) == str or type(center_row) == unicode:
-        center_row, center_column = find_center(IM, method=center_row, verbose=verbose)
-    
-    IM = np.atleast_2d(IM)    
-    row, col = IM.shape
-    if row == 1: # Convert row into columnar array
-        IM = IM.T 
-        row, col = IM.shape
-
-    # distance between "true center" and "shape center"
-    distance_from_center = round(center_row) - (row-1)/2
-    trim = distance_from_center*2
-       
-    if trim < 0: symmetric_IM = IM[:trim]
-    else: symmetric_IM = IM[trim:]
-
-    # To average top and bottom, take the mean of IM and np.flipud(IM)
-    return (symmetric_IM + np.flipud(symmetric_IM)) / 2.0

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -12,7 +12,7 @@ from scipy.ndimage.interpolation import shift
 from scipy.optimize import curve_fit, minimize
 
 
-def calculate_speeds(IM, origin=None, Jacobian=True, dr=1, dt=None):
+def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     """ Angular integration of the image.
 
         Returning the one-dimentional intensity profile as a function of the 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -59,7 +59,7 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     speeds = np.sum(polarIM, axis=1)
     n = speeds.shape[0]   
 
-    return speeds, r[:n]   # limit radial coordinates range to match speed
+    return r[:n], speeds   # limit radial coordinates range to match speed
 
 
 def calculate_angular_distributions(IM, radial_ranges=None):

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -9,249 +9,237 @@ import abel
 import time
 import warnings
 
-class AbelTransform(object):
-    """AbelTransform class
-    
-    This class provides a conveinent way to call all of transform functions
-    as well as the preprocessing (centering) and post processing 
-    (integration) functions. 
-    
-    
-    Attributes
-        ----------
-        IM : NxM numpy array
-            the original 2D image supplied
-        transform : NxM numpy array
-            the transformed (either forward or inverse) image
+def transform(IM, direction='inverse', method='three_point', center='none', verbose=True,
+              vertical_symmetry=True, horizontal_symmetry=True, use_quadrants=(True,True,True,True),
+              transform_options=(), center_options=()):
+    """transform - the go-to function for all of your Abel transform needs!!
 
+    This performs the forward or reverse Abel transform using a user-selected method.
+    
+
+    Parameters
+    ----------
+    IM : a NxM numpy array
+        This is the image to be transformed
+    direction : 'forward' or 'inverse'
+        The type of Abel transform to be performed. 
+        A 'forward' Abel transform takes a (2D) slice of a 3D image and returns the 2D projection.
+        An 'inverse' Abel transform takes a 2D projection and reconstructs a 2D slice of the 3D image.
+        The default is 'inverse'. 
+    method : str
+        specifies which numerical approximation to the Abel transform should be employed (see below).
+        
+        The options are:
+            'hansenlaw' - the recursive algorithm described by Hansen and Law
+            'basex' - the Gaussian "basis set expansion" method of Dribinski et al.
+            'direct' - a naive implementation of the analytical formula by Roman Yurchuk. 
+            'three_point' - the three-point transform of Dasch and co-workers
+    center : tuple or str
+        If a tuple (float, float) is provides, this specifies the image center in (y,x) 
+        (row, column) format. A value None can be supplied if no centering is desired in one dimention,
+        for example center=(None, 250).
+        If a string is provided, an automatic centering algorithm is used:
+            'image_center' - the center is assumed to be the center of the image. 
+            'by_slice' 
+            'com' - the center is calculated as the center of mass
+            'none' - no centering is performed. An image with an odd number of columns must be provided.
+            (default is 'none')
+    verbose : boolean
+        True/False to determine if non-critical output should be printed.
+    vertical_symmetry : boolean
+        Symmetrize the image in the up/down direction? (The first axis is the vertical axis.)
+    horizontal_symmetry: boolean
+        Symmetrize the image in the left/right direction?
+    use_quadrants: boolean tuple (Q0,Q1,Q2,Q3)
+        select quadrants to be used in the analysis. The quadrants are numbered starting from 
+        Q0 in the upper right and proceeding counter-clockwise:
+        
+        ::
+
+             +--------+--------+                
+             | Q1   * | *   Q0 |
+             |   *    |    *   |                               
+             |  *     |     *  |                               AQ1 | AQ0
+             +--------o--------+ --(inverse Abel transform)--> ----o----
+             |  *     |     *  |                               AQ2 | AQ3 
+             |   *    |    *   |
+             | Q2  *  | *   Q3 |          AQi == inverse Abel transform  
+             +--------+--------+                 of quadrant Qi
+
+       ::
+
+       (1) vertical_symmetry = True 
+       ::
+
+           Combine:  `Q01 = Q1 + Q2, Q23 = Q2 + Q3`
+           inverse image   AQ01 | AQ01     
+                           -----o-----            
+                           AQ23 | AQ23
+       ::
+
+       (2) horizontal_symmetry = True
+       ::
+
+           Combine: Q12 = Q1 + Q2, Q03 = Q0 + Q3
+           inverse image   AQ12 | AQ03       
+                           -----o-----
+                           AQ12 | AQ03
+       ::
+
+       (3) vertical_symmetry = True, horizontal = True
+       :: 
+    
+           Combine: Q = Q0 + Q1 + Q2 + Q3
+           inverse image   AQ | AQ       
+                           ---o---  all quadrants equivalent
+                           AQ | AQ
+    
+    transform_options : tuple
+        Additional arguments to be passed to the individual transform functions. 
+        See the documentation for the individual transform method for options.
+    center_options : tuple
+        Additional arguments to be passed to the centering function. 
+        
+    Transform Methods
+    --------
+    As mentioned above, PyAbel offers several different approximations to the the exact abel transform.
+    All the the methods should produce similar results, but depending on the level and type of noise
+    found in the image, certain methods may perform better than others.
+    
+    'hansenlaw' - This "recursive algorithm" produces reliable results and is quite fast 
+        (~0.1 sec for a 1001x1001 image). 
+        It makes no assumptions about the data (apart from cylindrical symmetry).
+        It tends to require that the data is finely sampled for good convergence. 
+        
+        E. W. Hansen and P.-L. Law "Recursive methods for computing the Abel transform and its inverse" 
+        J. Opt. Soc. A*2, 510-520 (1985) (http://dx.doi.org/10.1364/JOSAA.2.000510)
+        
+    'basex'* - The "basis set exapansion" algorithm describes the data in terms of gaussian functions,
+        which themselves can be abel transformed analytically. Because the gaussian functions are approximately
+        the size of each pixel, this method also does not make any assumption about the shape of the data.
+        This method is one of the de-facto standards in photoelectron/photoion imaging.
+        
+         Dribinski et al, 2002 (Rev. Sci. Instrum. 73, 2634)
+         http://dx.doi.org/10.1063/1.1482156
+    
+    'direct' - This method attempts a direct integration of the Abel transform integral. It makes no 
+        assumptions about the data (apart from cylindrical symmetry), but it typically requires fine 
+        sampling to converge. Such methods are typically inefficient, but thanks to this Cython implementation
+        (by Roman Yurchuk), this 'direct' method is competitive with the other methods.
+        
+    'three_point'* - The "Three Point" Abel transform method exploits the observation that the value of 
+        the Abel inverted data at any radial position r is primarily determined from changes in the projection
+        data in the neighborhood of r. This method is also very efficient once it has generated the basis sets.
+        
+        Dasch, 1992 (Applied Optics, Vol 31, No 8, March 1992, Pg 1146-1152).
+    
+    *   The methods marked with a * indicate methods that generate basis sets. 
+        The first time they are run for a new image size, it takes seconds to minutes to generate the basis set.
+        However, this basis set is saved to disk can can be reloaded, meaning that future transforms are performed
+        much more quickly.
+
+
+    Returns
+    --------
+    results : dict
+        The transform function returns a dictionary of results depending on the options selected
+            - results['transform'] (always returned) is the 2D forward/reverse Abel transform
+            - results['radial_intensity'] is not currently implemented
+            - results['residual'] is not currently implemented
     """
-    def __init__ (self, IM, direction=None ,method='three_point', center='none', verbose=True,
-                 vertical_symmetry=True, horizontal_symmetry=True, integrate=True, use_quadrants=(True,True,True,True),
-                 transform_options=(), center_options=() ):
-        """__init__ initializing the AbelTransform class performs a forward (or reverse) abel transform
-
-        This performs the forward or reverse Abel transform using a user-selected method.
-        AbelTransform is typically not called directly, usually the 'abel' or 'iabel' functions are called,
-        which specify the forward or reverse abel transform.
-        
-        Transform Methods
-        --------
-        PyAbel offers several different approximations to the the exact abel transform 
-        ...<provide references here>
-       
-
-        Parameters
-        ----------
-        IM : a NxM numpy array
-            This is the image to be transformed
-        direction : 'forward' or 'inverse'
-            The type of Abel transform to be performed. 
-            A 'forward' Abel transform takes a (2D) slice of a 3D image and returns the 2D projection.
-            An 'inverse' Abel transform takes a 2D projection and reconstructs a 2D slice of the 3D image.
-        method : str
-            The method specifies which numerical approximation to the Abel transform should be employed.
-            All the the methods should produce similar results, but depending on the level and type of noise
-            found in the image, certain methods may perform better than others.
-            The options are:
-                'hansenlaw' - the recursive algorithm described by Hansen and Law
-                'basex' - the Gaussian "basis set expansion" method of Dribinski et al.
-                'direct' - a naive implementation of the analytical formula by Roman Yurchuk. 
-                'three_point' - the three-point transform of Dasch and co-workers
-        center : tuple or str
-            If a tuple (float, float) is provides, this specifies the image center in (y,x) 
-            (row, column) format. A value None can be supplied if no centering is desired in one dimention,
-            for example center=(None, 250).
-            If a string is provided, an automatic centering algorithm is used:
-                'image_center' - the center is assumed to be the center of the image. 
-                'by_slice' 
-                'com' - the center is calculated as the center of mass
-                'none' - no centering is performed. An image with an odd number of columns must be provided.
-                (default is 'none')
-        verbose : boolean
-            True/False to determine if output should be printed.
-        vertical_symmetry : boolean
-            Symmetrize the image in the up/down direction? (The first axis is the vertical axis.)
-        horizontal_symmetry: boolean
-            Symmetrize the image in the left/right direction?
-        integrate : boolean
-            Determines if an angular integration should be performed in order to extract the 
-            radial intensity distribution. This is useful, for example, for calculating the 
-            momentum (speeds) distribution in a photoelectron/photoion angular distribution (PAD)
-        use_quadrants: boolean tuple (Q0,Q1,Q2,Q3)
-            select quadrants to be used in the analysis::
-
-                 +--------+--------+                
-                 | Q1   * | *   Q0 |
-                 |   *    |    *   |                               
-                 |  *     |     *  |                               AQ1 | AQ0
-                 +--------o--------+ --(inverse Abel transform)--> ----o----
-                 |  *     |     *  |                               AQ2 | AQ3 
-                 |   *    |    *   |
-                 | Q2  *  | *   Q3 |          AQi == inverse Abel transform  
-                 +--------+--------+                 of quadrant Qi
- 
-           ::
-
-           (1) vertical_symmetry = True 
-           ::
- 
-               Combine:  `Q01 = Q1 + Q2, Q23 = Q2 + Q3`
-               inverse image   AQ01 | AQ01     
-                               -----o-----            
-                               AQ23 | AQ23
-           ::
-
-           (2) horizontal_symmetry = True
-           ::
-
-               Combine: Q12 = Q1 + Q2, Q03 = Q0 + Q3
-               inverse image   AQ12 | AQ03       
-                               -----o-----
-                               AQ12 | AQ03
-           ::
- 
-           (3) vertical_symmetry = True, horizontal = True
-           :: 
-        
-               Combine: Q = Q0 + Q1 + Q2 + Q3
-               inverse image   AQ | AQ       
-                               ---o---  all quadrants equivalent
-                               AQ | AQ
-        
-        transform_options : tuple
-            Additional arguments to be passed to the individual transform functions. 
-            See the documentation for the individual transform method for options.
-        center_options : tuple
-            Additional arguments to be passed to the centering function. 
-        
-        """
-        
-        self.IM = IM
                         
-        verboseprint = print if verbose else lambda *a, **k: None
-        
-        if self.IM.ndim == 1 or np.shape(self.IM)[0] <= 2:
-                raise ValueError('Data must be 2-dimensional.'
-                                 'To transform a single row, use'
-                                 'iabel_hansenlaw_transform().')
-
-        if not np.any(use_quadrants): raise ValueError('No image quadrants selected to use')
-        
-        rows, cols = np.shape(self.IM)
-        
-        #########################
-        # Centering is currently broken pending improvements to the centering functions.
-        # see the discussion in Issue 90: https://github.com/PyAbel/PyAbel/issues/90#issuecomment-184301835
-        if center == 'none':
-            # no centering
-            if rows%2 != 1: 
-                raise ValueError('Image must have an odd number of columns. Use a centering method.')
-            
-        elif center == 'com' or center == 'image_center':
-            # automatic centering
-            raise ValueError('Automatic centering not currently supported.')
-            
-        else:
-            # manual centering
-            raise ValueError('Manual centering not currently supported.')
-            # set center to y,x value
-            
-        #########################
-        
-         
-        verboseprint('Calculating {0} Abel transform using {1} method -'.format(direction,method),
-                     'image size: {:d}x{:d}'.format(rows, cols))
-        
-        t0 = time.time()
-
-
-        # split image into quadrants
-        Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(self.IM, reorient=True,
-                             vertical_symmetry=vertical_symmetry, horizontal_symmetry=horizontal_symmetry)
-
-        def selected_transform(Z):
-            if method == 'hansenlaw':
-                if direction == 'forward':
-                    return abel.hansenlaw.fabel_hansenlaw(Z, *transform_options)
-                elif direction == 'inverse':
-                    return abel.hansenlaw.iabel_hansenlaw(Z, *transform_options)
-            
-            elif method == 'three_point':
-                if direction == 'forward':
-                    raise ValueError('Forward three-point not implemented')
-                elif direction == 'inverse':
-                    return abel.three_point.iabel_three_point_transform(Z, *transform_options)
-            
-            elif method == 'basex':
-                if direction == 'forward':
-                    raise ValueError('Forward basex not implemented')
-                elif direction == 'inverse':
-                    warnings.warn('BASEX implementation not working correctly within abel.iabel!')
-                    return abel.basex.iabel_basex(Z, *transform_options)
-            
-            elif method == 'direct':
-                if direction == 'forward':
-                    raise ValueError('Coming soon...')
-                elif direction == 'inverse':
-                    raise ValueError('Coming soon...')
-                    
-        AQ0 = AQ1 = AQ2 = AQ3 = None
-        # Inverse Abel transform for quadrant 1 (all include Q1)
-        AQ1 = selected_transform(Q1)
-
-        if vertical_symmetry:
-            AQ2 = selected_transform(Q2)
-
-        if horizontal_symmetry:
-            AQ0 = selected_transform(Q0)
-
-        if not vertical_symmetry and not horizontal_symmetry:
-            AQ0 = selected_transform(Q0)
-            AQ2 = selected_transform(Q2)
-            AQ3 = selected_transform(Q3)
-
-        # reassemble image
-        self.transform = abel.tools.symmetry.put_image_quadrants((AQ0, AQ1, AQ2, AQ3), odd_size=cols % 2,
-                                    vertical_symmetry=vertical_symmetry,
-                                    horizontal_symmetry=horizontal_symmetry)
-
-        verboseprint("{:.2f} seconds".format(time.time()-t0))
-        
+    verboseprint = print if verbose else lambda *a, **k: None
     
-    def angular_integration(self,*args,**kwargs):
-        self.radial_intensity, self.radial_coordinate = abel.tools.vmi.calculate_speeds(self.transform, *args, **kwargs)
-        return self.radial_coordinate, self.radial_intensity
+    if IM.ndim == 1 or np.shape(IM)[0] <= 2:
+            raise ValueError('Data must be 2-dimensional.'
+                             'To transform a single row use the individual transform function.')
+
+    if not np.any(use_quadrants): raise ValueError('No image quadrants selected to use')
+    
+    rows, cols = np.shape(IM)
+    
+    # centering: 
+    if center == 'none': # no centering
+        if rows%2 != 1: 
+            raise ValueError('Image must have an odd number of columns. Use a centering method.')
         
-    def calculate_anisotropy(self):
-        print('Anisotropy not yet implemented!')
-        return 1
+    elif center == 'com' or center == 'image_center':
+        # automatic centering
+        IM = abel.center_image(IM,center)
+        
+    else:
+        # manual centering
+        raise ValueError('Manual centering not currently supported.')
+        # set center to y,x value
+    #########################
     
-    def residual(self):
-        print('Not yet implemented')
-        # in some cases, like basex, we can recover the projection while we are performing the inverse transform
-        # in that case, we can: return self.IM - self.proj 
+     
+    verboseprint('Calculating {0} Abel transform using {1} method -'.format(direction,method),
+                 'image size: {:d}x{:d}'.format(rows, cols))
     
-    @classmethod
-    def iabel(cls, *args, **kwargs):
-        trans=cls(*args, direction='inverse', **kwargs)
-        return trans
-    
-    @classmethod
-    def fabel(cls, *args, **kwargs):
-        trans=cls(*args, direction='forward', **kwargs)
-        return trans
+    t0 = time.time()
 
-iabel = AbelTransform.iabel
-fabel = AbelTransform.fabel
 
+    # split image into quadrants
+    Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(IM, reorient=True,
+                         vertical_symmetry=vertical_symmetry, horizontal_symmetry=horizontal_symmetry)
+
+    def selected_transform(Z):
+        if method == 'hansenlaw':
+            if direction == 'forward':
+                return abel.hansenlaw.fabel_hansenlaw(Z, *transform_options)
+            elif direction == 'inverse':
+                return abel.hansenlaw.iabel_hansenlaw(Z, *transform_options)
+        
+        elif method == 'three_point':
+            if direction == 'forward':
+                raise ValueError('Forward three-point not implemented')
+            elif direction == 'inverse':
+                return abel.three_point.iabel_three_point_transform(Z, *transform_options)
+        
+        elif method == 'basex':
+            if direction == 'forward':
+                raise ValueError('Forward basex not implemented')
+            elif direction == 'inverse':
+                return abel.basex.iabel_basex(Z, *transform_options)
+        
+        elif method == 'direct':
+            if direction == 'forward':
+                raise ValueError('Coming soon...')
+            elif direction == 'inverse':
+                raise ValueError('Coming soon...')
+                
+    AQ0 = AQ1 = AQ2 = AQ3 = None
+    # Inverse Abel transform for quadrant 1 (all include Q1)
+    AQ1 = selected_transform(Q1)
+
+    if vertical_symmetry:
+        AQ2 = selected_transform(Q2)
+
+    if horizontal_symmetry:
+        AQ0 = selected_transform(Q0)
+
+    if not vertical_symmetry and not horizontal_symmetry:
+        AQ0 = selected_transform(Q0)
+        AQ2 = selected_transform(Q2)
+        AQ3 = selected_transform(Q3)
+
+    # reassemble image
+    results = {}
+    results['transform'] = abel.tools.symmetry.put_image_quadrants((AQ0, AQ1, AQ2, AQ3), odd_size=cols % 2,
+                                vertical_symmetry=vertical_symmetry,
+                                horizontal_symmetry=horizontal_symmetry)
+
+    verboseprint("{:.2f} seconds".format(time.time()-t0))
+    
+    return results
+    
 
 def main():
     import matplotlib.pyplot as plt
-    IM0 = abel.tools.analytical.sample_image_dribinski(n=361)
-    trans1 = fabel(IM0,method='hansenlaw')
-    IM1 = trans1.transform
-    trans2 = iabel(IM1,method='three_point')
-    IM2 = trans2.transform
+    IM0 = abel.tools.analytical.sample_image_dribinski(n=201)
+    IM1 = transform(IM0,direction='forward',center='com',method='hansenlaw')['transform']
+    IM2 = transform(IM1,direction='inverse',method='basex')['transform']
     
     fig, axs = plt.subplots(2,3,figsize=(10,6))
     
@@ -259,14 +247,12 @@ def main():
     axs[0,1].imshow(IM1)
     axs[0,2].imshow(IM2)
     
-    axs[1,0].plot(*abel.tools.vmi.calculate_speeds(IM0)[::-1])
-    axs[1,1].plot(*trans1.angular_integration())
-    axs[1,2].plot(*trans2.angular_integration())
+    axs[1,0].plot(*abel.tools.vmi.angular_integration(IM0)[::-1])
+    axs[1,1].plot(*abel.tools.vmi.angular_integration(IM1)[::-1])
+    axs[1,2].plot(*abel.tools.vmi.angular_integration(IM2)[::-1])
     
     plt.show()
     
     
 if __name__ == "__main__":
     main()
-    
-    

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -11,7 +11,7 @@ import warnings
 
 def transform(IM, direction='inverse', method='three_point', center='none', verbose=True,
               vertical_symmetry=True, horizontal_symmetry=True, use_quadrants=(True,True,True,True),
-              transform_options=(), center_options=()):
+              transform_options={}, center_options={}):
     """transform - the go-to function for all of your Abel transform needs!!
 
     This performs the forward or reverse Abel transform using a user-selected method.
@@ -242,9 +242,9 @@ def main():
     axs[0,1].imshow(IM1)
     axs[0,2].imshow(IM2)
     
-    axs[1,0].plot(*abel.tools.vmi.angular_integration(IM0)[::-1])
-    axs[1,1].plot(*abel.tools.vmi.angular_integration(IM1)[::-1])
-    axs[1,2].plot(*abel.tools.vmi.angular_integration(IM2)[::-1])
+    axs[1,0].plot(*abel.tools.vmi.angular_integration(IM0))
+    axs[1,1].plot(*abel.tools.vmi.angular_integration(IM1))
+    axs[1,2].plot(*abel.tools.vmi.angular_integration(IM2))
     
     plt.show()
     

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -163,14 +163,9 @@ def transform(IM, direction='inverse', method='three_point', center='none', verb
         if rows%2 != 1: 
             raise ValueError('Image must have an odd number of columns. Use a centering method.')
         
-    elif center == 'com' or center == 'image_center':
-        # automatic centering
-        IM = abel.center_image(IM,center)
-        
     else:
-        # manual centering
-        raise ValueError('Manual centering not currently supported.')
-        # set center to y,x value
+        IM = abel.center_image(IM,center)
+
     #########################
     
      
@@ -187,21 +182,21 @@ def transform(IM, direction='inverse', method='three_point', center='none', verb
     def selected_transform(Z):
         if method == 'hansenlaw':
             if direction == 'forward':
-                return abel.hansenlaw.fabel_hansenlaw(Z, *transform_options)
+                return abel.hansenlaw.fabel_hansenlaw(Z, **transform_options)
             elif direction == 'inverse':
-                return abel.hansenlaw.iabel_hansenlaw(Z, *transform_options)
+                return abel.hansenlaw.iabel_hansenlaw(Z, **transform_options)
         
         elif method == 'three_point':
             if direction == 'forward':
                 raise ValueError('Forward three-point not implemented')
             elif direction == 'inverse':
-                return abel.three_point.iabel_three_point_transform(Z, *transform_options)
+                return abel.three_point.iabel_three_point_transform(Z, **transform_options)
         
         elif method == 'basex':
             if direction == 'forward':
                 raise ValueError('Forward basex not implemented')
             elif direction == 'inverse':
-                return abel.basex.iabel_basex(Z, *transform_options)
+                return abel.basex.iabel_basex(Z, **transform_options)
         
         elif method == 'direct':
             if direction == 'forward':

--- a/doc/example_basex_gaussian.rst
+++ b/doc/example_basex_gaussian.rst
@@ -1,0 +1,8 @@
+Example: Basex gaussian
+======================
+
+
+.. plot:: ../examples/example_basex_gaussian.py
+   :include-source:
+
+	

--- a/doc/example_basex_photoelectron.rst
+++ b/doc/example_basex_photoelectron.rst
@@ -1,0 +1,8 @@
+Example: Basex Photoelectron
+======================
+
+
+.. plot:: ../examples/example_basex_photoelectron.py
+   :include-source:
+
+	

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,7 @@ Contents:
    example_O2_PES_PAD
    example_hansenlaw_Xe
    example_basex_gaussian
+   example_basex_photoelectron
    
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,7 @@ Contents:
    example_hansenlaw
    example_O2_PES_PAD
    example_hansenlaw_Xe
+   example_basex_gaussian
    
 
 

--- a/examples/example_basex_gaussian.py
+++ b/examples/example_basex_gaussian.py
@@ -1,7 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from abel.basex import BASEX
-from abel.tools.analytical import GaussianAnalytical
+import abel
 
 # This example performs a BASEX transform of a simple 1D Gaussian function and compares
 # this to the analytical inverse Abel transform 
@@ -14,7 +13,7 @@ n = 101
 r_max = 20
 sigma = 10
 
-ref = GaussianAnalytical(n, r_max, sigma)
+ref = abel.tools.analytical.GaussianAnalytical(n, r_max, sigma,symmetric=False)
 
 ax.plot(ref.r, ref.func, 'b', label='Original signal')
 
@@ -24,14 +23,13 @@ center = n//2
 
 # BASEX Transform: 
 # Calculate the inverse abel transform for the centered data
-recon = BASEX(ref.abel, center,  n=n, basis_dir=None, dr=ref.dr,
-        verbose=True, calc_speeds=False)
+recon = abel.basex.iabel_basex(ref.abel, verbose=True, basis_dir=None, dr=ref.dr)
 
-ax.plot(ref.r, recon , '--o',c='red', label='Inverse transform [BASEX]')
+ax.plot(ref.r, recon , 'o',color='red', label='Inverse transform [BASEX]', ms=5, mec='none',alpha=0.5)
 
 ax.legend()
 
-ax.set_xlim(-20,20)
+ax.set_xlim(0,20)
 ax.set_xlabel('x')
 ax.set_ylabel('f(x)')
 


### PR DESCRIPTION
As discussed in issue # https://github.com/PyAbel/PyAbel/issues/93, I converted the previous `transform.AbelTransform` class into the `abel.transform` function, which calls the other transform functions and returns a dictionary, where `results['transform']` is the 2D transform.

I also just called this `abel.transform` instead of using the `iabel/fabel` structure.

Other big changes:

1. I reformatted basex.py to get rid of all of the centering and speeds calculation stuff that we now do in the `abel.transform` function. 

2. I made some changes to `center.py`, trying to make everything in (y,x) (aka: row,column) format. 

3. I made `example_basex_photoelectron.py` and `example_basex_gaussian.py` work. I think that the rest of them are still broken.

4. I added some more to the docstring for `abel.transform`. See if you like it.

I'd like to merge this soon to restore functionality to PyAbel, so let me know your thoughts. @stggh @rth @DhrubajyotiDas @ldes89150 