### PR TITLE
Getting benchmark.py working again and migrating the wiki

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,6 +40,25 @@ Once you have that installed, then you can build the documentation using ::
 	 cd PyAbel/doc/
 	 make html
 
+Then you can open ``doc/_build/hmtl/index.html`` to look at the documentation. Sometimes you need to use ::
+
+	make clean
+	make html
+
+to clear out the old documentation and get things to re-build properly.
+
+When you get tired of typing ``make html`` every time you make a change to the documentation, it's nice to use use `sphix-autobuild <https://pypi.python.org/pypi/sphinx-autobuild>`_ to automatically update the documentation in your browser for you. So, install sphinx-autobuild using ::
+	
+	pip install sphinx-autobuild
+
+Now you should be able to ::
+	
+	cd PyAbel/doc/
+	make livehtml
+
+which should launch a browser window displaying the docs. When you save a change to any of the docs, the re-build should happen automatically and the docs should update in a matter of a few seconds. 
+
+Alternatively, `restview <https://pypi.python.org/pypi/restview>`_ is a nice way to preview the ``.rst`` files.
 
 Before merging
 --------------

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Output:
 
 Documentation
 -------------
-General information about the various Abel transforms available in PyAbel is available at the `PyAbel Wiki <https://github.com/PyAbel/PyAbel/wiki>`_. The complete documentation for all of the methods in PyAbel is hosted at https://pyabel.readthedocs.org.
+General information about the various Abel transforms available in PyAbel is available at the links above. The complete documentation for all of the methods in PyAbel is hosted at https://pyabel.readthedocs.org.
 
 
 Support
@@ -132,6 +132,8 @@ PyAble is licensed under the `MIT license <https://github.com/PyAbel/PyAbel/blob
 
 Citation
 --------
+First and foremost, please cite the paper(s) corresponding to the implementation of the Abel Transform that you use in your work. The references can be found at the links above.
+
 If you find PyAbel useful in you work, it would bring us great joy if you would cite the project. [DOI coming soon!]
 
 Have fun!

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -159,7 +159,7 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
     for the defintion of a center of the image.
     """
 
-    Q0, Q1, Q2, Q3 = get_image_quadrants(arr, reorient=False)
+    Q0, Q1, Q2, Q3 = abel.symmetry.get_image_quadrants(arr, reorient=False)
 
     if i_sym and not j_sym:
         valid_flag = [np.allclose(np.fliplr(Q1), Q0),
@@ -190,12 +190,12 @@ def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
         a reconstruction (i.e. inverse abel)
         given by some PyAbel implementation
     """
-    mask = analytical.mask_valid
+    mask = abel.analytical.mask_valid
 
     if kind == 'inverse':
-        func = analytical.func
+        func = abel.analytical.func
     elif kind == 'direct':
-        func = analytical.abel
+        func = abel.analytical.abel
 
     err = func[mask]/recon[mask]
     return err

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -8,9 +8,6 @@ from __future__ import unicode_literals
 import numpy as np
 
 
-# from abel.tools.symmetry import get_image_quadrants
-# from abel.tools.polar import CythonExtensionsNotBuilt
-
 import abel
 
 
@@ -159,7 +156,7 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
     for the defintion of a center of the image.
     """
 
-    Q0, Q1, Q2, Q3 = abel.symmetry.get_image_quadrants(arr, reorient=False)
+    Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(arr, reorient=False)
 
     if i_sym and not j_sym:
         valid_flag = [np.allclose(np.fliplr(Q1), Q0),
@@ -190,12 +187,12 @@ def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
         a reconstruction (i.e. inverse abel)
         given by some PyAbel implementation
     """
-    mask = abel.analytical.mask_valid
+    mask = analytical.mask_valid
 
     if kind == 'inverse':
-        func = abel.analytical.func
+        func = analytical.func
     elif kind == 'direct':
-        func = abel.analytical.abel
+        func = analytical.abel
 
     err = func[mask]/recon[mask]
     return err

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -200,7 +200,8 @@ def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
 
 def main():
     # run some benchmarks!!
-    print(AbelTiming(n=[51, 101, 501]) )
+    time = AbelTiming(n=[501]) 
+    print(time)
     
 
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -51,6 +51,9 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 
+livehtml:
+	sphinx-autobuild -b html --open-browser $(ALLSPHINXOPTS) $(BUILDDIR)/html
+
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ Contents:
    readme_link
    contributing_link
    abel
+   transform_methods
    examples
    
 

--- a/doc/transform_methods.rst
+++ b/doc/transform_methods.rst
@@ -12,3 +12,5 @@ Contents:
    transform_methods/direct
    transform_methods/hansenlaw
    transform_methods/three_point
+   transform_methods/onion_peeling
+   transform_methods/pop

--- a/doc/transform_methods.rst
+++ b/doc/transform_methods.rst
@@ -1,0 +1,9 @@
+Transform Methods
+=================
+
+Contents:
+
+.. toctree::
+   :maxdepth: 2
+
+   transform_methods/basex

--- a/doc/transform_methods.rst
+++ b/doc/transform_methods.rst
@@ -1,3 +1,4 @@
+.. _transform_methods:
 Transform Methods
 =================
 
@@ -5,5 +6,7 @@ Contents:
 
 .. toctree::
    :maxdepth: 2
-
+   
+   transform_methods/comparison
    transform_methods/basex
+   transform_methods/direct

--- a/doc/transform_methods.rst
+++ b/doc/transform_methods.rst
@@ -10,3 +10,5 @@ Contents:
    transform_methods/comparison
    transform_methods/basex
    transform_methods/direct
+   transform_methods/hansenlaw
+   transform_methods/three_point

--- a/doc/transform_methods/basex.rst
+++ b/doc/transform_methods/basex.rst
@@ -1,0 +1,47 @@
+BASEX
+=====
+
+
+Introduction
+------------
+
+BASEX (Basis set expansion method) transform utilizes well-behaved functions (i.e., functions which have a known analytic Abel inverse) to transform images. 
+In the current iteration of PyAbel, these functions (called basis functions) are modified Gaussian-type functions.
+This technique was developed by `Dribinski et al, 2002 (Rev. Sci. Instrum. 73, 2634) <http://dx.doi.org/10.1063/1.1482156>`_, (`pdf <http://www-bcf.usc.edu/~reisler/assets/pdf/67.pdf>`_).
+
+
+How it works
+------------
+
+This technique is based on expressing line-of-sight projection images (``raw_data``) as sums of functions which have known analytic Abel inverses. The provided raw images are expanded in a basis set composed of these basis functions with some weighting coefficients determined through a least-squares fitting process. 
+These weighting coefficients are then applied to the (known) analytic inverse of these basis functions, which directly provides the Abel inverse of the raw images. Thus, the transform can be completed using simple linear algebra. 
+
+In the current iteration of PyAbel, these basis functions are modified gaussians (see Eqs 14 and 15 in Dribinski et al. 2002). The process of evaluating these functions is computationally intensive, and the basis set generation process can take several seconds to minutes for larger images (larger than ~1000x1000 pixels). However, once calculated, these basis sets can be reused, and are therefore stored on disk and loaded quickly for future use. 
+The transform then proceeds very quickly, since each raw image inversion is a simple matrix multiplication step.
+
+
+When to use it
+--------------
+
+According to Dribinski et al. BASEX has several advantages:
+
+1. For synthesized noise-free projections, BASEX reconstructs an essentially exact and artifact-free image, eschewing the need for interpolation procedures, which may introduce additional errors or assumptions.
+
+2. BASEX is computationally cheap and only requires matrix multiplication once the basis sets have been generated and saved to disk.
+
+3. The current basis set is composed of the modified Gaussian functions which are highly localized, uniform in coverage, and sufficiently narrow. 
+This allows for resolution of very sharp features in the raw data with the basis functions. 
+Moreover, the reconstruction procedure does not contribute to noise in the reconstructed image; noise appears in the image only when it exists in the projection.
+
+4. Resolution of images reconstructed with BASEX are superior to those obtained with the Fourier-Hankel method, particularly for noisy projections. 
+However, to obtain maximum resolution, it is important to properly center the projections prior to transforming with BASEX.
+
+5. BASEX reconstructed images have an exact analytical expression, which allows for an analytical, higher resolution, calculation of the speed distribution, without increasing computation time.
+
+**Example**
+
+*Todo*
+
+**Notes**
+Good information about interpreting the equations in the paper and implementing the up/down asymmetric transform:
+https://github.com/PyAbel/PyAbel/pull/54#issuecomment-164898116

--- a/doc/transform_methods/basex.rst
+++ b/doc/transform_methods/basex.rst
@@ -42,7 +42,7 @@ The recommended way to complete the inverse Abel transform using the BASEX algor
 
 	abel.transform(myImage, method='basex', direction='inverse')
 
-Note that the forwrad BASEX transform is not yet implemented in PyAbel. 
+Note that the forward BASEX transform is not yet implemented in PyAbel. 
 
 If you would like to access the BASEX algorithm directly (to transform a right-side half-image), you can use :func:`abel.basex.basex_transform`.
 

--- a/doc/transform_methods/basex.rst
+++ b/doc/transform_methods/basex.rst
@@ -7,8 +7,7 @@ Introduction
 
 BASEX (Basis set expansion method) transform utilizes well-behaved functions (i.e., functions which have a known analytic Abel inverse) to transform images. 
 In the current iteration of PyAbel, these functions (called basis functions) are modified Gaussian-type functions.
-This technique was developed by `Dribinski et al, 2002 (Rev. Sci. Instrum. 73, 2634) <http://dx.doi.org/10.1063/1.1482156>`_, (`pdf <http://www-bcf.usc.edu/~reisler/assets/pdf/67.pdf>`_).
-
+This technique was developed by Dribinski et al [1].
 
 How it works
 ------------
@@ -29,19 +28,30 @@ According to Dribinski et al. BASEX has several advantages:
 
 2. BASEX is computationally cheap and only requires matrix multiplication once the basis sets have been generated and saved to disk.
 
-3. The current basis set is composed of the modified Gaussian functions which are highly localized, uniform in coverage, and sufficiently narrow. 
-This allows for resolution of very sharp features in the raw data with the basis functions. 
-Moreover, the reconstruction procedure does not contribute to noise in the reconstructed image; noise appears in the image only when it exists in the projection.
+3. The current basis set is composed of the modified Gaussian functions which are highly localized, uniform in coverage, and sufficiently narrow. This allows for resolution of very sharp features in the raw data with the basis functions. Moreover, the reconstruction procedure does not contribute to noise in the reconstructed image; noise appears in the image only when it exists in the projection.
 
-4. Resolution of images reconstructed with BASEX are superior to those obtained with the Fourier-Hankel method, particularly for noisy projections. 
-However, to obtain maximum resolution, it is important to properly center the projections prior to transforming with BASEX.
+4. Resolution of images reconstructed with BASEX are superior to those obtained with the Fourier-Hankel method, particularly for noisy projections. However, to obtain maximum resolution, it is important to properly center the projections prior to transforming with BASEX.
 
 5. BASEX reconstructed images have an exact analytical expression, which allows for an analytical, higher resolution, calculation of the speed distribution, without increasing computation time.
 
-**Example**
 
-*Todo*
+How to use it
+-------------
 
-**Notes**
-Good information about interpreting the equations in the paper and implementing the up/down asymmetric transform:
-https://github.com/PyAbel/PyAbel/pull/54#issuecomment-164898116
+The recommended way to complete the inverse Abel transform using the BASEX algorithm for a full image is to use the :func:`abel.transform` function: ::
+
+	abel.transform(myImage, method='basex', direction='inverse')
+
+Note that the forwrad BASEX transform is not yet implemented in PyAbel. 
+
+If you would like to access the BASEX algorithm directly (to transform a right-side half-image), you can use :func:`abel.basex.basex_transform`.
+
+
+Notes
+-----
+More information about interpreting the equations in the paper and implementing the up/down asymmetric transform is discussed in `PyAbel Issue #54 <https://github.com/PyAbel/PyAbel/pull/54#issuecomment-164898116>`_
+
+
+Citation
+--------
+[1] `Dribinski et al, 2002 (Rev. Sci. Instrum. 73, 2634) <http://dx.doi.org/10.1063/1.1482156>`_, (`pdf <http://www-bcf.usc.edu/~reisler/assets/pdf/67.pdf>`_)

--- a/doc/transform_methods/comparison.rst
+++ b/doc/transform_methods/comparison.rst
@@ -1,0 +1,12 @@
+Comparison of Abel Transform Methods
+====================================
+
+
+Introduction
+------------
+
+Each new Abel transform method claims to be the best, providing a lower-noise, more accurate transform. The point of PyAbel is to provide an easy platform to try several abel transform methods and determine which provides the best results for a specific dataset.
+
+So far, we have found that for a high-quality dataset, all of the transform methods produce good results.
+
+

--- a/doc/transform_methods/comparison.rst
+++ b/doc/transform_methods/comparison.rst
@@ -10,3 +10,12 @@ Each new Abel transform method claims to be the best, providing a lower-noise, m
 So far, we have found that for a high-quality dataset, all of the transform methods produce good results.
 
 
+Speed benchmarks
+----------------
+The :class:`abel.benchmark.AbelTiming` class provides the ability to benchmark the relative speed of the Abel transform algorithms.
+
+
+Transform quality
+-----------------
+
+...coming soon! ...

--- a/doc/transform_methods/direct.rst
+++ b/doc/transform_methods/direct.rst
@@ -1,0 +1,36 @@
+Direct
+=====
+
+
+Introduction
+------------
+
+This method attempts a direct integration of the Abel transform integral. It makes no assumptions about the data (apart from cylindrical symmetry), but it typically requires fine sampling to converge. Such methods are typically inefficient, but thanks to this Cython implementation (by Roman Yurchuk), this 'direct' method is competitive with the other methods.
+
+
+How it works
+------------
+
+Information about the algorithm and the numerical optimizations is contained in `PR #52 <https://github.com/PyAbel/PyAbel/pull/52>`_
+
+When to use it
+--------------
+
+When a robust forward transform is required, this method works quite well. It is not typically recommended for the inverse transform, but it can work well for smooth functions that are finely sampled.
+
+
+How to use it
+-------------
+
+To complete the forward or inverse transform of a full image with the direct method, simply use the :func:`abel.transform` function: ::
+
+	abel.transform(myImage, method='direct', direction='forward')
+	abel.transform(myImage, method='direct', direction='inverse')
+	
+
+If you would like to access the BASEX algorithm directly (to transform a right-side half-image), you can use :func:`abel.basex.direct_transform`.
+
+
+Citation
+--------
+[1] `Dribinski et al, 2002 (Rev. Sci. Instrum. 73, 2634) <http://dx.doi.org/10.1063/1.1482156>`_, (`pdf <http://www-bcf.usc.edu/~reisler/assets/pdf/67.pdf>`_)

--- a/doc/transform_methods/direct.rst
+++ b/doc/transform_methods/direct.rst
@@ -28,7 +28,7 @@ To complete the forward or inverse transform of a full image with the direct met
 	abel.transform(myImage, method='direct', direction='inverse')
 	
 
-If you would like to access the BASEX algorithm directly (to transform a right-side half-image), you can use :func:`abel.basex.direct_transform`.
+If you would like to access the Direct algorithm directly (to transform a right-side half-image), you can use :func:`abel.direct.direct_transform`.
 
 
 Citation

--- a/doc/transform_methods/hansenlaw.rst
+++ b/doc/transform_methods/hansenlaw.rst
@@ -1,0 +1,65 @@
+Hansen-Law
+==========
+
+Introduction
+------------
+
+The Hansen and Law transform is the work of E. W. Hansen and P.-L. Law [1].
+
+From the abstract:
+
+... new family of algorithms, principally for Abel inversion, that are recursive and hence computationally efficient. The methods are based on a linear, space-variant, state-variable model of the Abel transform. The model is the basis for deterministic algorithms, applicable when data are noise free, and least-squares estimation (Kalman filter) algorithms, which accommodate the noisy data case.
+
+The key advantage of the algorithm is its computational simplicity that amounts to only a few lines of code. 
+
+
+
+How it works
+------------
+
+.. image:: https://cloud.githubusercontent.com/assets/10932229/13250293/40a333c2-da7d-11e5-9647-d8404a12626a.png
+   :width: 650px
+   :alt: Path of integration
+
+The Hansen and Law method makes use of a coordinate transformation, which is used to model the Abel transform, and derive *reconstruction* filters. The Abel transform is treated as a system modeled by a set of linear differential equations. 
+
+.. image:: https://cloud.githubusercontent.com/assets/10932229/13251144/88f7a1d0-da82-11e5-8c09-7bf2dc4be830.png
+   :width: 550px
+   :alt: hansenlaw-iteration
+
+The algorithm iterates along each row of the image, starting at the out edge, and ending at the center.
+
+to be continued...
+
+
+When to use it
+--------------
+
+The Hansen-Law algorithm offers one of the fastest, most robust methods for both the forward and inverse transforms. It requires reasonably fine sampling of the data to provide exact agreement with the analytical result, but otherwise this method is a hidden gem of the field.
+
+
+How to use it
+-------------
+
+To complete the forward or inverse transform of a full image with the ``hansenlaw method``, simply use the :func:`abel.transform` function: ::
+
+	abel.transform(myImage, method='hansenlaw', direction='forward')
+	abel.transform(myImage, method='hansenlaw', direction='inverse')
+	
+
+If you would like to access the Hansen-Law algorithm directly (to transform a right-side half-image), you can use :func:`abel.hansenlaw.hansenlaw_transform`.
+
+
+Historical Note
+---------------
+
+The Hansen and Law algorithm was almost lost to the scientific community. It was rediscovered by Jason Gascooke (Flinders University, South Australia) for use in his velocity-map image analysis and written up in his PhD thesis: 
+
+J. R. Gascooke, PhD Thesis: *"Energy Transfer in Polyatomic-Rare Gas Collisions and Van Der Waals Molecule Dissociation"*, Flinders University (2000).
+Unfortunately, not available in electronic format.
+
+
+
+Citation
+--------
+[1] `E. W. Hansen and P.-L. Law, "Recursive methods for computing the Abel transform and its inverse", J. Opt. Soc. A2, 510-520 (1985) <http://dx.doi.org/10.1364/JOSAA.2.000510>`_

--- a/doc/transform_methods/onion_peeling.rst
+++ b/doc/transform_methods/onion_peeling.rst
@@ -1,0 +1,43 @@
+Onion Peeling
+=============
+
+
+
+Introduction
+------------
+
+The onion peeling method has been premiminarily ported to Python, but not yet incorporated into Pyabel.
+
+See the discussion here: https://github.com/PyAbel/PyAbel/issues/56
+
+How it works
+------------
+
+It doesn't really work yet.
+
+
+When to use it
+--------------
+
+Probably not until sombody finished it.
+
+
+How to use it
+-------------
+
+Don't
+
+
+Example
+-------
+
+Nope.
+
+
+
+
+Citation
+--------
+[1] http://scitation.aip.org/content/aip/journal/rsi/85/11/10.1063/1.4899267
+
+[2] https://github.com/PyAbel/PyAbel/issues/dx.doi.org/10.1063/1.1147044

--- a/doc/transform_methods/onion_peeling.rst
+++ b/doc/transform_methods/onion_peeling.rst
@@ -1,5 +1,5 @@
-Onion Peeling
-=============
+Onion Peeling (not implemented)
+===============================
 
 
 

--- a/doc/transform_methods/pop.rst
+++ b/doc/transform_methods/pop.rst
@@ -37,3 +37,5 @@ Put it here!
 Citation
 --------
 [1] http://dx.doi.org/10.1063/1.3126527
+
+[2] http://www.mathworks.com/matlabcentral/fileexchange/41064-polar-onion-peeling

--- a/doc/transform_methods/pop.rst
+++ b/doc/transform_methods/pop.rst
@@ -1,5 +1,5 @@
-Polar Onion Peeling
-===================
+Polar Onion Peeling (not implemented)
+=====================================
 
 
 Introduction

--- a/doc/transform_methods/pop.rst
+++ b/doc/transform_methods/pop.rst
@@ -1,0 +1,39 @@
+Polar Onion Peeling
+===================
+
+
+Introduction
+------------
+
+TThe polar onion peeling (POP) method is still under development.
+
+See the discussion here: https://github.com/PyAbel/PyAbel/issues/30
+
+
+How it works
+------------
+
+It doesn't exists in PyAbel!
+
+
+When to use it
+--------------
+
+When you implement it! :)
+
+
+How to use it
+-------------
+
+Code it!
+
+
+Example
+-------
+
+Put it here!
+
+
+Citation
+--------
+[1] http://dx.doi.org/10.1063/1.3126527

--- a/doc/transform_methods/three_point.rst
+++ b/doc/transform_methods/three_point.rst
@@ -11,10 +11,10 @@ The "Three Point" Abel transform method exploits the observation that the value 
 How it works
 ------------
 
-The projection data (raw data **P**) is expanded as a quadratic function of *r - r<sub>j</sub>* in the neighborhood of each data point in **P**. 
-In other words, *P'(r) = dP/dr* is estimated using a 3-point approximation (to the derivative), similar to central differencing.
-Doing so enables an analytical integration of the inverse Abel integral around each point *r<sub>j</sub>*. 
-The result of this integration is expressed as a linear operator **D**, operating on the projection data **P** to give the underlying radial distribution **F**.
+The projection data (raw data :math:`\mathbf{P}`) is expanded as a quadratic function of :math:`r - r_{j*}` in the neighborhood of each data point in :math:`\mathbf{P}`. 
+In other words, :math:`\mathbf{P}'(r) = dP/dr` is estimated using a 3-point approximation (to the derivative), similar to central differencing.
+Doing so enables an analytical integration of the inverse Abel integral around each point :math:`r_j`. 
+The result of this integration is expressed as a linear operator :math:`\mathbf{D}`, operating on the projection data :math:`\mathbf{P}` to give the underlying radial distribution :math:`\mathbf{F}`.
 
 
 
@@ -22,7 +22,7 @@ When to use it
 --------------
 
 Dasch recommends this method based on its speed of implementation, robustness in the presence of sharp edges, and low noise.
-He also notes that this technique works best for cases where the real difference between adjacent projections is much greater than the noise in the projections. This is important, because if the projections are oversampled (raw data **P** taken with data points very close to each other), the spacing between adjacent projections is decreased, and the real difference between them becomes comparable with the noise in the projections. In such situations, the deconvolution is highly inaccurate, and the projection data **P** must be smoothed before this technique is used.
+He also notes that this technique works best for cases where the real difference between adjacent projections is much greater than the noise in the projections. This is important, because if the projections are oversampled (raw data :math:`\mathbf{P}` taken with data points very close to each other), the spacing between adjacent projections is decreased, and the real difference between them becomes comparable with the noise in the projections. In such situations, the deconvolution is highly inaccurate, and the projection data :math:`\mathbf{P}` must be smoothed before this technique is used. (Consider smoothing with `scipy.ndimage.filters.gaussian_filter <http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.ndimage.filters.gaussian_filter.html>`_.)
 
 
 How to use it

--- a/doc/transform_methods/three_point.rst
+++ b/doc/transform_methods/three_point.rst
@@ -1,0 +1,63 @@
+Three Point
+===========
+
+
+
+Introduction
+------------
+
+The "Three Point" Abel transform method exploits the observation that the value of the Abel inverted data at any radial position ``r`` is primarily determined from changes in the projection data in the neighborhood of ``r``. This technique was developed by Dasch [1].
+
+How it works
+------------
+
+The projection data (raw data **P**) is expanded as a quadratic function of *r - r<sub>j</sub>* in the neighborhood of each data point in **P**. 
+In other words, *P'(r) = dP/dr* is estimated using a 3-point approximation (to the derivative), similar to central differencing.
+Doing so enables an analytical integration of the inverse Abel integral around each point *r<sub>j</sub>*. 
+The result of this integration is expressed as a linear operator **D**, operating on the projection data **P** to give the underlying radial distribution **F**.
+
+
+
+When to use it
+--------------
+
+Dasch recommends this method based on its speed of implementation, robustness in the presence of sharp edges, and low noise.
+He also notes that this technique works best for cases where the real difference between adjacent projections is much greater than the noise in the projections. This is important, because if the projections are oversampled (raw data **P** taken with data points very close to each other), the spacing between adjacent projections is decreased, and the real difference between them becomes comparable with the noise in the projections. In such situations, the deconvolution is highly inaccurate, and the projection data **P** must be smoothed before this technique is used.
+
+
+How to use it
+-------------
+
+To complete the inverse transform of a full image with the ``hansenlaw method``, simply use the :func:`abel.transform` function: ::
+
+	abel.transform(myImage, method='three_point', direction='inverse')
+	
+Note that the forward Three point transform is not yet implemented in PyAbel.
+
+If you would like to access the Three Point algorithm directly (to transform a right-side half-image), you can use :func:`abel.three_point.three_point_transform`.
+
+
+Example
+-------
+
+Note: this does not currently work:
+
+.. plot:: ../examples/example_three_point.py
+	:include-source:
+
+
+Notes
+-----
+
+The algorithm contained two typos in Eq (7) in the original citation [1]. A corrected form of these equations is presented in Karl Martin's 2002 PhD thesis [2]. PyAbel uses the corrected version of the algorithm.
+
+For more information on the PyAbel implementation of the three-point algorithm, please see `Issue #61 <https://github.com/PyAbel/PyAbel/issues/61>`_ and `Pull Request #64 <https://github.com/PyAbel/PyAbel/pull/64>`_.
+
+
+
+Citation
+--------
+[1] `Dasch, Applied Optics, Vol 31, No 8, March 1992, Pg 1146-1152 <(http://dx.doi.org/10.1364/AO.31.001146>`_.
+
+[2] Martin, Karl. PhD Thesis, University of Texas at Austin. Acoustic Modification of Sooting Combustion. 2002: https://www.lib.utexas.edu/etd/d/2002/martinkm07836/martinkm07836.pdf
+

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -15,6 +15,7 @@ import abel
 
 import scipy.misc
 from scipy.ndimage.interpolation import shift
+from scipy.ndimage import zoom
 
 # This example demonstrates both Hansen and Law inverse Abel transform
 # and basex for an image obtained using a velocity map imaging (VMI) 
@@ -37,6 +38,7 @@ output_plot  = name + '_comparison_HansenLaw.png'
 # Load an image file as a numpy array
 print('Loading ' + filename)
 im = np.loadtxt(filename)
+im = zoom(im, 0.5)
 (rows,cols) = np.shape(im)
 if cols%2 == 0:
     print ("Even pixel image cols={:d}, adjusting image centre\n",

--- a/examples/example_three_point.py
+++ b/examples/example_three_point.py
@@ -1,0 +1,34 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import abel 
+
+n = 101
+r_max = 4
+r = np.linspace(-1*r_max, r_max, n)
+dr = r[1]-r[0]
+
+fig, axes = plt.subplots(ncols = 2)
+fig.set_size_inches(8,4)
+
+axes[0].set_xlabel("Lateral position, x")
+axes[0].set_ylabel("F(x)")
+axes[0].set_title("Original LOS signal")
+axes[1].set_xlabel("Radial position, r")
+axes[1].set_ylabel("f(r)")
+axes[1].set_title("Inverted radial signal")
+
+Mat = np.sqrt(np.pi)*np.exp(-1*r*r)
+AnalyticAbelMat = np.exp(-1*r*r)
+DaschAbelMat = abel.three_point.three_point_transform(Mat)[0]
+
+axes[0].plot(r, Mat, 'r', label = r'$\sqrt{\pi}e^{-r^2}$')
+axes[0].legend()
+
+axes[1].plot(r, AnalyticAbelMat, 'k', lw = 1.5, alpha = 0.5, label = r'$e^{-r^2}$')
+axes[1].plot(r, DaschAbelMat, 'r--', lw = 1.5, label = '3-pt Abel')
+
+box = axes[1].get_position()
+axes[1].set_position([box.x0, box.y0, box.width * 0.8, box.height])
+axes[1].legend(loc='center left', bbox_to_anchor=(1, 0.5))
+fig.tight_layout()
+plt.show()


### PR DESCRIPTION
I am taking all of the descriptions of the transform methods out of the wiki and putting them into doc/transform_methods. I think that it looks really good as part of the documentation. 

Also, I made benchmark.py sort-of work again. It still needs some more work, and I'm done working on it for not. If @stggh or @DhrubajyotiDas want to take a look at it, that would be great. Currently, I think that it benchmarks the basis set generations as well as the transform methods 5 times each. This is probably too many times for the basis set generation, since this takes a long time anyway.