### PR TITLE
benchmark.py fixes

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -18,17 +18,14 @@ class AbelTiming(object):
 
         Parameters
         ----------
-          - n: a list of arrays sizes for the benchmark (assuming 2D
-            square arrays (n,n) )
-          - n_max_bs: since the basis sets generation takes a long time,
+        n: integer
+            a list of arrays sizes for the benchmark (assuming 2D square arrays (n,n))
+        n_max_bs: integer
+            since the basis sets generation takes a long time,
             do not run this benchmark for implementations that use basis sets
             for n > n_max_bs
         """
-        # from basex import get_bs_basex_cached, basex_core_transform
-        # from .hansenlaw import hansenlaw_transform
         from timeit import Timer
-        # from .direct import direct_transform, cython_ext
-        # from .three_point import three_point_transform
 
         self.n = n
 
@@ -66,6 +63,8 @@ class AbelTiming(object):
             else:
                 res_iabel['BASEX']['bs'].append(np.nan)
                 res_iabel['BASEX']['tr'].append(np.nan)
+                res_iabel['Three_point']['bs'].append(np.nan)
+                res_iabel['Three_point']['tr'].append(np.nan)
 
             res_fabel['HansenLaw']['tr'].append(
                 Timer(lambda: abel.hansenlaw.hansenlaw_transform(
@@ -73,25 +72,22 @@ class AbelTiming(object):
             res_iabel['HansenLaw']['tr'].append(
                 Timer(lambda: abel.hansenlaw.hansenlaw_transform(x,
                       x, direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
-            res_iabel['Three_point']['tr'].append(
-                Timer(lambda: abel.three_point.three_point_transform(
-                      x, direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
             res_iabel['direct_Python']['tr'].append(
                 Timer(lambda: abel.direct.direct_transform(
-                      x, correction=False, backend='Python',
+                      x, backend='Python',
                       direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
             res_fabel['direct_Python']['tr'].append(
                 Timer(lambda: abel.direct.direct_transform(
-                      x, correction=False, backend='Python',
+                      x, backend='Python',
                       direction='forward')).timeit(number=NREPEAT)/NREPEAT)
             if abel.direct.cython_ext:
                 res_iabel['direct_C']['tr'].append(
                     Timer(lambda: abel.direct.direct_transform(
-                        x, correction=False, backend='C',
+                        x, backend='C',
                         direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
                 res_fabel['direct_C']['tr'].append(
                     Timer(lambda: abel.direct.direct_transform(
-                        x, correction=False, backend='C',
+                        x, backend='C',
                         direction='forward')).timeit(number=NREPEAT)/NREPEAT)
 
         self.fabel = res_fabel
@@ -105,11 +101,11 @@ class AbelTiming(object):
         out += ['PyAbel benchmark run on {}\n'.format(platform.processor())]
 
         LABEL_FORMAT = '|'.join([' Implementation '] +
-                                ['    n = {:<12} '.
+                                ['    n = {:<8} '.
                                 format(ni) for ni in self.n])
-        TR_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:8.1e}            ']\
+        TR_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:.4f}          ']\
                                  * len(self.n))
-        BS_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:8.1e} ({:8.1e}) ']\
+        BS_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:.4f} ({:.4f}) ']\
                                  * len(self.n))
         SEP_ROW = ' ' + '-'*(22 + (17+1)*len(self.n))
 
@@ -206,7 +202,7 @@ def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
 
 def main():
     # run some benchmarks!!
-    time = AbelTiming()
+    time = AbelTiming(n=[201], n_max_bs=101)
     print(time)
 
 

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -202,7 +202,7 @@ def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
 
 def main():
     # run some benchmarks!!
-    time = AbelTiming(n=[201], n_max_bs=101)
+    time = AbelTiming()
     print(time)
 
 

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -12,7 +12,7 @@ import abel
 
 
 class AbelTiming(object):
-    def __init__(self, n=[201, 401], n_max_bs=700):
+    def __init__(self, n=[301, 501], n_max_bs=700):
         """
         Benchmark performance of different iAbel/fAbel implementations.
 
@@ -206,7 +206,7 @@ def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
 
 def main():
     # run some benchmarks!!
-    time = AbelTiming(n=[301, 501])
+    time = AbelTiming()
     print(time)
 
 

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -34,12 +34,12 @@ class AbelTiming(object):
 
         NREPEAT = 5
 
-        res_fabel = {}
-        res_iabel = {'BASEX':      {'bs': [], 'tr': []},
-                     'Three_point':{'bs': [], 'tr': []},
-                     'HansenLaw': {'tr': []}}
-        res_fabel['direct_Python'] = {'tr': []}
-        res_iabel['direct_Python'] = {'tr': []}
+        res_fabel = {'HansenLaw':     {'tr': []},
+                     'direct_Python': {'tr': []}}
+        res_iabel = {'BASEX':         {'bs': [], 'tr': []},
+                     'Three_point':   {'bs': [], 'tr': []},
+                     'HansenLaw':     {'tr': []},
+                     'direct_Python': {'tr': []}}
         if abel.direct.cython_ext:
             res_fabel['direct_C'] = {'tr': []}
             res_iabel['direct_C'] = {'tr': []}
@@ -53,41 +53,46 @@ class AbelTiming(object):
                     Timer(lambda: abel.basex.get_bs_basex_cached(ni, ni)).
                     timeit(number=1))
                 res_iabel['BASEX']['tr'].append(
-                    Timer(lambda: abel.basex.basex_core_transform(x, *bs)).timeit(
-                        number=NREPEAT)/NREPEAT)
+                    Timer(lambda: abel.basex.basex_core_transform(x, *bs)).
+                    timeit(number=NREPEAT)/NREPEAT)
                 res_iabel['Three_point']['bs'].append(
-                    Timer(lambda: abel.three_point.get_bs_three_point_cached( ni)).
-                    timeit(number=1))
-                res_iabel['Three_point']['tr'].append( # currently this is wrong because it also generated the basis sets!  
-                    Timer(lambda: abel.three_point.three_point_transform(x)).timeit(
-                        number=NREPEAT)/NREPEAT)
+                    Timer(lambda: abel.three_point.
+                          get_bs_three_point_cached(ni)).timeit(number=1))
+                res_iabel['Three_point']['tr'].append(
+                    # currently this is wrong because it also generated 
+                    # the basis sets!
+                    Timer(lambda: abel.three_point.three_point_transform(x)).
+                          timeit(number=NREPEAT)/NREPEAT)
             else:
                 res_iabel['BASEX']['bs'].append(np.nan)
                 res_iabel['BASEX']['tr'].append(np.nan)
 
+            res_fabel['HansenLaw']['tr'].append(
+                Timer(lambda: abel.hansenlaw.hansenlaw_transform(
+                      x, direction='forward')).timeit(number=NREPEAT)/NREPEAT)
             res_iabel['HansenLaw']['tr'].append(
-                Timer(lambda: abel.hansenlaw.hansenlaw_transform(x, direction='inverse')).timeit(
-                    number=NREPEAT)/NREPEAT)
+                Timer(lambda: abel.hansenlaw.hansenlaw_transform(x,
+                      x, direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
             res_iabel['Three_point']['tr'].append(
-                Timer(lambda: abel.three_point.three_point_transform(x, direction='inverse')).timeit(
-                    number=NREPEAT)/NREPEAT)
+                Timer(lambda: abel.three_point.three_point_transform(
+                      x, direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
             res_iabel['direct_Python']['tr'].append(
                 Timer(lambda: abel.direct.direct_transform(
-                    x, correction=False, backend='Python', direction='inverse')).timeit(
-                        number=NREPEAT)/NREPEAT)
+                      x, correction=False, backend='Python',
+                      direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
             res_fabel['direct_Python']['tr'].append(
                 Timer(lambda: abel.direct.direct_transform(
-                    x, correction=False, backend='Python', direction='forward')).timeit(
-                        number=NREPEAT)/NREPEAT)
+                      x, correction=False, backend='Python',
+                      direction='forward')).timeit(number=NREPEAT)/NREPEAT)
             if abel.direct.cython_ext:
                 res_iabel['direct_C']['tr'].append(
                     Timer(lambda: abel.direct.direct_transform(
-                        x, correction=False, backend='C', direction='inverse')).timeit(
-                            number=NREPEAT)/NREPEAT)
+                        x, correction=False, backend='C',
+                        direction='inverse')).timeit(number=NREPEAT)/NREPEAT)
                 res_fabel['direct_C']['tr'].append(
                     Timer(lambda: abel.direct.direct_transform(
-                        x, correction=False, backend='C', direction='forward')).timeit(
-                            number=NREPEAT)/NREPEAT)
+                        x, correction=False, backend='C',
+                        direction='forward')).timeit(number=NREPEAT)/NREPEAT)
 
         self.fabel = res_fabel
         self.iabel = res_iabel
@@ -102,15 +107,15 @@ class AbelTiming(object):
         LABEL_FORMAT = '|'.join([' Implementation '] +
                                 ['    n = {:<12} '.
                                 format(ni) for ni in self.n])
-        TR_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:8.1e} \
-                                ']*len(self.n))
-        BS_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:8.1e} \
-                                ({:8.1e}) ']*len(self.n))
+        TR_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:8.1e}            ']\
+                                 * len(self.n))
+        BS_ROW_FORMAT = '|'.join(['{:>15} '] + [' {:8.1e} ({:8.1e}) ']\
+                                 * len(self.n))
         SEP_ROW = ' ' + '-'*(22 + (17+1)*len(self.n))
 
         HEADER_ROW = ' ========= {:>10} Abel implementations ==========\n' \
-                     'time to solution [s] -> transform \
-                        (basis sets generation)\n'
+                     'time to solution [s] -> transform'\
+                     ' (basis sets generation)\n'
 
         def print_benchmark(name, res):
             out = [HEADER_ROW.format(name)]
@@ -156,7 +161,8 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
     for the defintion of a center of the image.
     """
 
-    Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(arr, reorient=False)
+    Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(
+                                                 arr, reorient=False)
 
     if i_sym and not j_sym:
         valid_flag = [np.allclose(np.fliplr(Q1), Q0),
@@ -196,15 +202,13 @@ def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
 
     err = func[mask]/recon[mask]
     return err
-    
+
 
 def main():
     # run some benchmarks!!
-    time = AbelTiming(n=[501]) 
+    time = AbelTiming(n=[301, 501])
     print(time)
-    
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     main()
-    


### PR DESCRIPTION
`abel.benchmark.py` update
- included `hansenlaw` forward transform,
- corrected print spacing for the output table
- corrected most pep8 warnings

```
python benchmark.py
PyAbel benchmark run on x86_64

 =========     Direct Abel implementations ==========
time to solution [s] -> transform (basis sets generation)

 Implementation |    n = 301          |    n = 501          
 ----------------------------------------------------------
  direct_Python |  5.1e-02            |  2.3e-01            
      HansenLaw |  2.1e-02            |  4.3e-02            
       direct_C |  1.6e-02            |  7.1e-02            

 =========    Inverse Abel implementations ==========
time to solution [s] -> transform (basis sets generation)

 Implementation |    n = 301          |    n = 501          
 ----------------------------------------------------------
          BASEX |  3.5e-02 ( 2.1e-03) |  2.5e-01 ( 4.7e-03) 
    Three_point |  2.8e-02 ( 4.3e-04) |  2.7e-02 ( 5.8e-04) 
       direct_C |  4.3e-02            |  2.0e-01            
      HansenLaw |  2.3e-02            |  4.7e-02            
  direct_Python |  7.6e-02            |  3.5e-01       
```