### PR TITLE
Added dummy direction parameter to basex and three_point

### DIFF
--- a/abel/basex.py
+++ b/abel/basex.py
@@ -45,7 +45,8 @@ from ._version import __version__
 #############################################################################
 
 
-def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True):
+def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True,
+                direction='inverse'):
     """
     This function that centers the image,
     performs the BASEX transform (loads or generates basis sets),
@@ -71,6 +72,9 @@ def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True):
         size of one pixel in the radial direction
     verbose : boolean
         Determins if statements should be printed.
+    direction : str
+        The type of Abel transform to be performed.
+        Currently only accepts value 'inverse'
 
 
     Returns
@@ -80,6 +84,10 @@ def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True):
 
     """
     # make sure that the data is the right shape (1D must be converted to 2D)
+
+    if direction != 'inverse':
+        raise ValueError('Forward BASEX transform not implemented')
+
     data = np.atleast_2d(data)
     h, w = data.shape
 
@@ -134,6 +142,7 @@ def basex_transform(rawdata, M_vert, M_horz, Mc_vert,
     IM : NxM numpy array
         The abel-transformed image, a slice of the 3D distribution
     """
+
     # Reconstructing image  - This is where the magic happens
     Ci = vert_left.dot(rawdata).dot(horz_right)
 

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -147,7 +147,8 @@ def get_bs_three_point_cached(col, basis_dir='.', verbose=False):
 
 
 def iabel_three_point(data, center,
-                      dr=1.0, basis_dir='./', verbose=False):
+                      dr=1.0, basis_dir='./', verbose=False,
+                      direction='inverse'):
     """
     This function splits the image into two halves,
     sends each half to iabel_three_point_transform(),
@@ -171,12 +172,18 @@ def iabel_three_point(data, center,
         If None, the operator matrix will not be saved to disk.
     verbose : True/False
         Set to True to see more output for debugging
+    direction : str
+        The type of Abel transform to be performed.
+        Currently only accepts value 'inverse'
 
     Returns
     -------
     inv_IM : numpy array
         Abel inversion of IM - a rows x cols array
     """
+
+    if direction != 'inverse':
+        raise ValueError('Forward three_point transform not implemented')
 
     # sanity checks for center
     # 1. If center is tuple, only take the second value inside it


### PR DESCRIPTION
This PR adds the `direction` parameter to the function calls for `basex` and `three_point` as per the discussion in #96. 

@DanHickstein I hope I added the parameters in the right place.