### PR TITLE
Removal of f/iabel_<method> wrapper functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,7 @@ In order to allow a consistent user experience between different implementations
 
 The implementation named `<implementation>`, located under `abel/<implementation>.py` should use the following naming system for top-level functions,
 
- -  `fabel_<implemenation>`  :  forward transform (when defined)
- -  `iabel_<implemenation>` :  inverse implementation (when defined)
+ -  `<implemenation>_transform`  :  core transform (when defined)
  -  `_bs_<implementation>` :  function that generates  the basis sets (if necessary)
  -  `bs_<implementation>_cached` : function that loads the basis sets from disk, and generates them if they are not found (if necessary).
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -45,8 +45,8 @@ from ._version import __version__
 #############################################################################
 
 
-def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True,
-                direction='inverse'):
+def basex_transform(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True,
+                    direction='inverse'):
     """
     This function that centers the image,
     performs the BASEX transform (loads or generates basis sets),
@@ -109,8 +109,8 @@ def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True,
             n_vert=n[0], n_horz=n[1], nbf=nbf, basis_dir=basis_dir,
             verbose=verbose)
     # Do the actual transform:
-    recon = basex_transform(full_image, M_vert, M_horz,
-                            Mc_vert, Mc_horz, vert_left, horz_right, dr)
+    recon = basex_core_transform(full_image, M_vert, M_horz,
+                                  Mc_vert, Mc_horz, vert_left, horz_right, dr)
     if data_ndim == 1:  # taking the middle row, since the rest are zeroes
         recon = recon[recon.shape[0] - recon.shape[0]//2 - 1]
     if h == 1:
@@ -119,8 +119,8 @@ def iabel_basex(data, nbf='auto', basis_dir='./', dr=1.0, verbose=True,
         return recon[:, w-1:]
 
 
-def basex_transform(rawdata, M_vert, M_horz, Mc_vert,
-                    Mc_horz, vert_left, horz_right, dr=1.0):
+def basex_core_transform(rawdata, M_vert, M_horz, Mc_vert,
+                         Mc_horz, vert_left, horz_right, dr=1.0):
     """
     This is the internal function
     that does the actual BASEX transform

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -29,46 +29,6 @@ except (ImportError, UnicodeDecodeError):
 ###########################################################################
 
 
-_direct_doctsting = \
-    """
-    This algorithm does a direct computation of the Abel transform
-
-      * integration near the singular value is done analytically
-      * integration further from the singular value with the Simpson
-        rule.
-
-    Parameters
-    ----------
-
-    fr : 1d or 2d numpy array
-        input array to which direct/inversed Abel transform will be applied.
-        For a 2d array, the first dimension is assumed to be the z axis and
-        the second the r axis.
-    dr : float
-        spatial mesh resolution           (optional, default to 1.0)
-    f : 1D ndarray
-        the spatial mesh (optional)
-    derivative : callable
-        a function that can return the derivative of the fr array
-        with respect to r
-        (only used in the inverse Abel transform).
-    inverse : boolean
-        If True inverse Abel transform is applied,
-        otherwise use a forward Abel transform.
-    correction : boolean
-        if False integration is performed with the Simpson rule,
-        the pixel where the weighting function has a singular value is ignored
-        if True in addition to the integration with the Simpson rule,
-        integration near the singular value is done analytically,
-        assuming a piecewise linear data.
-
-    Returns
-    -------
-    out : 1d or 2d numpy array of the same shape as fr
-        with either the direct or the inverse abel transform.
-    """
-
-
 def simpson_rule_wrong(f, x=None, dx=None, axis=1, **args):
     """
     This function computes the Simpson rule
@@ -116,10 +76,43 @@ def direct_transform(fr, dr=None, r=None, direction='inverse',
                      int_func=simpson_rule_wrong,
                      correction=True, backend='C'):
     """
-    Returns the forward or the inverse Abel transform of a function
-    sampled using direct integration.
+    This algorithm does a direct computation of the Abel transform
 
+      * integration near the singular value is done analytically
+      * integration further from the singular value with the Simpson
+        rule.
+
+    Parameters
+    ----------
+
+    fr : 1d or 2d numpy array
+        input array to which direct/inversed Abel transform will be applied.
+        For a 2d array, the first dimension is assumed to be the z axis and
+        the second the r axis.
+    dr : float
+        spatial mesh resolution           (optional, default to 1.0)
+    f : 1D ndarray
+        the spatial mesh (optional)
+    derivative : callable
+        a function that can return the derivative of the fr array
+        with respect to r
+        (only used in the inverse Abel transform).
+    inverse : boolean
+        If True inverse Abel transform is applied,
+        otherwise use a forward Abel transform.
+    correction : boolean
+        if False integration is performed with the Simpson rule,
+        the pixel where the weighting function has a singular value is ignored
+        if True in addition to the integration with the Simpson rule,
+        integration near the singular value is done analytically,
+        assuming a piecewise linear data.
+
+    Returns
+    -------
+    out : 1d or 2d numpy array of the same shape as fr
+        with either the direct or the inverse abel transform.
     """
+
     backend = backend.lower()
     if backend not in ['c', 'python']:
         raise ValueError
@@ -220,12 +213,6 @@ def _pyabel_direct_integral(f, r, correction, int_func=simpson_rule_wrong):
                     + np.arccosh(r[1:]/r[:-1])*(row[:-1] - f_r[i]*r[:-1])
 
     return out
-
-
-# append the same docstring to all functions
-#iabel_direct.__doc__ += _direct_doctsting
-#fabel_direct.__doc__ += _direct_doctsting
-direct_transform.__doc__ += _direct_doctsting
 
 
 def is_uniform_sampling(r):

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -86,23 +86,6 @@ def simpson_rule_wrong(f, x=None, dx=None, axis=1, **args):
     return res*dx/3
 
 
-def iabel_direct(fr, dr=None, r=None, **args):
-    """
-    Returns the inverse Abel transform
-
-    """
-    return _abel_transform_wrapper(fr, dr=dr, r=r, inverse=True, **args)
-
-
-def fabel_direct(fr, dr=None, r=None, **args):
-    """
-    Returns the direct Abel transform of a function
-    sampled at discrete points.
-
-    """
-    return _abel_transform_wrapper(fr, dr=dr, r=r, inverse=False, **args)
-
-
 def _construct_r_grid(n, dr=None, r=None):
     """ Internal function to construct a 1D spatial grid """
     if dr is None and r is None:
@@ -128,10 +111,10 @@ def _construct_r_grid(n, dr=None, r=None):
     return r, dr
 
 
-def _abel_transform_wrapper(fr, dr=None, r=None, inverse=False,
-                            derivative=gradient,
-                            int_func=simpson_rule_wrong,
-                            correction=True, backend='C'):
+def direct_transform(fr, dr=None, r=None, direction='inverse',
+                     derivative=gradient,
+                     int_func=simpson_rule_wrong,
+                     correction=True, backend='C'):
     """
     Returns the forward or the inverse Abel transform of a function
     sampled using direct integration.
@@ -144,12 +127,12 @@ def _abel_transform_wrapper(fr, dr=None, r=None, inverse=False,
 
     r, dr = _construct_r_grid(f.shape[1], dr=dr, r=r)
 
-    if inverse:
+    if direction == "inverse":
         # a derivative function must be provided
         f = derivative(f)/dr
         # setting the derivative at the origin to 0
         # f[:,0] = 0
-    if inverse:
+    if direction == "inverse":
         f *= - 1./np.pi
     else:
         f *= 2*r[None, :]
@@ -240,9 +223,9 @@ def _pyabel_direct_integral(f, r, correction, int_func=simpson_rule_wrong):
 
 
 # append the same docstring to all functions
-iabel_direct.__doc__ += _direct_doctsting
-fabel_direct.__doc__ += _direct_doctsting
-_abel_transform_wrapper.__doc__ += _direct_doctsting
+#iabel_direct.__doc__ += _direct_doctsting
+#fabel_direct.__doc__ += _direct_doctsting
+direct_transform.__doc__ += _direct_doctsting
 
 
 def is_uniform_sampling(r):

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -8,30 +8,31 @@ import numpy as np
 from time import time
 from math import exp, log, pow, pi
 
-"""
-hansenlaw - a recursive method forward/inverse Abel transform algorithm
+#############################################################################
+# hansenlaw - a recursive method forward/inverse Abel transform algorithm
+# 
+# Stephen Gibson - Australian National University, Australia
+# Jason Gascooke - Flinders University, Australia
+# 
+# This algorithm is adapted by Jason Gascooke from the article
+#   E. W. Hansen and P-L. Law
+#  "Recursive methods for computing the Abel transform and its inverse"
+#   J. Opt. Soc. Am A2, 510-520 (1985) doi: 10.1364/JOSAA.2.000510
+# 
+#  J. R. Gascooke PhD Thesis:
+#   "Energy Transfer in Polyatomic-Rare Gas Collisions and Van Der Waals
+#    Molecule Dissociation", Flinders University, 2000.
+# 
+# Implemented in Python, with image quadrant co-adding, by Steve Gibson
+# 2015-12-16: Modified to calculate the forward Abel transform
+# 2015-12-03: Vectorization and code improvements Dan Hickstein and Roman Yurchak
+#             Previously the algorithm iterated over the rows of the image
+#             now all of the rows are calculated simultaneously, which provides
+#             the same result, but speeds up processing considerably.
+#############################################################################
 
-Stephen Gibson - Australian National University, Australia
-Jason Gascooke - Flinders University, Australia
 
-This algorithm is adapted by Jason Gascooke from the article
-  E. W. Hansen and P-L. Law
- "Recursive methods for computing the Abel transform and its inverse"
-  J. Opt. Soc. Am A2, 510-520 (1985) doi: 10.1364/JOSAA.2.000510
-
- J. R. Gascooke PhD Thesis:
-  "Energy Transfer in Polyatomic-Rare Gas Collisions and Van Der Waals
-   Molecule Dissociation", Flinders University, 2000.
-
-Implemented in Python, with image quadrant co-adding, by Steve Gibson
-2015-12-16: Modified to calculate the forward Abel transform
-2015-12-03: Vectorization and code improvements Dan Hickstein and Roman Yurchak
-            Previously the algorithm iterated over the rows of the image
-            now all of the rows are calculated simultaneously, which provides
-            the same result, but speeds up processing considerably.
-"""
-
-_hansenlaw_header_docstring = \
+def hansenlaw_transform(IM, dr=1, direction="inverse"):
     """
     Forward/Inverse Abel transformation using the algorithm of:
     Hansen and Law J. Opt. Soc. Am. A 2, 510-520 (1985).::
@@ -61,10 +62,7 @@ _hansenlaw_header_docstring = \
     g = abel.transform(r, direction="forward", method="hansenlaw")["transform"]
         forward Abel transform of image f
 
-    """
 
-_hansenlaw_transform_docstring = \
-    """
 
     Core Hansen and Law Abel transform e.g.
 
@@ -79,6 +77,9 @@ _hansenlaw_transform_docstring = \
     Use AIM = abel.transform(IM, method="hansenlaw", 
                              direction="inverse")["transform"]
     to transform a whole image
+
+
+
 
     Parameters
     ----------
@@ -113,11 +114,6 @@ _hansenlaw_transform_docstring = \
     """
 
 
-def hansenlaw_transform(IM, dr=1, direction="inverse"):
-    """
-    Hansen and Law JOSA A2 510 (1985) forward and inverse Abel transform
-    for right half (or right-top quadrant) of an image.
-    """
 
     IM = np.atleast_2d(IM)
     N = np.shape(IM)         # shape of input quadrant (half)
@@ -182,8 +178,3 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
         return AIM*np.pi/dr    # 1/dr - from derivative
     else:
         return -AIM*np.pi*dr   # forward still needs '-' sign
-
-# append the same docstring to all functions - borrowed from @rth
-#iabel_hansenlaw.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring
-#fabel_hansenlaw.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring
-#hansenlaw_transform.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -55,18 +55,20 @@ _hansenlaw_header_docstring = \
 
     Evaluation via Eq. (15 or 17), using (16a), (16b), and (16c or 18)
 
-    f = iabel_hansenlaw(g)
+    f = abel.transform(g, direction="inverse", method="hansenlaw")["transform"]
         inverse Abel transform of image g
-    g = fabel_hansenlaw(f)
+
+    g = abel.transform(r, direction="forward", method="hansenlaw")["transform"]
         forward Abel transform of image f
-    (f/i)abel_hansenlaw_transform()
-        core algorithm
+
     """
 
 _hansenlaw_transform_docstring = \
     """
 
-    Core Hansen and Law Abel transform
+    Core Hansen and Law Abel transform e.g.
+
+      Qtrans = abel.hansenlaw.hansenlaw_transform(Q, direction="inverse")
 
     Recursion method proceeds from the outer edge of the image
     toward the image centre (origin). i.e. when n=N-1, R=Rmax, and
@@ -74,7 +76,9 @@ _hansenlaw_transform_docstring = \
     quadrant (chosen orientation to be rightside-top), or one right-half
     image at a time.
 
-    Use (f/i)abel_transform (IM) to transform a whole image
+    Use AIM = abel.transform(IM, method="hansenlaw", 
+                             direction="inverse")["transform"]
+    to transform a whole image
 
     Parameters
     ----------
@@ -107,20 +111,6 @@ _hansenlaw_transform_docstring = \
         forward/inverse Abel transform image
 
     """
-
-
-def fabel_hansenlaw(IM, dr=1):
-    """
-    Forward Abel transform for one-quadrant
-    """
-    return hansenlaw_transform(IM, dr=dr, direction="forward")
-
-
-def iabel_hansenlaw(IM, dr=1):
-    """
-    Inverse Abel transform for one-quadrant
-    """
-    return hansenlaw_transform(IM, dr=dr, direction="inverse")
 
 
 def hansenlaw_transform(IM, dr=1, direction="inverse"):
@@ -194,6 +184,6 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
         return -AIM*np.pi*dr   # forward still needs '-' sign
 
 # append the same docstring to all functions - borrowed from @rth
-iabel_hansenlaw.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring
-fabel_hansenlaw.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring
-hansenlaw_transform.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring
+#iabel_hansenlaw.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring
+#fabel_hansenlaw.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring
+#hansenlaw_transform.__doc__ += _hansenlaw_header_docstring + _hansenlaw_transform_docstring

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -7,9 +8,7 @@ import os.path
 import numpy as np
 from numpy.testing import assert_allclose
 
-from abel.basex import get_bs_basex_cached, basex_transform
-from abel.tools.analytical import StepAnalytical, GaussianAnalytical
-from abel.benchmark import absolute_ratio_benchmark
+import abel
 
 
 DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
@@ -22,9 +21,9 @@ def test_basex_basis_sets_cache():
     if os.path.exists(file_name):
         os.remove(file_name)
     # 1st call generate and save
-    get_bs_basex_cached(n,n, basis_dir=DATA_DIR, verbose=False)
+    abel.basex.get_bs_basex_cached(n,n, basis_dir=DATA_DIR, verbose=False)
     # 2nd call load from file
-    get_bs_basex_cached(n,n, basis_dir=DATA_DIR, verbose=False)
+    abel.basex.get_bs_basex_cached(n,n, basis_dir=DATA_DIR, verbose=False)
     if os.path.exists(file_name):
         os.remove(file_name)
 
@@ -32,18 +31,18 @@ def test_basex_basis_sets_cache():
 def test_basex_shape():
     n = 21
     x = np.ones((n, n), dtype='float32')
-    bs = get_bs_basex_cached(n,n, basis_dir=None, verbose=False)
+    bs = abel.basex.get_bs_basex_cached(n,n, basis_dir=None, verbose=False)
 
-    recon = basex_transform(x, *bs)
+    recon = abel.basex.basex_core_transform(x, *bs)
 
     assert recon.shape == (n, n) 
 
 def test_basex_zeros():
     n = 21
     x = np.zeros((n, n), dtype='float32')
-    bs = get_bs_basex_cached(n,n, basis_dir=None, verbose=False)
+    bs = abel.basex.get_bs_basex_cached(n,n, basis_dir=None, verbose=False)
 
-    recon = basex_transform(x, *bs)
+    recon = abel.basex.basex_core_transform(x, *bs)
 
     assert_allclose(recon, 0)
 
@@ -53,15 +52,20 @@ def test_basex_step_ratio():
     n = 51
     r_max = 25
 
-    ref = GaussianAnalytical(n, r_max, symmetric=True,  sigma=10)
+    ref = abel.tools.analytical.GaussianAnalytical(n, r_max, symmetric=True,  sigma=10)
     tr = np.tile(ref.abel[None, :], (n, 1)) # make a 2D array from 1D
 
-    bs = get_bs_basex_cached(n,n, basis_dir=None, verbose=False)
+    bs = abel.basex.get_bs_basex_cached(n,n, basis_dir=None, verbose=False)
 
-    recon = basex_transform(tr, *bs)
+    recon = abel.basex.basex_core_transform(tr, *bs)
     recon1d = recon[n//2 + n%2]
 
-    ratio = absolute_ratio_benchmark(ref, recon1d)
+    ratio = abel.benchmark.absolute_ratio_benchmark(ref, recon1d)
 
     assert_allclose( ratio , 1.0, rtol=3e-2, atol=0)
 
+if __name__ == '__main__':
+    test_basex_basis_sets_cache()
+    test_basex_shape()
+    test_basex_zeros()
+    test_basex_step_ratio()

--- a/abel/tests/test_direct.py
+++ b/abel/tests/test_direct.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import time
 

--- a/abel/tests/test_direct.py
+++ b/abel/tests/test_direct.py
@@ -49,7 +49,7 @@ def test_inverse_direct_gaussian():
 
     ratio = abel.benchmark.absolute_ratio_benchmark(ref, recon, kind='inverse')
 
-    # FIX ME! - requires scalefactor!
+    # FIX ME! - requires scalefactor!  stggh 25Feb16
     scalefactor = recon[0]/ref.func[0]
     ratio *= scalefactor
 

--- a/abel/tests/test_hansenlaw.py
+++ b/abel/tests/test_hansenlaw.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/abel/tests/test_hansenlaw.py
+++ b/abel/tests/test_hansenlaw.py
@@ -1,14 +1,12 @@
+#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-import os.path
 
 import numpy as np
 from numpy.testing import assert_allclose
 
 import abel
-from abel.benchmark import absolute_ratio_benchmark
 
 # Curve A, Table 2, Fig 3. Abel transform pair  Hansen&Law JOSA A2 510 (1985)
 def f(r):
@@ -44,8 +42,8 @@ def test_hansenlaw_zeros():
     assert_allclose(recon, 0)
 
 
-def test_fabel_hansenlaw_gaussian():
-    """Check fabel_hansenlaw with a Gaussian function"""
+def test_hansenlaw_forward_tansform_gaussian():
+    """Check hansenlaw forward tansform with a Gaussian function"""
     n = 1001
     r_max = 501   # more points better fit
 
@@ -55,30 +53,30 @@ def test_fabel_hansenlaw_gaussian():
     recon = abel.hansenlaw.hansenlaw_transform(ref.func, ref.dr,
                                                direction='forward')
 
-    ratio = absolute_ratio_benchmark(ref, recon, kind='direct')
+    ratio = abel.benchmark.absolute_ratio_benchmark(ref, recon, kind='direct')
 
     assert_allclose(ratio, 1.0, rtol=7e-2, atol=0)
 
 
-def test_iabel_hansenlaw_gaussian():
-    """Check iabel_hansenlaw with a Gaussian function"""
+def test_hansenlaw_inverse_transform_gaussian():
+    """Check hansenlaw inverse transform with a Gaussian function"""
     n = 1001   # better with a larger number of points
     r_max = 501
 
-    ref = abel.tools.analyticalGaussianAnalytical(n, r_max, 
+    ref = abel.tools.analytical.GaussianAnalytical(n, r_max, 
           symmetric=False,  sigma=200)
     tr = np.tile(ref.abel[None, :], (n, 1)) # make a 2D array from 1D
 
     recon = abel.hansenlaw.hansenlaw_transform(tr, ref.dr, direction='inverse')
     recon1d = recon[n//2 + n%2]  # centre row
 
-    ratio = absolute_ratio_benchmark(ref, recon1d)
+    ratio = abel.benchmark.absolute_ratio_benchmark(ref, recon1d)
 
     assert_allclose(ratio, 1.0, rtol=1e-1, atol=0)
 
 
-def test_fabel_hansenlaw_curveA():
-    """ Check fabel_hansenlaw_transform() curve A
+def test_hansenlaw_forward_curveA():
+    """ Check hansenlaw forward transform with 'curve A'
     """
     delta = 0.01  # sample size
 
@@ -97,9 +95,8 @@ def test_fabel_hansenlaw_curveA():
     assert_allclose(proj, Aproj, rtol=0, atol=6.0e-2)
 
 
-
-def test_iabel_hansenlaw_transform_curveA():
-    """ Check iabel_hansenlaw_transform() curve A
+def test_hansenlaw_inverse_transform_curveA():
+    """ Check hansenlaw inverse transform() 'curve A'
     """
     delta = 0.001 # sample size, smaller the better inversion
 
@@ -118,13 +115,13 @@ def test_iabel_hansenlaw_transform_curveA():
     assert_allclose(orig, recon, rtol=0, atol=0.01)
 
 
-def test_hansenlaw_with_dribinski_image():
-    """ Check fabel_hansenlaw_transform() and iabel_hansenlaw_transform()
+def test_hansenlaw_forward_dribinski_image():
+    """ Check hansenlaw forward/inverse transform
         using BASEX sample image, comparing speed distributions
     """
 
     # BASEX sample image
-    IM = abel.tools.analytical.sample_image(n=361, name="dribinski")
+    IM = abel.tools.analytical.sample_image(n=1001, name="dribinski")
 
     # core transform(s) use top-right quadrant, Q0
     Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(IM)
@@ -147,3 +144,12 @@ def test_hansenlaw_with_dribinski_image():
     
 
     assert np.allclose(orig_speed[50:125], speed[50:125], rtol=0.5, atol=0)
+
+if __name__ == "__main__":
+    test_hansenlaw_shape()
+    test_hansenlaw_zeros()
+    test_hansenlaw_forward_tansform_gaussian()
+    test_hansenlaw_inverse_transform_gaussian()
+    test_hansenlaw_forward_curveA()
+    test_hansenlaw_inverse_transform_curveA()
+    test_hansenlaw_forward_dribinski_image()

--- a/abel/tests/test_three_point.py
+++ b/abel/tests/test_three_point.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import

--- a/abel/tests/test_three_point.py
+++ b/abel/tests/test_three_point.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
@@ -34,10 +35,14 @@ def test_three_point_step_ratio():
     ref = abel.tools.analytical.GaussianAnalytical(n, r_max, symmetric=True,  sigma=10)
     tr = np.tile(ref.abel[None, :], (n, 1)) # make a 2D array from 1D
 
-    recon = abel.three_point.three_point_transform(tr, 25, basis_dir=None, 
+    recon = abel.three_point.three_point(tr, 25, basis_dir=None, 
             direction='inverse',verbose=False)
     recon1d = recon[n//2 + n%2]
 
     ratio = absolute_ratio_benchmark(ref, recon1d)
 
     assert_allclose( ratio , 1.0, rtol=3e-2, atol=0)
+
+if __name__ == "__main__":
+    test_three_point_basis_sets_cache_asym()
+    test_three_point_step_ratio()

--- a/abel/tests/test_three_point.py
+++ b/abel/tests/test_three_point.py
@@ -8,8 +8,7 @@ import os.path
 
 import numpy as np
 from numpy.testing import assert_allclose
-from abel.three_point import iabel_three_point_transform, iabel_three_point, get_bs_three_point_cached
-from abel.tools.analytical import GaussianAnalytical
+import abel
 from abel.benchmark import absolute_ratio_benchmark
 
 DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
@@ -20,9 +19,9 @@ def test_three_point_basis_sets_cache_asym():
     if os.path.exists(file_name):
         os.remove(file_name)
     # 1st call generate and save
-    get_bs_three_point_cached(n, basis_dir=DATA_DIR, verbose=False)
+    abel.three_point.get_bs_three_point_cached(n, basis_dir=DATA_DIR, verbose=False)
     # 2nd call load from file
-    get_bs_three_point_cached(n, basis_dir=DATA_DIR, verbose=False)
+    abel.three_point.get_bs_three_point_cached(n, basis_dir=DATA_DIR, verbose=False)
     if os.path.exists(file_name):
         os.remove(file_name)
 
@@ -32,10 +31,11 @@ def test_three_point_step_ratio():
     n = 51
     r_max = 25
 
-    ref = GaussianAnalytical(n, r_max, symmetric=True,  sigma=10)
+    ref = abel.tools.analytical.GaussianAnalytical(n, r_max, symmetric=True,  sigma=10)
     tr = np.tile(ref.abel[None, :], (n, 1)) # make a 2D array from 1D
 
-    recon = iabel_three_point(tr, 25, basis_dir=None, verbose=False)
+    recon = abel.three_point.three_point_transform(tr, 25, basis_dir=None, 
+            direction='inverse',verbose=False)
     recon1d = recon[n//2 + n%2]
 
     ratio = absolute_ratio_benchmark(ref, recon1d)

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/abel/tests/test_tools_symmetry.py
+++ b/abel/tests/test_tools_symmetry.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -9,7 +9,8 @@ import numpy as np
 from itertools import product
 
 
-def iabel_three_point_transform(IM, basis_dir='.', verbose=False):
+def three_point_transform(IM, basis_dir='.', direction="inverse", 
+                          verbose=False):
     """
     Inverse Abel transformation using the algorithm of:
     Dasch, Applied Optics, Vol. 31, No. 8, 1146-1152 (1992).

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -147,12 +147,12 @@ def get_bs_three_point_cached(col, basis_dir='.', verbose=False):
     return D
 
 
-def iabel_three_point(data, center,
+def three_point(data, center,
                       dr=1.0, basis_dir='./', verbose=False,
                       direction='inverse'):
     """
     This function splits the image into two halves,
-    sends each half to iabel_three_point_transform(),
+    sends each half to three_point_transform(),
     stitches the output back together,
     and returns the full transform to the user.
 
@@ -210,8 +210,8 @@ def iabel_three_point(data, center,
     left_half = np.fliplr(left_half)
 
     # transform both halves
-    inv_left = iabel_three_point_transform(left_half, basis_dir, verbose)
-    inv_right = iabel_three_point_transform(right_half, basis_dir, verbose)
+    inv_left = three_point_transform(left_half, basis_dir, verbose)
+    inv_right = three_point_transform(right_half, basis_dir, verbose)
 
     # undo mirroring of left half
     inv_left = np.fliplr(inv_left)

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -12,7 +12,7 @@ from scipy.ndimage.interpolation import shift
 from scipy.optimize import curve_fit
 
 
-def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
+def angular_integration(IM, origin=None, Jacobian=False, dr=1, dt=None):
     """ Angular integration of the image.
 
         Returning the one-dimentional intensity profile as a function of the

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -237,23 +237,21 @@ def transform(
 
     def selected_transform(Z):
         if method == 'hansenlaw':
-            if direction == 'forward':
-                return abel.hansenlaw.fabel_hansenlaw(Z, **transform_options)
-            elif direction == 'inverse':
-                return abel.hansenlaw.iabel_hansenlaw(Z, **transform_options)
+            return abel.hansenlaw.hansenlaw_transform(Z, direction=direction,
+                                                      **transform_options)
 
         elif method == 'three_point':
             if direction == 'forward':
                 raise ValueError('Forward three-point not implemented')
             elif direction == 'inverse':
-                return abel.three_point.iabel_three_point_transform(
+                return abel.three_point.three_point_transform(
                   Z, **transform_options)
 
         elif method == 'basex':
             if direction == 'forward':
                 raise ValueError('Forward basex not implemented')
             elif direction == 'inverse':
-                return abel.basex.iabel_basex(Z, **transform_options)
+                return abel.basex.basex_transform(Z, **transform_options)
 
         elif method == 'direct':
             if direction == 'forward':

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -15,7 +15,7 @@ def transform(
     IM, direction='inverse', method='three_point', center='none',
         verbose=True, symmetry_axis=None,
         use_quadrants=(True, True, True, True),
-        transform_options={}, center_options={}):
+        transform_options=dict(), center_options=dict()):
     """
     transform() is the go-to function for all of your Abel transform needs!!
 
@@ -103,7 +103,7 @@ def transform(
 
         ::
 
-           Combine:  Q01 = Q1 + Q2, Q23 = Q2 + Q3
+           Combine:  Q01 = Q0 + Q2, Q23 = Q2 + Q3
            inverse image   AQ01 | AQ01
                            -----o-----
                            AQ23 | AQ23
@@ -243,26 +243,25 @@ def transform(
     Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(
                      IM, reorient=True, symmetry_axis=symmetry_axis)
 
+    def selected_transform(Z):
+        return abel_transform[method](Z, direction=direction, 
+                                      **transform_options)
+
     AQ0 = AQ1 = AQ2 = AQ3 = None
 
     # Inverse Abel transform for quadrant 1 (all include Q1)
-    AQ1 = abel_transform[method](Q1, direction=direction, **transform_options)
+    AQ1 = selected_transform(Q1)
 
     if 0 in symmetry_axis:
-        AQ2 = abel_transform[method](Q2, direction=direction, 
-                                     **transform_options)
+        AQ2 = selected_transform(Q2)
 
     if 1 in symmetry_axis:
-        AQ0 = abel_transform[method](Q0, direction=direction, 
-                                     **transform_options)
+        AQ0 = selected_transform(Q0)
 
     if None in symmetry_axis:
-        AQ0 = abel_transform[method](Q0, direction=direction, 
-                                     **transform_options)
-        AQ2 = abel_transform[method](Q2, direction=direction,
-                                     **transform_options)
-        AQ3 = abel_transform[method](Q3, direction=direction,
-                                     **transform_options)
+        AQ0 = selected_transform(Q0)
+        AQ2 = selected_transform(Q2)
+        AQ3 = selected_transform(Q3)
 
     # reassemble image
     results = {}

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -42,7 +42,7 @@ print ('image size {:d}x{:d}'.format(rows, cols))
 print('Performing Hansen and Law inverse Abel transform:')
 
 AIM = abel.transform(IM, method="hansenlaw", direction="inverse",
-                    vertical_symmetry=False, horizontal_symmetry=False)['transform']
+                     symmetry_axis=None)['transform']
 
 # PES - photoelectron speed distribution  -------------
 print('Calculating speed distribution:')

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -24,11 +24,11 @@ from time import time
 #   dictionary of method: function()
 
 transforms = {
-  "direct": abel.direct.iabel_direct,      
+  "direct": abel.direct.direct_transform,      
   #"onion": iabel_onion_transform, 
-  "hansenlaw": abel.hansenlaw.iabel_hansenlaw,
-  "basex": abel.basex.iabel_basex,   
-  "three_point": abel.three_point.iabel_three_point_transform,
+  "hansenlaw": abel.hansenlaw.hansenlaw_transform,
+  "basex": abel.basex.basex_transform,   
+  "three_point": abel.three_point.three_point_transform,
 }
 # sort dictionary 
 transforms = collections.OrderedDict(sorted(transforms.items()))
@@ -70,7 +70,8 @@ for q, method in enumerate(transforms.keys()):
     print ("\n------- {:s} inverse ...".format(method))  
     t0 = time()
 
-    IAQ0 = transforms[method](Q0)   # inverse Abel transform using 'method'
+    # inverse Abel transform using 'method'
+    IAQ0 = transforms[method](Q0, direction="inverse") 
 
     print ("                    {:.1f} sec".format(time()-t0))
 

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This example compares the available inverse Abel transform methods
+# for the Ominus sample image
+#
+# Note it transforms only the Q0 (top-right) quadrant
+# using the fundamental transform code
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import abel
+
+import collections
+import matplotlib.pylab as plt
+from time import time
+
+# inverse Abel transform methods -----------------------------
+#   dictionary of method: function()
+
+transforms = {
+  "direct": abel.direct.direct_transform,      
+  #"onion": iabel_onion_transform, 
+  "hansenlaw": abel.hansenlaw.hansenlaw_transform,
+  "basex": abel.basex.basex_transform,   
+  "three_point": abel.three_point.three_point_transform,
+}
+# sort dictionary 
+transforms = collections.OrderedDict(sorted(transforms.items()))
+ntrans = np.size(transforms.keys())  # number of transforms
+
+
+# Image:   O2- VMI 1024x1024 pixel ------------------
+IM = abel.tools.analytical.sample_image(n=1001, name="Ominus")
+
+h, w = IM.shape
+
+# forward transform
+fIM = abel.transform(IM, direction="forward", method="hansenlaw")['transform']
+
+Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(fIM, reorient=True)
+
+Q0fresh = Q0.copy()    # keep clean copy
+print ("quadrant shape {}".format(Q0.shape))
+
+# process Q0 quadrant using each method --------------------
+
+iabelQ = []  # keep inverse Abel transformed image
+
+for q, method in enumerate(transforms.keys()):
+
+    Q0 = Q0fresh.copy()   # top-right quadrant of O2- image
+
+    print ("\n------- {:s} inverse ...".format(method))  
+    t0 = time()
+
+    # inverse Abel transform using 'method'
+    IAQ0 = transforms[method](Q0, direction="inverse") 
+
+    print ("                    {:.1f} sec".format(time()-t0))
+
+    iabelQ.append(IAQ0)  # store for plot
+
+    # polar projection and speed profile
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0))
+
+    # normalize image intensity and speed distribution
+    IAQ0 /= IAQ0.max()  
+    speed /= speed[radial > 50].max()
+
+    # plots    #121 whole image,   #122 speed distributions
+    plt.subplot(121) 
+
+    # method label for each quadrant
+    annot_angle = -(45+q*90)*np.pi/180  # -ve because numpy coords from top
+    if q > 3: 
+        annot_angle += 50*np.pi/180    # shared quadrant - move the label  
+    annot_coord = (h/2+(h*0.9)*np.cos(annot_angle)/2, 
+                   w/2+(w*0.9)*np.sin(annot_angle)/2)
+    plt.annotate(method, annot_coord, color="yellow")
+
+    # plot speed distribution
+    plt.subplot(122) 
+    plt.plot(radial, speed, label=method)
+
+# reassemble image, each quadrant a different method
+
+# for < 4 images pad using a blank quadrant
+blank = np.zeros(IAQ0.shape)  
+for q in range(ntrans, 4):
+    iabelQ.append(blank)
+
+# more than 4, split quadrant
+if ntrans == 5:
+    # split last quadrant into 2 = upper and lower triangles
+    tmp_img = np.tril(np.flipud(iabelQ[-2])) +\
+              np.triu(np.flipud(iabelQ[-1]))
+    iabelQ[3] = np.flipud(tmp_img)
+# Fix me when > 5 images
+ 
+
+im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
+                                              iabelQ[2], iabelQ[3]), 
+                                              odd_size=True)
+
+plt.subplot(121)
+plt.imshow(im, vmin=0, vmax=0.8)
+
+plt.subplot(122)
+plt.title("Ominus sample image")
+plt.axis(ymin=-0.05, ymax=1.1, xmin=200, xmax=450)
+plt.legend(loc=0, labelspacing=0.1)
+plt.tight_layout()
+plt.savefig('example_all_Ominus.png', dpi=100)
+plt.show()

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -66,7 +66,7 @@ for q, method in enumerate(transforms.keys()):
     iabelQ.append(IAQ0)  # store for plot
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0))
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0), Jacobian=False)
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0.max()  

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This example compares the available inverse Abel transform methods
+# for the Ominus sample image
+#
+# Note it transforms only the Q0 (top-right) quadrant
+# using the fundamental transform code
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import abel
+
+import collections
+import matplotlib.pylab as plt
+from time import time
+
+# inverse Abel transform methods -----------------------------
+#   dictionary of method: function()
+
+transforms = {
+  "direct": abel.direct.direct_transform,      
+  #"onion": iabel_onion_transform, 
+  "hansenlaw": abel.hansenlaw.hansenlaw_transform,
+  "basex": abel.basex.basex_transform,   
+  "three_point": abel.three_point.three_point_transform,
+}
+# sort dictionary 
+transforms = collections.OrderedDict(sorted(transforms.items()))
+ntrans = np.size(transforms.keys())  # number of transforms
+
+
+# Image:   O2- VMI 1024x1024 pixel ------------------
+IM = abel.tools.analytical.sample_image(n=1001, name="dribinski")
+
+h, w = IM.shape
+
+# forward transform
+fIM = abel.transform(IM, direction="forward", method="hansenlaw")['transform']
+
+Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(fIM, reorient=True)
+
+Q0fresh = Q0.copy()    # keep clean copy
+print ("quadrant shape {}".format(Q0.shape))
+
+# process Q0 quadrant using each method --------------------
+
+iabelQ = []  # keep inverse Abel transformed image
+
+for q, method in enumerate(transforms.keys()):
+
+    Q0 = Q0fresh.copy()   # top-right quadrant of O2- image
+
+    print ("\n------- {:s} inverse ...".format(method))  
+    t0 = time()
+
+    # inverse Abel transform using 'method'
+    IAQ0 = transforms[method](Q0, direction="inverse") 
+
+    print ("                    {:.1f} sec".format(time()-t0))
+
+    iabelQ.append(IAQ0)  # store for plot
+
+    # polar projection and speed profile
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0))
+
+    # normalize image intensity and speed distribution
+    IAQ0 /= IAQ0.max()  
+    speed /= speed.max()
+
+    # plots    #121 whole image,   #122 speed distributions
+    plt.subplot(121) 
+
+    # method label for each quadrant
+    annot_angle = -(45+q*90)*np.pi/180  # -ve because numpy coords from top
+    if q > 3: 
+        annot_angle += 50*np.pi/180    # shared quadrant - move the label  
+    annot_coord = (h/2+(h*0.9)*np.cos(annot_angle)/2, 
+                   w/2+(w*0.9)*np.sin(annot_angle)/2)
+    plt.annotate(method, annot_coord, color="yellow")
+
+    # plot speed distribution
+    plt.subplot(122) 
+    plt.plot(radial, speed, label=method)
+
+# reassemble image, each quadrant a different method
+
+# for < 4 images pad using a blank quadrant
+blank = np.zeros(IAQ0.shape)  
+for q in range(ntrans, 4):
+    iabelQ.append(blank)
+
+# more than 4, split quadrant
+if ntrans == 5:
+    # split last quadrant into 2 = upper and lower triangles
+    tmp_img = np.tril(np.flipud(iabelQ[-2])) +\
+              np.triu(np.flipud(iabelQ[-1]))
+    iabelQ[3] = np.flipud(tmp_img)
+# Fix me when > 5 images
+ 
+
+im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
+                                              iabelQ[2], iabelQ[3]), 
+                                              odd_size=True)
+
+plt.subplot(121)
+plt.imshow(im, vmin=0, vmax=0.1)
+
+plt.subplot(122)
+plt.title("dribinski sample image")
+plt.axis(ymin=-0.05, ymax=0.5, xmin=0, xmax=200)
+plt.legend(loc=0, labelspacing=0.1)
+plt.tight_layout()
+plt.savefig('example_all_dribinski.png', dpi=100)
+plt.show()

--- a/examples/example_basex_gaussian.py
+++ b/examples/example_basex_gaussian.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import numpy as np
 import matplotlib.pyplot as plt
 import abel
@@ -23,7 +24,8 @@ center = n//2
 
 # BASEX Transform: 
 # Calculate the inverse abel transform for the centered data
-recon = abel.basex.iabel_basex(ref.abel, verbose=True, basis_dir=None, dr=ref.dr)
+recon = abel.basex.basex_transform(ref.abel, verbose=True, basis_dir=None, 
+        dr=ref.dr, direction='inverse')
 
 ax.plot(ref.r, recon , 'o',color='red', label='Inverse transform [BASEX]', ms=5, mec='none',alpha=0.5)
 

--- a/examples/example_basex_step.py
+++ b/examples/example_basex_step.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python
 import matplotlib.pyplot as plt
-from abel.basex import BASEX
-from abel.analytical import StepAnalytical
+from abel.basex import basex_transform
+from abel.tools.analytical import StepAnalytical
 
 # This example calculates the BASEX transform of a step function and 
 # compares with the analtical result.
@@ -23,8 +24,8 @@ ax.plot(st.r, st.abel*0.05, 'r', label='Direct Abel transform x0.05 [analytical]
 center = n//2
 # BASEX Transform: 
 # Calculate the inverse abel transform for the centered data
-recon = BASEX(st.abel, center, n=n, basis_dir='./', dr=st.dr,
-                                    verbose=True, calc_speeds=False)
+recon = basex_transform(st.abel, basis_dir='./', dr=st.dr,
+                                 verbose=True)
 
 
 plt.plot(st.r, recon , '--o',c='red', label='Inverse transform x10 [BASEX]')

--- a/examples/example_direct_gaussian.py
+++ b/examples/example_direct_gaussian.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
@@ -9,7 +10,7 @@ import matplotlib.pyplot as plt
 from time import time
 import sys
 
-from abel.direct import fabel_direct, iabel_direct
+from abel.direct import direct_transform
 from abel.tools.analytical import GaussianAnalytical
 
 
@@ -26,17 +27,27 @@ ax[1].set_title('Inverse transform of a Gaussian')
 
 ax[0].plot(ref.r, ref.abel, 'b', label='Analytical transform')
 
-recon = fabel_direct(ref.func, dr=ref.dr, correction=True, backend='C')
+recon = direct_transform(ref.func, dr=ref.dr, direction="forward",
+                        correction=True, backend='C')
+
 ax[0].plot(ref.r, recon , '--o',c='red', label='direct')
-recon = fabel_direct(ref.func, dr=ref.dr, correction=True, backend='Python')
+
+recon = direct_transform(ref.func, dr=ref.dr, direction="forward",
+                        correction=True, backend='Python')
+
 ax[0].plot(ref.r, recon , ':d', c='k', label='direct naive')
 
 
 ax[1].plot(ref.r, ref.func, 'b', label='Original function')
 
-recon = iabel_direct(ref.abel, dr=ref.dr, correction=True)
+recon = direct_transform(ref.abel, dr=ref.dr, direction="inverse",
+                         correction=True)
+
 ax[1].plot(ref.r, recon , '--o', c='red', label='direct')
-recon = iabel_direct(ref.abel, dr=ref.dr, correction=False)
+
+recon = direct_transform(ref.abel, dr=ref.dr, direction="inverse",
+                         correction=False)
+
 ax[1].plot(ref.r, recon , ':d', c='k', label='direct - naive')
 
 for axi in ax:

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -40,7 +40,7 @@ im = np.loadtxt(filename)
 (rows,cols) = np.shape(im)
 if cols%2 == 0:
     print ("Even pixel image cols={:d}, adjusting image centre\n",
-           " find_image_center_by_slice ()")
+           " find_image_center_by_slice ()".format(cols))
     im = abel.tools.center.find_image_center_by_slice (im, radial_range=(300,400))[0]
     # alternative
     #im = shift(im,(0.5,0.5))


### PR DESCRIPTION
#96 and #103 removed `f/iabel_<method>` wrapper functions from all methods (except onion).

Repaired all `f/iabel` calls in `abel.<method>.py`, `abel.transform.py`, including doc strings, all unit tests, and all examples (phew!). 

All core functions are now `abel.<method>.<method>_transform()` with `direction="inverse/forward"` to transform right-side 1/2 or 1/4 image, and `abel.transform(method="<method>")` transforms the whole image.

IFAICT all unit tests and all examples run without error. 

NB:
 @rth `test_direct.py` required a scaling factor to pass the unit test `test_inverse_direct_gaussian()`
@DhrubajyotiDas `example_basex_step.py`  the curves do not overlap

@DanHickstein, @ldes89150 please check the examples. I am not happy with Xe `hansenlaw` vs `basex`