### PR TITLE
recast images to float64 and keep sample_image constant zoom

### DIFF
--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -8,7 +8,7 @@ import scipy.constants as const
 # impementations.
 
 
-def sample_image(n=361, name="dribinski", sigma=2, temperature=200):
+def sample_image(n=361, name="dribinski", sigma=3, temperature=200):
     """
     Sample images, made up of Gaussian functions
 
@@ -64,7 +64,7 @@ def sample_image(n=361, name="dribinski", sigma=2, temperature=200):
         t9 = 20*gauss(r, 45, 3600)  # background under t3 to t5
         return 2000*(t0+t1+t2) + 200*(t3+t4+t5) + 50*(t6+t7+t8) + t9
 
-    def Ominus(r, theta, sigma, boltzmann, rfact):
+    def Ominus(r, theta, sigma, boltzmann, rfact=1):
         """
         Simulate the photoelectron spectrum of O- photodetachment
         3PJ <- 2P3/2,1/2
@@ -91,8 +91,14 @@ def sample_image(n=361, name="dribinski", sigma=2, temperature=200):
 
     n2 = n//2
 
-    # meshgrid @DanHickstein issue #67, updated #70
+    
     x = np.linspace(-n2, n2, n)
+    
+    if name=='dribinski': 
+        x = x * 180/n2
+    elif name=='Ominus':
+        x = x * 501/n2
+    
 
     X, Y = np.meshgrid(x, x)
     R, THETA = cart2polar(X, Y)
@@ -100,8 +106,7 @@ def sample_image(n=361, name="dribinski", sigma=2, temperature=200):
         IM = dribinski(R, THETA, sigma=sigma)
     elif name == "Ominus":
         boltzmann = 0.5*np.exp(-177.1*const.h*const.c*100/const.k/temperature)
-        rfact = n/1001.0
-        IM = Ominus(R, THETA, sigma=sigma, boltzmann=boltzmann, rfact=rfact)
+        IM = Ominus(R, THETA, sigma=sigma, boltzmann=boltzmann)
     else:
         raise ValueError('sample image name not recognized')
 

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -14,7 +14,7 @@ import warnings
 def transform(
     IM, direction='inverse', method='three_point', center='none',
         verbose=True, symmetry_axis=None,
-        use_quadrants=(True, True, True, True),
+        use_quadrants=(True, True, True, True), recast_as_float64=True,
         transform_options=dict(), center_options=dict()):
     """This is the main function of PyAbel, providing both forward
     and inverse abel transforms for full images. In addition,
@@ -84,6 +84,12 @@ def transform(
         Quadrants are numbered counter-clockwide from upper right.
         See note below for description of quadrants. 
         Default is ``(True, True, True, True)``, which uses all quadrants.
+        
+    recast_as_float64 : boolean
+        True/False that determines if the input image should be recast to float64. 
+        Many images are imported in other formats (such as ``uint8`` or ``unit15``)
+        and this does not always play well with the transorm algorithms. This should
+        probably always be set to True. (Default is True.)
 
     transform_options : tuple
         Additional arguments passed to the individual transform functions.
@@ -230,7 +236,9 @@ def transform(
     if not isinstance(symmetry_axis, (list, tuple)):
         # if the user supplies an int, make it into a 1-element list:
         symmetry_axis = [symmetry_axis]
-
+    
+    if recast_as_float64:
+        IM = IM.astype('float64')
     # centering:
     if center == 'none':  # no centering
         if cols % 2 != 1:

--- a/doc/abel.rst
+++ b/doc/abel.rst
@@ -19,7 +19,7 @@ abel.basex module
     :members:
     :undoc-members:
     :show-inheritance:
-
+	
 abel.benchmark module
 ---------------------
 

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -35,7 +35,7 @@ ntrans = np.size(transforms.keys())  # number of transforms
 
 
 # Image:   O2- VMI 1024x1024 pixel ------------------
-IM = abel.tools.analytical.sample_image(n=1001, name="Ominus")
+IM = abel.tools.analytical.sample_image(n=501, name="Ominus")
 
 h, w = IM.shape
 

--- a/examples/example_basex_photoelectron.py
+++ b/examples/example_basex_photoelectron.py
@@ -75,7 +75,7 @@ ax3.plot(*speeds)
 ax3.set_xlabel('Speed (pixel)')
 ax3.set_ylabel('Yield (log)')
 ax3.set_yscale('log')
-ax3.set_ylim(1e6,1e10)
+ax3.set_ylim(1e2,1e5)
 
 # Prettify the plot a little bit:
 plt.subplots_adjust(left=0.06,bottom=0.17,right=0.95,top=0.89,wspace=0.35,hspace=0.37)

--- a/examples/example_hansenlaw_Xe.py
+++ b/examples/example_hansenlaw_Xe.py
@@ -41,17 +41,17 @@ output_plot  = name + '_comparison_HansenLaw.pdf'
 # Step 1: Load an image file as a numpy array
 print('Loading ' + filename)
 #im = np.loadtxt(filename)
-im = plt.imread(filename)
+im = plt.imread(filename) 
 (rows,cols) = np.shape(im)
 print ('image size {:d}x{:d}'.format(rows,cols))
 
-#im = abel.tools.center.center_image (im, (340,245))
 
 # Step 2: perform the Hansen & Law transform!
 print('Performing Hansen and Law inverse Abel transform:')
 
 recon = abel.transform(im, method="hansenlaw", direction="inverse", 
-                       symmetry_axis=None, verbose=True)['transform']
+                       symmetry_axis=None, verbose=True, center=(240,340))['transform']
+                       
 r, speeds = abel.tools.vmi.angular_integration(recon)
 
 


### PR DESCRIPTION
This addresses issues https://github.com/PyAbel/PyAbel/issues/117 and https://github.com/PyAbel/PyAbel/issues/119. 

It adds an options (which defaults to True) in `abel.transform` to recast the input image to `float64` to avoid problems with overflowing numbers in common image datatypes like `unit16`. 

Also, this changes the behavior of the sample_image function to keep the sample images the same size and shape as `n`, the number of points, is varied. I think that this is the desired behavior, because it's nice to compare how the transforms work as the sampling is changed, and this is only really possible if the image is remaining the same and only the sampling interval is changing.

The reason that I was working on this is that I would like to change all of the examples to use smaller images so that they can run quickly and be included in the documentation. `n=1001` can take a few minutes for basex to build the basis set.  `n=301` runs quickly enough, and we should probably pick this as the standard for our examples.

@stggh or @DhrubajyotiDas, If you have time, can you make more of the examples run efficiently and then add them to the documentation by including a new `doc/example_<method>.rst` file and then appending the example name to the `doc/examples.rst` file?