### PR TITLE
Fix examples

### DIFF
--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -8,7 +8,7 @@ import scipy.constants as const
 # impementations.
 
 
-def sample_image(n=361, name="dribinski", sigma=3, temperature=200):
+def sample_image(n=361, name="dribinski", sigma=2, temperature=200):
     """
     Sample images, made up of Gaussian functions
 

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -121,11 +121,12 @@ def transform(
         
         1. symmetry_axis = 0 (vertical): ::
 
-            Combine:  Q01 = Q0 + Q2, Q23 = Q2 + Q3
-            inverse image   AQ01 | AQ01
-                            -----o----- (left and right equivalent)
-                            AQ23 | AQ23
-                        
+           Combine:  Q01 = Q0 + Q1, Q23 = Q2 + Q3
+           inverse image   AQ01 | AQ01
+                           -----o-----
+                           AQ23 | AQ23
+
+        (2) symmetry_axis = 1 (horizontal)
 
         2. symmetry_axis = 1 (horizontal): ::
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ environment:
     - PYTHON_VERSION: 3.4
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 3.4
-      PYTHON_ARCH: "64"
-      MINICONDA: C:\Miniconda3-x64
+      #- PYTHON_VERSION: 3.4
+      #- PYTHON_ARCH: "64"
+      #- MINICONDA: C:\Miniconda3-x64
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"

--- a/doc/example_all_dribinski.rst
+++ b/doc/example_all_dribinski.rst
@@ -1,0 +1,8 @@
+Example: All_Dribinski
+======================
+
+
+.. plot:: ../examples/example_all_dribinski.py
+   :include-source:
+
+	

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -12,3 +12,4 @@ Contents:
    example_hansenlaw_Xe
    example_basex_gaussian
    example_basex_photoelectron
+   example_all_dribinski

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -19,27 +19,28 @@ import collections
 import matplotlib.pylab as plt
 from time import time
 
+fig, (ax1,ax2) = plt.subplots(1, 2, figsize=(8,4))
+
 # inverse Abel transform methods -----------------------------
 #   dictionary of method: function()
 
 transforms = {
   "direct": abel.direct.direct_transform,      
-  #"onion": iabel_onion_transform, 
   "hansenlaw": abel.hansenlaw.hansenlaw_transform,
   "basex": abel.basex.basex_transform,   
   "three_point": abel.three_point.three_point_transform,
 }
-# sort dictionary 
+
+# sort dictionary:
 transforms = collections.OrderedDict(sorted(transforms.items()))
-ntrans = np.size(transforms.keys())  # number of transforms
-
-
-# Image:   O2- VMI 1024x1024 pixel ------------------
-IM = abel.tools.analytical.sample_image(n=1001, name="dribinski")
+# number of transforms:
+ntrans = np.size(transforms.keys())
+  
+IM = abel.tools.analytical.sample_image(n=301, name="dribinski")
 
 h, w = IM.shape
 
-# forward transform
+# forward transform:
 fIM = abel.transform(IM, direction="forward", method="hansenlaw")['transform']
 
 Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(fIM, reorient=True)
@@ -61,7 +62,7 @@ for q, method in enumerate(transforms.keys()):
     # inverse Abel transform using 'method'
     IAQ0 = transforms[method](Q0, direction="inverse") 
 
-    print ("                    {:.1f} sec".format(time()-t0))
+    print ("                    {:.4f} sec".format(time()-t0))
 
     iabelQ.append(IAQ0)  # store for plot
 
@@ -72,20 +73,16 @@ for q, method in enumerate(transforms.keys()):
     IAQ0 /= IAQ0.max()  
     speed /= speed.max()
 
-    # plots    #121 whole image,   #122 speed distributions
-    plt.subplot(121) 
-
     # method label for each quadrant
     annot_angle = -(45+q*90)*np.pi/180  # -ve because numpy coords from top
     if q > 3: 
         annot_angle += 50*np.pi/180    # shared quadrant - move the label  
-    annot_coord = (h/2+(h*0.9)*np.cos(annot_angle)/2, 
+    annot_coord = (h/2+(h*0.9)*np.cos(annot_angle)/2 -50, 
                    w/2+(w*0.9)*np.sin(annot_angle)/2)
-    plt.annotate(method, annot_coord, color="yellow")
+    ax1.annotate(method, annot_coord, color="yellow")
 
     # plot speed distribution
-    plt.subplot(122) 
-    plt.plot(radial, speed, label=method)
+    ax2.plot(radial, speed, label=method)
 
 # reassemble image, each quadrant a different method
 
@@ -100,20 +97,25 @@ if ntrans == 5:
     tmp_img = np.tril(np.flipud(iabelQ[-2])) +\
               np.triu(np.flipud(iabelQ[-1]))
     iabelQ[3] = np.flipud(tmp_img)
-# Fix me when > 5 images
  
-
 im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
                                               iabelQ[2], iabelQ[3]), 
                                               odd_size=True)
 
-plt.subplot(121)
-plt.imshow(im, vmin=0, vmax=0.1)
+ax1.imshow(im, vmin=0, vmax=0.15)
+ax1.set_title('Inverse Abel comparison')
 
-plt.subplot(122)
-plt.title("dribinski sample image")
-plt.axis(ymin=-0.05, ymax=0.5, xmin=0, xmax=200)
-plt.legend(loc=0, labelspacing=0.1)
+
+ax2.set_xlim(0, 200)
+ax2.set_ylim(-0.5,2)
+ax2.legend(loc=0, labelspacing=0.1, frameon=False)
+ax2.set_title('Angular integration')
+ax2.set_xlabel('Radial coordinate (pixel)')
+ax2.set_ylabel('Integrated intensity')
+
+
+plt.suptitle('Dribinski sample image')
+
 plt.tight_layout()
 plt.savefig('example_all_dribinski.png', dpi=100)
 plt.show()

--- a/examples/example_basex_gaussian.py
+++ b/examples/example_basex_gaussian.py
@@ -17,7 +17,6 @@ sigma = 10
 ref = abel.tools.analytical.GaussianAnalytical(n, r_max, sigma,symmetric=False)
 
 ax.plot(ref.r, ref.func, 'b', label='Original signal')
-
 ax.plot(ref.r, ref.abel*0.05, 'r', label='Direct Abel transform x0.05 [analytical]')
 
 center = n//2

--- a/examples/example_basex_step.py
+++ b/examples/example_basex_step.py
@@ -3,9 +3,9 @@ import matplotlib.pyplot as plt
 from abel.basex import basex_transform
 from abel.tools.analytical import StepAnalytical
 
-# This example calculates the BASEX transform of a step function and 
+# This example calculates the BASEX transform of a step function and
 # compares with the analtical result.
-fig, ax= plt.subplots(1,1)
+fig, ax = plt.subplots(1, 1)
 plt.title('Abel tranforms of a step function')
 
 n = 501
@@ -17,22 +17,30 @@ r2 = 14.0
 # define a symmetric step function and calculate its analytical Abel transform
 st = StepAnalytical(n, r_max, r1, r2, A0)
 
-ax.plot(st.r, st.func,'b', label='Original signal')
+ax.plot(st.r, st.func, 'b', label='Original signal')
 
-ax.plot(st.r, st.abel*0.05, 'r', label='Direct Abel transform x0.05 [analytical]')
+ax.plot(
+    st.r, st.abel*0.05, 'r',
+    label='Direct Abel transform x0.05 [analytical]')
 
 center = n//2
-# BASEX Transform: 
+right_half = st.abel[center:]
+left_half = st.abel[:center+1][::-1]
+# BASEX Transform:
 # Calculate the inverse abel transform for the centered data
-recon = basex_transform(st.abel, basis_dir='./', dr=st.dr,
-                                 verbose=True)
+recon_right = basex_transform(
+    right_half, basis_dir='./', dr=st.dr, verbose=True)
+recon_left = basex_transform(
+    left_half, basis_dir='./', dr=st.dr, verbose=False)
+plt.plot(
+    st.r[center:], recon_right, '--.', c='red',
+    label='Inverse transform [BASEX]')
 
-
-plt.plot(st.r, recon , '--o',c='red', label='Inverse transform x10 [BASEX]')
+plt.plot(st.r[:center+1], recon_left[::-1], '--.', c='red')
 
 ax.legend()
 
-ax.set_xlim(-20,20)
+ax.set_xlim(-20, 20)
 ax.set_ylim(-5, 20)
 ax.set_xlabel('x')
 ax.set_ylabel("f(x)")


### PR DESCRIPTION
This PR fixes the `basex` step example. 

![figure_1](https://cloud.githubusercontent.com/assets/6530840/13447057/69bfce50-dfe6-11e5-954f-644969dcffd0.png)

@DanHickstein Do you want me to reduce the `example_hansenlaw_basex.py` size to `n=301` in this PR as well?