### PR TITLE
doc update for hansenlaw, vmi

### DIFF
--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -39,7 +39,7 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
     <http://dx.doi.org/10.1364/JOSAA.2.000510>`_ equation 2a: 
     
     
-    .. math:: f(r) = \frac{1}{\pi} \int_{r}^{\inf} \frac{g^\prime(R)}{\sqrt{R^2-r^2}} dR,
+    .. math:: f(r) = -\frac{1}{\pi} \int_{r}^{\inf} \frac{g^\prime(R)}{\sqrt{R^2-r^2}} dR,
     
     where 
 

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -39,7 +39,7 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
     <http://dx.doi.org/10.1364/JOSAA.2.000510>`_ equation 2a: 
     
     
-    .. math:: f(r) = -\frac{1}{\pi} \int_{r}^{\inf} \frac{g^\prime(R)}{\sqrt{R^2-r^2}} dR,
+    .. math:: f(r) = -\frac{1}{\pi} \int_{r}^{\infty} \frac{g^\prime(R)}{\sqrt{R^2-r^2}} dR,
     
     where 
 

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -21,12 +21,12 @@ def test_center_image():
     IMx = shift(IM, (-1,2))
 
     # find_center using 'slice' method
-    center = abel.tools.center.find_center(IMx, method="slice", axis=(0,1)) 
+    center = abel.tools.center.find_center(IMx, center="slice", axis=(0,1)) 
 
     assert np.allclose(center, (179, 182), rtol=0, atol=0.1)
 
     # find_center using 'com' method
-    center = abel.tools.center.find_center(IMx, method="com")
+    center = abel.tools.center.find_center(IMx, center="com")
    
     assert np.allclose(center, (179, 182), rtol=0, atol=0.4)
 

--- a/abel/tests/test_tools_symmetry.py
+++ b/abel/tests/test_tools_symmetry.py
@@ -9,16 +9,16 @@ from numpy.testing import assert_allclose
 
 import abel
 
-def test_symmetry_get_put_quadrants(verbose=False):
+def test_symmetry_get_put_quadrants(n=5, verbose=False):
     
-    z = np.zeros((5, 5))
-    z[0,0] = 1
-    z[-1,0] = 2
-    z[-1,-1] = 3
-    z[1, 1] = 1
-    z[1, -2] = 1
-    z[-2, 1] = 1
-    z[-2, -2]= 1
+    z = np.ones((n, n))*(-1)     # axes tagged with '-1'
+    c2 = n//2 
+    r2 = n//2 
+    # tag each quadrant with its number
+    z[:r2, -c2:] = 0
+    z[:r2, :c2] = 1
+    z[-r2:, :c2] = 2
+    z[-r2:, -c2:] = 3 
 
     if verbose:
         print("test image")
@@ -31,7 +31,7 @@ def test_symmetry_get_put_quadrants(verbose=False):
             print("\nreoriented quadrant Q{:d}".format(i))
             print(qi)
 
-    r = abel.tools.symmetry.put_image_quadrants(q, odd_size=True)
+    r = abel.tools.symmetry.put_image_quadrants(q, original_image_shape=(n,n))
 
     if verbose:
         print("\nreassembled image")
@@ -42,4 +42,4 @@ def test_symmetry_get_put_quadrants(verbose=False):
 
 
 if __name__ == "__main__":
-  test_symmetry_get_put_quadrants(verbose=True)
+  test_symmetry_get_put_quadrants(n=5, verbose=True)

--- a/abel/tests/test_tools_symmetry.py
+++ b/abel/tests/test_tools_symmetry.py
@@ -9,10 +9,11 @@ from numpy.testing import assert_allclose
 
 import abel
 
-def test_symmetry_get_put_quadrants(n=5, verbose=False):
+def test_symmetry_get_put_quadrants(image_shape=(5,5), verbose=False):
     
-    z = np.ones((n, n))*(-1)     # axes tagged with '-1'
-    c2 = n//2 
+    n, m = image_shape
+    z = np.ones((n, m))*(-1)     # odd-image axes tagged with '-1'
+    c2 = m//2 
     r2 = n//2 
     # tag each quadrant with its number
     z[:r2, -c2:] = 0
@@ -21,7 +22,9 @@ def test_symmetry_get_put_quadrants(n=5, verbose=False):
     z[-r2:, -c2:] = 3 
 
     if verbose:
-        print("test image")
+        print("test image of shape ", z.shape)
+        if n % 2 or m % 2:
+            print(" odd-size axes tagged with '-1'")
         print(z)
 
     q = abel.tools.symmetry.get_image_quadrants(z, reorient=True)
@@ -31,10 +34,10 @@ def test_symmetry_get_put_quadrants(n=5, verbose=False):
             print("\nreoriented quadrant Q{:d}".format(i))
             print(qi)
 
-    r = abel.tools.symmetry.put_image_quadrants(q, original_image_shape=(n,n))
+    r = abel.tools.symmetry.put_image_quadrants(q, original_image_shape=z.shape)
 
     if verbose:
-        print("\nreassembled image")
+        print("\nreassembled image, shape = ", r.shape)
         print(r)
 
 
@@ -42,4 +45,4 @@ def test_symmetry_get_put_quadrants(n=5, verbose=False):
 
 
 if __name__ == "__main__":
-  test_symmetry_get_put_quadrants(n=5, verbose=True)
+  test_symmetry_get_put_quadrants(image_shape=(4, 5), verbose=True)

--- a/abel/tests/test_tools_symmetry.py
+++ b/abel/tests/test_tools_symmetry.py
@@ -40,9 +40,18 @@ def test_symmetry_get_put_quadrants(image_shape=(5,5), verbose=False):
         print("\nreassembled image, shape = ", r.shape)
         print(r)
 
-
     assert not (z-r).any()
+
+"""
+    q = abel.tools.symmetry.get_image_quadrants(z, reorient=True, 
+            use_quadrants=(True, False, False, False), symmetry_axis=(0, 1)) 
+
+    if verbose:
+        for i, qi in enumerate(q):
+            print("\nreoriented quadrant Q{:d}".format(i))
+            print(qi)
+"""
 
 
 if __name__ == "__main__":
-  test_symmetry_get_put_quadrants(image_shape=(4, 5), verbose=True)
+  test_symmetry_get_put_quadrants(image_shape=(5, 5), verbose=True)

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -13,7 +13,9 @@ from scipy.optimize import minimize
 from six import string_types # testing stings with Python 2 and 3 compatibility
 
 def find_center(IM, center='image_center', verbose=False, **kwargs):
-    """
+    """Find the coordinates of image center, using the method 
+       specified by the `center` parameter.
+
     Parameters
     ----------
     IM : 2D np.array
@@ -105,9 +107,9 @@ def center_image(IM, center='com', odd_size=True, verbose=False, **kwargs):
 
     # center is in y,x (row column) format!
     if isinstance(center, string_types):
-        center = find_center(IM, center, verbose=verbose, **kwargs)
+        center = find_center(IM, center=center, verbose=verbose, **kwargs)
 
-    centered_data = set_center(IM, center, verbose=verbose, **kwargs)
+    centered_data = set_center(IM, center=center, verbose=verbose, **kwargs)
     return centered_data
 
 

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -12,14 +12,14 @@ from scipy.ndimage.interpolation import shift
 from scipy.optimize import minimize
 from six import string_types # testing stings with Python 2 and 3 compatibility
 
-def find_center(IM, method='image_center', verbose=False, **kwargs):
+def find_center(IM, center='image_center', verbose=False, **kwargs):
     """
     Parameters
     ----------
     IM : 2D np.array
       image data
 
-    method : str
+    center : str
         this determines how the center should be found. The options are:
         
         ``image_center``
@@ -39,7 +39,7 @@ def find_center(IM, method='image_center', verbose=False, **kwargs):
       coordinate of the center of the image in the (y,x) format (row, column)
 
     """
-    return func_method[method](IM, verbose=verbose, **kwargs)
+    return func_method[center](IM, verbose=verbose, **kwargs)
 
 
 def center_image(IM, center='com', odd_size=True, verbose=False, **kwargs):

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -199,13 +199,13 @@ def put_image_quadrants(Q, original_image_shape, symmetry_axis=None):
         Q2 = Q1
         Q3 = Q0
 
-    if original_image_shape[0] % 2 == 1:
-        # odd-rows => remove duplicate bottom row of Q1, Q0
+    if original_image_shape[0] % 2:
+        # odd-rows => remove duplicate bottom row from Q1, Q0
         Q0 = Q0[:-1, :]
         Q1 = Q1[:-1, :]
 
-    if original_image_shape[1] % 2 == 1:
-        # odd-columns => remove duplicate first column of Q1, Q2
+    if original_image_shape[1] % 2:
+        # odd-columns => remove duplicate first column from Q1, Q2
         Q1 = Q1[:, 1:]
         Q2 = Q2[:, 1:]
 

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -126,12 +126,15 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
                   (use_quadrants[0] + use_quadrants[1])
         Q2 = Q3 = (Q2*use_quadrants[2]+Q3*use_quadrants[3])/\
                   (use_quadrants[2] + use_quadrants[3])
+        # quadrants now all valid
+        use_quadrants = (True, True, True, True)
 
     if 1 in symmetry_axis:  # horizontal axis image symmetry
         Q1 = Q2 = (Q1*use_quadrants[1]+Q2*use_quadrants[2])/\
                   (use_quadrants[1] + use_quadrants[2])
         Q0 = Q3 = (Q0*use_quadrants[0]+Q3*use_quadrants[3])/\
                   (use_quadrants[0] + use_quadrants[3])
+
 
     return Q0, Q1, Q2, Q3
 
@@ -180,7 +183,7 @@ def put_image_quadrants(Q, odd_size=True, symmetry_axis=None):
              None             0              1           (0,1)
 
             Q1 | Q0        Q1 | Q1        Q1 | Q0       Q1 | Q1
-            ----o----  or  ----o----  or  ----o----  or ----o----
+           ----o----  or  ----o----  or  ----o----  or ----o----
             Q2 | Q3        Q2 | Q2        Q1 | Q0       Q1 | Q1
 
     """

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -109,7 +109,7 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
         (symmetry_axis == [1] and use_quadrants[0]==False and 
                                   use_quadrants[3]==False)    # right empty
                                                                 or
-        (symmetry_axis == (0, 1) and not np.all(use_quadrants))
+        (symmetry_axis == (0, 1) and not np.any(use_quadrants))
         ): 
         raise ValueError('At least one quadrant would be empty.'
                          ' Please check symmetry_axis and use_quadrant'

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -161,7 +161,12 @@ def put_image_quadrants(Q, original_image_shape, symmetry_axis=None):
 
     original_image_shape: tuple
        (rows, cols)
-       odd size will trim 1 row from Q1, Q0, and 1 column from Q1, Q2
+
+       reverses the padding added by `get_image_quadrants()` for odd-axis sizes
+
+       odd row trims 1 row from Q1, Q0
+
+       odd column trims 1 column from Q1, Q2
 
     symmetry_axis : int or tuple
        impose image symmetry

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -24,7 +24,7 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
     symmetry_axis : int or tuple
         can have values of ``None``, ``0``, ``1``, or ``(0,1)`` and specifies 
         no symmetry, vertical symmetry axis, horizontal symmetry axis, and both vertical
-        and horizontal symmetry axes. Quadrants are averaged.
+        and horizontal symmetry axes. Quadrants are added.
         See Note. 
 
     use_quadrants : boolean tuple
@@ -41,7 +41,7 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
     Notes
     -----
      
-    The symmetry_axis keyword averages quadrants like this: ::
+    The symmetry_axis keyword adds quadrants like this: ::
 
          +--------+--------+
          | Q1   * | *   Q0 |
@@ -50,13 +50,13 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
          +--------o--------+ --(output) -> ----o----
          |  *     |     *  |               cQ2 | cQ3
          |   *    |    *   |
-         | Q2  *  | *   Q3 |          cQi == averaged combined quadrants
+         | Q2  *  | *   Q3 |          cQi == combined quadrants
          +--------+--------+                 
 
         symmetry_axis = None - individual quadrants
-        symmetry_axis = 0 (vertical) - average Q0+Q1, and Q2+Q3
-        symmetry_axis = 1 (horizontal) - average Q1+Q2, and Q0+Q3
-        symmetry_axis = (0, 1) (both) - combine and average all 4 quadrants
+        symmetry_axis = 0 (vertical) - sum Q0+Q1, and Q2+Q3
+        symmetry_axis = 1 (horizontal) - sum Q1+Q2, and Q0+Q3
+        symmetry_axis = (0, 1) (both) - combine and sum all 4 quadrants
     
 
     The end results look like this: ::
@@ -103,10 +103,10 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
 
     # define 4 quadrants of the image
     # see definition above
-    Q0 = IM[:n_c, -m_c:]
-    Q1 = IM[:n_c, :m_c]
-    Q2 = IM[-n_c:, :m_c]
-    Q3 = IM[-n_c:, -m_c:]
+    Q0 = IM[:n_c, -m_c:]*use_quadrants[0]
+    Q1 = IM[:n_c, :m_c]*use_quadrants[1]
+    Q2 = IM[-n_c:, :m_c]*use_quadrants[2]
+    Q3 = IM[-n_c:, -m_c:]*use_quadrants[3]
 
     if reorient:
         Q1 = np.fliplr(Q1)
@@ -119,19 +119,12 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
             vertical symmetry), you must reorient the image.')
 
     if 0 in symmetry_axis:   #  vertical axis image symmetry
-        Q0 = Q1 = (Q0*use_quadrants[0]+Q1*use_quadrants[1])/\
-                  (use_quadrants[0] + use_quadrants[1])
-        Q2 = Q3 = (Q2*use_quadrants[2]+Q3*use_quadrants[3])/\
-                  (use_quadrants[2] + use_quadrants[3])
-        # quadrants now all valid
-        use_quadrants = (True, True, True, True)
+        Q0 = Q1 = Q0 + Q1
+        Q2 = Q3 = Q2 + Q3
 
-    if 1 in symmetry_axis:  # horizontal axis image symmetry
-        Q1 = Q2 = (Q1*use_quadrants[1]+Q2*use_quadrants[2])/\
-                  (use_quadrants[1] + use_quadrants[2])
-        Q0 = Q3 = (Q0*use_quadrants[0]+Q3*use_quadrants[3])/\
-                  (use_quadrants[0] + use_quadrants[3])
-
+    if 1 in symmetry_axis:   # horizontal axis image symmetry
+        Q1 = Q2 = Q1 + Q2
+        Q0 = Q3 = Q0 + Q3
 
     return Q0, Q1, Q2, Q3
 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -29,14 +29,15 @@ def angular_integration(IM, origin=None, Jacobian=False, dr=1, dt=None):
         defaults to ``rows//2+rows%2,cols//2+cols%2``.
 
     Jacobian : boolean
-        Include :math:`r\sin(\\theta)` in the angular sum (integration).
+        Include :math:`r\sin\\theta` in the angular sum (integration).
         Also, ``Jacobian=True`` is passed to 
         :func:`abel.tools.polar.reproject_image_into_polar`,
         which includes another value of ``r``, thus providing the appropriate 
-        total Jacobian of :math:`r^2\sin(\\theta)`.
+        total Jacobian of :math:`r^2\sin\\theta`.
 
     dr : float
-        Radial coordinate grid spacing, in pixels (default 1).
+        Radial coordinate grid spacing, in pixels (default 1). `dr=0.5` may 
+        reduce pixel granularity of the speed profile.
 
     dt : float
         Theta coordinate grid spacing in degrees. 
@@ -67,14 +68,16 @@ def angular_integration(IM, origin=None, Jacobian=False, dr=1, dt=None):
     return R[:n, 0], speeds   # limit radial coordinates range to match speed
 
 
-def calculate_angular_distributions(IM, radial_ranges=None):
-    """ Intensity variation in the angular coordinate, theta.
+def radial_integration(IM, radial_ranges=None):
+    """ Intensity variation in the angular coordinate.
 
-    This function is the theta-coordinate complement to 
+    This function is the :math:`\\theta`-coordinate complement to 
     :func:`abel.tools.vmi.angular_integration`
 
     (optionally and more useful) returning intensity vs angle for defined
-    radial ranges.
+    radial ranges, to evaluate the anisotropy parameter.
+
+    See :doc:`examples/example_O2_PES_PAD.py <examples>`
 
     Parameters
     ----------
@@ -82,6 +85,7 @@ def calculate_angular_distributions(IM, radial_ranges=None):
         Image data
 
     radial_ranges : list of tuples
+        integration ranges
         ``[(r0, r1), (r2, r3), ...]``
         Evaluate the intensity vs angle
         for the radial ranges ``r0_r1``, ``r2_r3``, etc.
@@ -116,11 +120,14 @@ def calculate_angular_distributions(IM, radial_ranges=None):
 
 def anisotropy_parameter(theta, intensity, theta_ranges=None):
     """ 
-    Evaluate anisotropy parameter beta, for I vs theta data.
+    Evaluate anisotropy parameter :math:`\\beta`, for :math:`I` vs :math:`\\theta` data.
 
-    ``I = xs_total/4pi [ 1 + beta P2(cos theta) ]     Eq. (1)``
+    .. math::
 
-    where ``P2(x)=(3x^2-1)/2`` is a 2nd order Legendre polynomial.
+        I = \\frac{\sigma_\\text{total}}{4\pi} [ 1 + \\beta P_2(\cos\\theta) ]   
+
+
+    where :math:`P_2(x)=\\frac{3x^2-1}{2}` is a 2nd order Legendre polynomial.
 
     `Cooper and Zare "Angular distribution of photoelectrons"
     J Chem Phys 48, 942-943 (1968) <http://dx.doi.org/10.1063/1.1668742>`_

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -253,8 +253,9 @@ def transform(
 
     #########################
 
-    verboseprint('Calculating {0} Abel transform using {1} method -'.format(
-      direction, method), 'image size: {:d}x{:d}'.format(rows, cols))
+    verboseprint('Calculating {0} Abel transform using {1} method -'\
+                 .format(direction, method), 
+                 '\n    image size: {:d}x{:d}'.format(rows, cols))
 
     t0 = time.time()
 

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -78,7 +78,7 @@ def transform(
     verbose : boolean
         True/False to determine if non-critical output should be printed.
 
-    symmetry_axis : int or tuple
+    symmetry_axis : None, int or tuple
         Symmetrize the image about the numpy axis 
         0 (vertical), 1 (horizontal), (0,1) (both axes)
         

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -102,7 +102,7 @@ def transform(
         Additional arguments to be passed to the centering function.
         
         
-    .. note:: Quadrant averaging 
+    .. note:: Quadrant combining 
          The quadrants can be combined (summed) using the 
          ``use_quadrants`` keyword in order to provide better data quality.
          

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -103,7 +103,7 @@ def transform(
         
         
     .. note:: Quadrant combining 
-         The quadrants can be combined (summed) using the 
+         The quadrants can be combined (averaged) using the 
          ``use_quadrants`` keyword in order to provide better data quality.
          
          The quadrants are numbered starting from

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -103,7 +103,7 @@ def transform(
         
         
     .. note:: Quadrant averaging 
-         The quadrants can be averaged using the 
+         The quadrants can be combined (summed) using the 
          ``use_quadrants`` keyword in order to provide better data quality.
          
          The quadrants are numbered starting from

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -126,8 +126,8 @@ def transform(
 
                 Combine:  Q01 = Q0 + Q1, Q23 = Q2 + Q3
                 inverse image   AQ01 | AQ01
-                               -----o-----
-                               AQ23 | AQ23
+                                -----o-----
+                                AQ23 | AQ23
 
 
         2) symmetry_axis = 1 (horizontal): ::

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -285,7 +285,7 @@ def transform(
     # reassemble image
     results = {}
     results['transform'] = abel.tools.symmetry.put_image_quadrants(
-                           (AQ0, AQ1, AQ2, AQ3), odd_size=cols % 2,
+                           (AQ0, AQ1, AQ2, AQ3), original_image_shape = IM.shape,
                             symmetry_axis=symmetry_axis)
 
     verboseprint("{:.2f} seconds".format(time.time()-t0))

--- a/doc/transform_methods/hansenlaw.rst
+++ b/doc/transform_methods/hansenlaw.rst
@@ -92,7 +92,7 @@ parameter constants, all listed in [1].
 
 
 The algorithm iterates along each individual row of the image, starting at 
-the out edge, ending at the center-line. Since all rows in a column can be 
+the out edge, ending at the center-line. Since all rows in an image can be 
 processed simultaneously, the operation can be easily vectorized and is 
 therefore numerically efficient.
 

--- a/doc/transform_methods/hansenlaw.rst
+++ b/doc/transform_methods/hansenlaw.rst
@@ -14,23 +14,26 @@ From the abstract:
 
 *... new family of algorithms, principally for Abel inversion, that are 
 recursive and hence computationally efficient. The methods are based on a 
-linear, space-variant, state-variable model of the Abel transform. The model 
+linear, space-variant, state-variable model of the Abel transform. The modl 
 is the basis for deterministic algorithms, applicable when data are noise free, 
 and least-squares estimation (Kalman filter) algorithms, which accommodate 
 the noisy data case.*
 
-The key advantage of the algorithm is its computational simplicity that amounts to only a few lines of code. 
+The key advantage of the algorithm is its computational simplicity that 
+amounts to only a few lines of code. 
 
 
 
 How it works
 ------------
 
-.. image:: https://cloud.githubusercontent.com/assets/10932229/13543157/c83d3796-e2bc-11e5-9210-12be6d24b8fc.png
+.. figure:: https://cloud.githubusercontent.com/assets/10932229/13543157/c83d3796-e2bc-11e5-9210-12be6d24b8fc.png
    :width: 200px
    :alt: projection diag
    :align: right
+   :figclass: align-center
 
+   Projection geometry (Fig. 1 [1])
 
 image function |nbsp|  :math:`f(r)`, |nbsp| projected function |nbsp|  :math:`g(R)`
 
@@ -51,6 +54,15 @@ equations. In this framework the forward Abel transform :math:`g(R)` is
 the solution of a differential equation with :math:`f(r)` as its driving 
 function.
 
+.. figure:: https://cloud.githubusercontent.com/assets/10932229/13544803/13bf0d0e-e2cf-11e5-97d5-bece1e61d904.png 
+   :width: 350px
+   :alt: recursion
+   :align: right
+   :figclass: align-center
+
+   Recursion inner-pixel generated from outer
+
+
 forward transform
 
 .. math:: 
@@ -67,38 +79,49 @@ inverse transform
 
   f_n &= \tilde{C} x_n
 
-Note the only difference between the *forward* and *inverse* algorithms is only
+
+Note the only difference between the *forward* and *inverse* algorithms is 
 the exchange of :math:`f_n` with :math:`g^\prime_n` (or :math:`g_n`).
+
 :math:`\Phi_n` and :math:`\Gamma_n` are functions with predetermined 
 parameter constants, all listed in [1].
 
+
 The algorithm iterates along each individual row of the image, starting at 
-the out edge, and ending at the center. This provides for efficient code 
+the out edge, ending at the center-line. This provides for efficient code 
 parallelization.
+
 
 
 When to use it
 --------------
 
-The Hansen-Law algorithm offers one of the fastest, most robust methods for both the forward and inverse transforms. It requires reasonably fine sampling of the data to provide exact agreement with the analytical result, but otherwise this method is a hidden gem of the field.
+The Hansen-Law algorithm offers one of the fastest, most robust methods for 
+both the forward and inverse transforms. It requires reasonably fine sampling 
+of the data to provide exact agreement with the analytical result, but otherwise
+this method is a hidden gem of the field.
 
 
 How to use it
 -------------
 
-To complete the forward or inverse transform of a full image with the ``hansenlaw method``, simply use the :func:`abel.transform` function: ::
+To complete the forward or inverse transform of a full image with the 
+``hansenlaw method``, simply use the :func:`abel.transform` function: ::
 
 	abel.transform(myImage, method='hansenlaw', direction='forward')
 	abel.transform(myImage, method='hansenlaw', direction='inverse')
 	
 
-If you would like to access the Hansen-Law algorithm directly (to transform a right-side half-image), you can use :func:`abel.hansenlaw.hansenlaw_transform`.
+If you would like to access the Hansen-Law algorithm directly (to transform a 
+right-side half-image), you can use :func:`abel.hansenlaw.hansenlaw_transform`.
 
 
 Historical Note
 ---------------
 
-The Hansen and Law algorithm was almost lost to the scientific community. It was rediscovered by Jason Gascooke (Flinders University, South Australia) for use in his velocity-map image analysis and written up in his PhD thesis: 
+The Hansen and Law algorithm was almost lost to the scientific community. It was 
+rediscovered by Jason Gascooke (Flinders University, South Australia) for use in 
+his velocity-map image analysis, and written up in his PhD thesis: 
 
 J. R. Gascooke, PhD Thesis: *"Energy Transfer in Polyatomic-Rare Gas Collisions and Van Der Waals Molecule Dissociation"*, Flinders University (2000).
 Unfortunately, not available in electronic format.

--- a/doc/transform_methods/hansenlaw.rst
+++ b/doc/transform_methods/hansenlaw.rst
@@ -92,8 +92,9 @@ parameter constants, all listed in [1].
 
 
 The algorithm iterates along each individual row of the image, starting at 
-the out edge, ending at the center-line. This provides for efficient code 
-parallelization.
+the out edge, ending at the center-line. Since all rows in a column can be 
+processed simultaneously, the operation can be easily vectorized and is 
+therefore numerically efficient.
 
 
 

--- a/doc/transform_methods/hansenlaw.rst
+++ b/doc/transform_methods/hansenlaw.rst
@@ -52,7 +52,8 @@ used to model the Abel transform, and derive *reconstruction* filters. The Abel
 transform is treated as a system modeled by a set of linear differential 
 equations. In this framework the forward Abel transform :math:`g(R)` is 
 the solution of a differential equation with :math:`f(r)` as its driving 
-function.
+function. Similarly, the Abel inversion :math:`f(r)` is a solution of a 
+differential equation with :math:`g^\prime(R)` as its driving function. 
 
 .. figure:: https://cloud.githubusercontent.com/assets/10932229/13544803/13bf0d0e-e2cf-11e5-97d5-bece1e61d904.png 
    :width: 350px
@@ -60,7 +61,7 @@ function.
    :align: right
    :figclass: align-center
 
-   Recursion inner-pixel generated from outer
+   Recursion: pixel value from adjacent outer-pixel
 
 
 forward transform
@@ -82,6 +83,9 @@ inverse transform
 
 Note the only difference between the *forward* and *inverse* algorithms is 
 the exchange of :math:`f_n` with :math:`g^\prime_n` (or :math:`g_n`).
+
+|
+|
 
 :math:`\Phi_n` and :math:`\Gamma_n` are functions with predetermined 
 parameter constants, all listed in [1].
@@ -114,6 +118,12 @@ To complete the forward or inverse transform of a full image with the
 
 If you would like to access the Hansen-Law algorithm directly (to transform a 
 right-side half-image), you can use :func:`abel.hansenlaw.hansenlaw_transform`.
+
+
+Example
+-------
+
+.. plot:: ../examples/example_O2_PES_PAD.py
 
 
 Historical Note

--- a/doc/transform_methods/hansenlaw.rst
+++ b/doc/transform_methods/hansenlaw.rst
@@ -1,3 +1,6 @@
+.. |nbsp| unicode:: 0xA0 
+   :trim:
+
 Hansen-Law
 ==========
 
@@ -9,7 +12,12 @@ The Hansen and Law transform is the work of E. W. Hansen and P.-L. Law [1].
 
 From the abstract:
 
-... new family of algorithms, principally for Abel inversion, that are recursive and hence computationally efficient. The methods are based on a linear, space-variant, state-variable model of the Abel transform. The model is the basis for deterministic algorithms, applicable when data are noise free, and least-squares estimation (Kalman filter) algorithms, which accommodate the noisy data case.
+*... new family of algorithms, principally for Abel inversion, that are 
+recursive and hence computationally efficient. The methods are based on a 
+linear, space-variant, state-variable model of the Abel transform. The model 
+is the basis for deterministic algorithms, applicable when data are noise free, 
+and least-squares estimation (Kalman filter) algorithms, which accommodate 
+the noisy data case.*
 
 The key advantage of the algorithm is its computational simplicity that amounts to only a few lines of code. 
 
@@ -18,19 +26,55 @@ The key advantage of the algorithm is its computational simplicity that amounts 
 How it works
 ------------
 
-.. image:: https://cloud.githubusercontent.com/assets/10932229/13250293/40a333c2-da7d-11e5-9647-d8404a12626a.png
-   :width: 650px
-   :alt: Path of integration
+.. image:: https://cloud.githubusercontent.com/assets/10932229/13543157/c83d3796-e2bc-11e5-9210-12be6d24b8fc.png
+   :width: 200px
+   :alt: projection diag
+   :align: right
 
-The Hansen and Law method makes use of a coordinate transformation, which is used to model the Abel transform, and derive *reconstruction* filters. The Abel transform is treated as a system modeled by a set of linear differential equations. 
 
-.. image:: https://cloud.githubusercontent.com/assets/10932229/13251144/88f7a1d0-da82-11e5-8c09-7bf2dc4be830.png
-   :width: 550px
-   :alt: hansenlaw-iteration
+image function |nbsp|  :math:`f(r)`, |nbsp| projected function |nbsp|  :math:`g(R)`
 
-The algorithm iterates along each row of the image, starting at the out edge, and ending at the center.
+forward Abel transform 
 
-to be continued...
+.. math:: g(R) = 2 \int_R^\infty \frac{f(r) r}{\sqrt{r^2 - R^2}} dr 
+
+inverse Abel transform 
+
+.. math:: f(r) = -\frac{1}{\pi}  \int_r^\infty \frac{g^\prime(R)}{\sqrt{R^2 - r^2}} dR
+
+
+
+The Hansen and Law method makes use of a coordinate transformation, which is 
+used to model the Abel transform, and derive *reconstruction* filters. The Abel
+transform is treated as a system modeled by a set of linear differential 
+equations. In this framework the forward Abel transform :math:`g(R)` is 
+the solution of a differential equation with :math:`f(r)` as its driving 
+function.
+
+forward transform
+
+.. math:: 
+
+  x_{n+1} &= \Phi_n x_n + \Gamma_n f_n 
+
+  g_n &= \tilde{C} x_n
+
+inverse transform
+
+.. math:: 
+
+  x_{n+1} &= \Phi_n x_n + \Gamma_n g^\prime_n 
+
+  f_n &= \tilde{C} x_n
+
+Note the only difference between the *forward* and *inverse* algorithms is only
+the exchange of :math:`f_n` with :math:`g^\prime_n` (or :math:`g_n`).
+:math:`\Phi_n` and :math:`\Gamma_n` are functions with predetermined 
+parameter constants, all listed in [1].
+
+The algorithm iterates along each individual row of the image, starting at 
+the out edge, and ending at the center. This provides for efficient code 
+parallelization.
 
 
 When to use it

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: iso-8859-1 -*-
 
 # Illustrative GUI driving a small subset of PyAbel methods

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -453,7 +453,7 @@ class PyAbel:  #(tk.Tk):
     
         # intensity vs angle
         self.intensity, self.theta = abel.tools.vmi.\
-                                     calculate_angular_distributions(self.AIM,\
+                                     radial_integration(self.AIM,\
                                      radial_ranges=[self.rmx,])
     
         # fit to P2(cos theta)

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -60,7 +60,7 @@ r_range = [(93, 111), (145, 162), (255, 280), (330, 350), (350, 370),
            (370, 390), (390, 410), (410, 430)]
 
 # map to intensity vs theta for each radial range
-intensities, theta = abel.tools.vmi.calculate_angular_distributions(AIM,
+intensities, theta = abel.tools.vmi.radial_integration(AIM,
                                                      radial_ranges=r_range)
 
 print("radial-range      anisotropy parameter (beta)")

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import division
 from __future__ import print_function
@@ -8,7 +7,6 @@ import numpy as np
 import abel
 
 import matplotlib.pylab as plt
-from scipy.ndimage.interpolation import shift
 
 # This example demonstrates Hansen and Law inverse Abel transform
 # of an image obtained using a velocity map imaging (VMI) photoelecton 
@@ -17,30 +15,22 @@ from scipy.ndimage.interpolation import shift
 # Measured at  The Australian National University
 # J. Chem. Phys. 133, 174311 (2010) DOI: 10.1063/1.3493349
 
-# image file
-filename = 'data/O2-ANU1024.txt.bz2' 
-# numpy handles .gz or plain .txt extensions
-
-# Load image as a numpy array
-print('Loading ' + filename)
-IM = np.loadtxt(filename)   
+# Load image as a numpy array - numpy handles .gz, .bz2 
+IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
 # use scipy.misc.imread(filename) to load image formats (.png, .jpg, etc)
 
 rows, cols = IM.shape    # image size
 
 # Image center should be mid-pixel, i.e. odd number of colums
 if cols % 2 != 1: 
-    print ("HL: even pixel width image, re-adjusting image centre")
-    IM = shift(IM, (-1/2, -1/2))[:-1, :-1]
+    print ("even pixel width image, make it odd and re-adjust image center")
+    IM = abel.tools.center.center_image(IM, center="slice")
     rows, cols = IM.shape   # new image size
 
 r2 = rows//2   # half-height image size
 c2 = cols//2   # half-width image size
-print ('image size {:d}x{:d}'.format(rows, cols))
 
 # Hansen & Law inverse Abel transform
-print('Performing Hansen and Law inverse Abel transform:')
-
 AIM = abel.transform(IM, method="hansenlaw", direction="inverse",
                      symmetry_axis=None)['transform']
 
@@ -61,7 +51,7 @@ r_range = [(93, 111), (145, 162), (255, 280), (330, 350), (350, 370),
 
 # map to intensity vs theta for each radial range
 intensities, theta = abel.tools.vmi.radial_integration(AIM,
-                                                     radial_ranges=r_range)
+                                    radial_ranges=r_range)
 
 print("radial-range      anisotropy parameter (beta)")
 for rr, intensity in zip(r_range, intensities):
@@ -84,12 +74,6 @@ JIM = np.concatenate((IM[:, :c2], AIM[:, c2:]), axis=1)
 rr = r_range[-3]
 intensity = intensities[-3]
 beta, amp = abel.tools.vmi.anisotropy_parameter(theta, intensity) 
-# draw a 1/2 circle representing this radial range
-# for rw in range(rows):
-#   for cl in range(c2,cols):
-#       circ = (rw-r2)**2 + (cl-c2)**2
-#       if circ >= rr[0]**2 and circ <= rr[1]**2:
-#           JIM[rw,cl] = vmax
 
 # Prettify the plot a little bit:
 # Plot the raw data
@@ -97,7 +81,8 @@ im1 = ax1.imshow(JIM, origin='lower', aspect='auto', vmin=0, vmax=vmax)
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
 ax1.set_ylabel('y (pixels)')
-ax1.set_title('velocity map image| inverse Abel             ')
+ax1.set_title('VMI, inverse Abel: {:d}x{:d}'\
+              .format(rows, cols))
 
 # Plot the 1D speed distribution
 ax2.plot(speed)
@@ -105,7 +90,7 @@ ax2.plot((rr[0], rr[0], rr[1], rr[1]), (1, 1.1, 1.1, 1), 'r-')  # red highlight
 ax2.axis(xmax=450, ymin=-0.05, ymax=1.2)
 ax2.set_xlabel('radial pixel')
 ax2.set_ylabel('intensity')
-ax2.set_title('Speed distribution')
+ax2.set_title('speed distribution')
 
 # Plot anisotropy variation
 ax3.plot(theta, intensity, 'r',
@@ -135,7 +120,7 @@ plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89,
                     wspace=0.35, hspace=0.37)
 
 # Save a image of the plot
-# plt.savefig(filename[:-7]+"png", dpi=150)
+plt.savefig("example_O2_PES_PAD.png", dpi=100)
 
 # Show the plots
 plt.show()

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This example compares the available inverse Abel transform methods
@@ -41,7 +40,7 @@ IM = np.loadtxt('data/O2-ANU1024.txt.bz2')
 
 # recenter the image to an odd size
 
-IModd = abel.tools.center.center_image(IM, center="com", odd_size=True)
+IModd = abel.tools.center.center_image(IM, center="slice", odd_size=True)
 # np.savetxt("O2-ANU1023.txt", IModd)
 
 h, w = IModd.shape

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -116,7 +116,7 @@ if ntrans == 5:
 
 im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
                                               iabelQ[2], iabelQ[3]), 
-                                              odd_size=True)
+                                              original_image_shape=IModd.shape)
 
 plt.subplot(121)
 plt.imshow(im, vmin=0, vmax=0.8)

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -39,7 +39,7 @@ IM = abel.tools.analytical.sample_image(n=501, name="Ominus")
 
 h, w = IM.shape
 
-# forward transform
+# forward transform (whole image)
 fIM = abel.transform(IM, direction="forward", method="hansenlaw")['transform']
 
 Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(fIM, reorient=True)
@@ -59,7 +59,7 @@ for q, method in enumerate(transforms.keys()):
     t0 = time()
 
     # inverse Abel transform using 'method'
-    IAQ0 = transforms[method](Q0, direction="inverse") 
+    IAQ0 = transforms[method](Q0, direction="inverse")
 
     print ("                    {:.1f} sec".format(time()-t0))
 
@@ -70,7 +70,7 @@ for q, method in enumerate(transforms.keys()):
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0.max()  
-    speed /= speed[radial > 50].max()
+    speed /= speed.max()
 
     # plots    #121 whole image,   #122 speed distributions
     plt.subplot(121) 
@@ -112,7 +112,7 @@ plt.imshow(im, vmin=0, vmax=0.8)
 
 plt.subplot(122)
 plt.title("Ominus sample image")
-plt.axis(ymin=-0.05, ymax=1.1, xmin=200, xmax=450)
+plt.axis(ymin=-0.05, ymax=1.1)
 plt.legend(loc=0, labelspacing=0.1)
 plt.tight_layout()
 plt.savefig('example_all_Ominus.png', dpi=100)

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -105,7 +105,7 @@ if ntrans == 5:
 
 im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
                                               iabelQ[2], iabelQ[3]), 
-                                              odd_size=True)
+                                              original_image_shape=IM.shape)
 
 plt.subplot(121)
 plt.imshow(im, vmin=0, vmax=0.8)

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This example compares the available inverse Abel transform methods

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # This example compares the available inverse Abel transform methods

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -100,7 +100,7 @@ if ntrans == 5:
  
 im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
                                               iabelQ[2], iabelQ[3]), 
-                                              odd_size=True)
+                                              original_image_shape=IM.shape)
 
 ax1.imshow(im, vmin=0, vmax=0.15)
 ax1.set_title('Inverse Abel comparison')

--- a/examples/example_basex_gaussian.py
+++ b/examples/example_basex_gaussian.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 import matplotlib.pyplot as plt
 import abel

--- a/examples/example_basex_photoelectron.py
+++ b/examples/example_basex_photoelectron.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import

--- a/examples/example_basex_step.py
+++ b/examples/example_basex_step.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import matplotlib.pyplot as plt
 from abel.basex import basex_transform
 from abel.tools.analytical import StepAnalytical

--- a/examples/example_direct_gaussian.py
+++ b/examples/example_direct_gaussian.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -79,7 +79,7 @@ plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89, wspace=0.35,
                     hspace=0.37)
 
 # Save a image of the plot
-plt.savefig(filename[:-7]+"png", dpi=150)
+plt.savefig(filename[5:-7]+"png", dpi=150)
 
 # Show the plots
 plt.show()

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -57,7 +57,7 @@ im1 = ax1.imshow(IM, origin='lower', aspect='auto')
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
 ax1.set_ylabel('y (pixels)')
-ax1.set_title('velocity map image')
+ax1.set_title('velocity map image: size {:d}x{:d}'.format(rows, cols))
 
 # Plot the 2D transform
 im2 = ax2.imshow(AIM, origin='lower', aspect='auto', vmin=0, 
@@ -70,9 +70,9 @@ ax2.set_title('Hansen Law inverse Abel')
 # Plot the 1D speed distribution
 ax3.plot(rs, speeds/speeds[200:].max())
 ax3.axis(xmax=500, ymin=-0.05, ymax=1.1)
-ax3.set_xlabel('Speed (pixel)')
-ax3.set_ylabel('Intensity')
-ax3.set_title('Speed distribution')
+ax3.set_xlabel('speed (pixel)')
+ax3.set_ylabel('intensity')
+ax3.set_title('speed distribution')
 
 # Prettify the plot a little bit:
 plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89, wspace=0.35,

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import division
 from __future__ import print_function
@@ -6,7 +5,6 @@ from __future__ import unicode_literals
 
 import numpy as np
 import abel
-import scipy.misc
 import matplotlib.pylab as plt
 
 # Hansen and Law inverse Abel transform of a velocity-map image 
@@ -15,36 +13,29 @@ import matplotlib.pylab as plt
 # ANU / The Australian National University
 # J. Chem. Phys. 133, 174311 (2010) DOI: 10.1063/1.3493349
 
-# image file in examples/data
-filename = 'data/O2-ANU1024.txt.bz2'
-
 # Load as a numpy array
-print('Loading ' + filename)
-IM = np.loadtxt(filename)   
+print("HL: loading 'data/O2-ANU1024.txt.bz2'")
+IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
 # use plt.imread(filename) to load image formats (.png, .jpg, etc)
 
 rows, cols = IM.shape    # image size
 
-# Image center should be mid-pixel, i.e. odd number of colums
+# Image center-line should be mid-pixel, i.e. odd number of columns
 if cols % 2 == 0: 
-    print ("HL: even pixel width image, re-adjust image centre")
-    # re-center image based on horizontal and vertical slice profiles
-    # covering the radial range [300:400] pixels from the center
-    IM = abel.tools.center.center_image(IM, center="com", odd_size=True)
+    print ("HL: even pixel width image, re-adjusting image centre\n"
+           "    using `slice` method, returning odd-width size image")
+    IM = abel.tools.center.center_image(IM, center="slice", odd_size=True)
     rows, cols = IM.shape   # new image size
 
-c2 = cols//2   # half-image
-print('image size {:d}x{:d}'.format(rows, cols))
-
-# Step 2: perform the Hansen & Law transform!
-print('Performing Hansen and Law inverse Abel transform:')
-
+# dr=0.5 may help reduce pixel grid coarseness
+# NB remember to pass to angular_integration
 AIM = abel.transform(IM, method='hansenlaw',
                      use_quadrants=(True, True, True, True),
                      symmetry_axis=None,
+                     transform_options=dict(dr=0.5),
                      verbose=True)['transform']
 
-rs, speeds  = abel.tools.vmi.angular_integration(AIM, dr=1)
+rs, speeds  = abel.tools.vmi.angular_integration(AIM, dr=0.5)
 
 # Set up some axes
 fig = plt.figure(figsize=(15, 4))
@@ -52,22 +43,22 @@ ax1 = plt.subplot(131)
 ax2 = plt.subplot(132)
 ax3 = plt.subplot(133)
 
-# Plot the raw data
-im1 = ax1.imshow(IM, origin='lower', aspect='auto')
+# raw image
+im1 = ax1.imshow(IM, aspect='auto')
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
 ax1.set_ylabel('y (pixels)')
 ax1.set_title('velocity map image: size {:d}x{:d}'.format(rows, cols))
 
-# Plot the 2D transform
-im2 = ax2.imshow(AIM, origin='lower', aspect='auto', vmin=0, 
-                 vmax=AIM[:c2-50, :c2-50].max())
+# 2D transform
+c2 = cols//2   # half-image width
+im2 = ax2.imshow(AIM, aspect='auto', vmin=0, vmax=AIM[:c2-50, :c2-50].max())
 fig.colorbar(im2, ax=ax2, fraction=.1, shrink=0.9, pad=0.03)
 ax2.set_xlabel('x (pixels)')
 ax2.set_ylabel('y (pixels)')
 ax2.set_title('Hansen Law inverse Abel')
 
-# Plot the 1D speed distribution
+# 1D speed distribution
 ax3.plot(rs, speeds/speeds[200:].max())
 ax3.axis(xmax=500, ymin=-0.05, ymax=1.1)
 ax3.set_xlabel('speed (pixel)')
@@ -78,8 +69,7 @@ ax3.set_title('speed distribution')
 plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89, wspace=0.35,
                     hspace=0.37)
 
-# Save a image of the plot
-plt.savefig(filename[5:-7]+"png", dpi=150)
+# save an image of the plot
+plt.savefig("example_hansenlaw.png", dpi=100)
 
-# Show the plots
 plt.show()

--- a/examples/example_hansenlaw_Xe.py
+++ b/examples/example_hansenlaw_Xe.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
@@ -20,16 +19,6 @@ import scipy.misc
 # ANU / The Australian National University
 # J. Chem. Phys. 133, 174311 (2010) DOI: 10.1063/1.3493349
 
-# Before you start, centre of the NxN numpy array should be the centre
-#  of image symmetry
-#   +----+----+
-#   |    |    |
-#   +----o----+
-#   |    |    |
-#   + ---+----+
-
-# Specify the path to the file
-#filename = 'data/O2-ANU1024.txt.bz2'
 filename = 'data/Xenon_ATI_VMI_800_nm_649x519.tif'
 
 # Name the output files
@@ -38,7 +27,6 @@ output_image = name + '_inverse_Abel_transform_HansenLaw.png'
 output_text  = name + '_speeds_HansenLaw.dat'
 output_plot  = name + '_comparison_HansenLaw.pdf'
 
-# Step 1: Load an image file as a numpy array
 print('Loading ' + filename)
 #im = np.loadtxt(filename)
 im = plt.imread(filename) 
@@ -50,18 +38,10 @@ print ('image size {:d}x{:d}'.format(rows,cols))
 print('Performing Hansen and Law inverse Abel transform:')
 
 recon = abel.transform(im, method="hansenlaw", direction="inverse", 
-                       symmetry_axis=None, verbose=True, center=(240,340))['transform']
+                       symmetry_axis=None, verbose=True, 
+                       center=(240,340))['transform']
                        
 r, speeds = abel.tools.vmi.angular_integration(recon)
-
-
-# save the transform in 8-bit format:
-#scipy.misc.imsave(output_image,recon)
-
-# save the speed distribution
-#np.savetxt(output_text,speeds)
-
-## Finally, let's plot the data
 
 # Set up some axes
 fig = plt.figure(figsize=(15,4))
@@ -69,21 +49,21 @@ ax1 = plt.subplot(131)
 ax2 = plt.subplot(132)
 ax3 = plt.subplot(133)
 
-# Plot the raw data
+# raw data
 im1 = ax1.imshow(im, origin='lower', aspect='auto')
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
 ax1.set_ylabel('y (pixels)')
 ax1.set_title('velocity map image')
 
-# Plot the 2D transform
+# 2D transform
 im2 = ax2.imshow(recon, origin='lower', aspect='auto')
 fig.colorbar(im2, ax=ax2, fraction=.1, shrink=0.9, pad=0.03)
 ax2.set_xlabel('x (pixels)')
 ax2.set_ylabel('y (pixels)')
 ax2.set_title('Hansen Law inverse Abel')
 
-# Plot the 1D speed distribution
+# 1D speed distribution
 ax3.plot(speeds)
 ax3.set_xlabel('Speed (pixel)')
 ax3.set_ylabel('Yield (log)')
@@ -95,7 +75,7 @@ plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89, wspace=0.35,
                     hspace=0.37)
 
 # Save a image of the plot
-plt.savefig(output_plot, dpi=150)
+plt.savefig(output_plot, dpi=100)
 
 # Show the plots
 plt.show()

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
@@ -24,6 +23,8 @@ from scipy.ndimage import zoom
 # This spectrum was recorded in 2010  
 # ANU / The Australian National University
 # J. Chem. Phys. 133, 174311 (2010) DOI: 10.1063/1.3493349
+#
+# Note the image zoomed to reduce calculation time
 
 # Specify the path to the file
 filename = os.path.join('data', 'O2-ANU1024.txt.bz2')
@@ -44,7 +45,7 @@ im = zoom(im, 0.4892578125)
 if cols%2 == 0:
     print ("Even pixel image cols={:d}, adjusting image centre\n",
            " center_image()".format(cols))
-    im = abel.tools.center.center_image(im, center="com", odd_size=True)
+    im = abel.tools.center.center_image(im, center="slice", odd_size=True)
     # alternative
     #im = shift(im,(0.5,0.5))
     #im = im[:-1, 1::]  # drop left col, bottom row

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -38,8 +38,9 @@ output_plot  = name + '_comparison_HansenLaw.png'
 # Load an image file as a numpy array
 print('Loading ' + filename)
 im = np.loadtxt(filename)
+print("scaling image x1/2 to reduce the time of the basis set calculation")
 im = zoom(im, 0.5)
-(rows,cols) = np.shape(im)
+(rows, cols) = np.shape(im)
 if cols%2 == 0:
     print ("Even pixel image cols={:d}, adjusting image centre\n",
            " center_image()".format(cols))
@@ -79,7 +80,7 @@ im1 = ax1.imshow(im, origin='lower', aspect='auto')
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
 ax1.set_ylabel('y (pixels)')
-ax1.set_title('velocity map image')
+ax1.set_title('velocity map image: size {:d}x{:d}'.format(rows, cols))
 
 # Plot the 2D transform
 reconH2 = reconH[:,:c2]
@@ -93,12 +94,12 @@ ax2.set_ylabel('y (pixels)')
 ax2.set_title('Hansen Law | Basex',x=0.4)
 
 # Plot the 1D speed distribution - normalized
-ax3.plot(rB, speedsB/speedsB[350:].max(), 'r-', label="Basex")
-ax3.plot(rH, speedsH/speedsH[350:].max(), 'b-', label="Hansen Law")
-ax3.axis(xmax=c2-12, ymin=-0.1, ymax=1.5)
-ax3.set_xlabel('Speed (pixel)')
-ax3.set_ylabel('Intensity')
-ax3.set_title('Speed distribution')
+ax3.plot(rB, speedsB/speedsB[150:].max(), 'r-', label="Basex")
+ax3.plot(rH, speedsH/speedsH[150:].max(), 'b-', label="Hansen Law")
+ax3.axis(xmax=250, ymin=-0.1, ymax=1.5)
+ax3.set_xlabel('speed (pixel)')
+ax3.set_ylabel('intensity')
+ax3.set_title('speed distribution')
 ax3.legend(labelspacing=0.1, fontsize='small')
 
 # Prettify the plot a little bit:

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -38,8 +38,8 @@ output_plot  = name + '_comparison_HansenLaw.png'
 # Load an image file as a numpy array
 print('Loading ' + filename)
 im = np.loadtxt(filename)
-print("scaling image x1/2 to reduce the time of the basis set calculation")
-im = zoom(im, 0.5)
+print("scaling image to size 501 reduce the time of the basis set calculation")
+im = zoom(im, 0.4892578125)
 (rows, cols) = np.shape(im)
 if cols%2 == 0:
     print ("Even pixel image cols={:d}, adjusting image centre\n",

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Illustrative GUI driving a small subset of PyAbel methods
 
 # tkinter code adapted from

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -158,7 +158,7 @@ def _anisotropy():
     _transform()
 
     # intensity vs angle
-    intensity, theta = abel.tools.vmi.calculate_angular_distributions(AIM,\
+    intensity, theta = abel.tools.vmi.radial_integration(AIM,\
                                                   radial_ranges=[rmx,])
 
     # fit to P2(cos theta)


### PR DESCRIPTION
Updated docs for `doc/transform_methods/hansenlaw.rst` and `abel.tools.vmi.py`. 

NB I renamed `calculate_angular_distributions()` to `radial_integration()` to better align with the partner method `angular_integration()`.  Modified examples to suit.

Hmm, some of the listed changes were just a 80 column reformat, sorry.

@DanHickstein `livehtml` is neat, and certainly speeds up the editing process.

Edit: NB changed name of parameter `method` to `center` in `abel.tools.center.find_center(image, center="<method>")` to match `center_image(image, center="<method>")`
