### PR TITLE
switched linalg from numpy to scipy in basex and three point

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md
+include README.rst
 recursive-include abel *.py
 recursive-include abel *.gz
 recursive-include examples *.py

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -13,8 +13,9 @@ import sys
 
 import numpy as np
 from scipy.special import gammaln
-from numpy.linalg import inv
+from scipy.linalg import inv
 from scipy.ndimage import median_filter, gaussian_filter, center_of_mass
+import scipy
 
 from ._version import __version__
 
@@ -25,7 +26,12 @@ from ._version import __version__
 # V. Dribinski, A. Ossadtchi, V. A. Mandelshtam, and H. Reisler,
 # Review of Scientific Instruments 73, 2634 (2002).
 #
-# Version 0.7 - 2016-02-17
+# 
+# version 0.62 - 2016-03-07 
+#   DH changed all linear algebra steps from numpy to scipy
+#   Scipy uses fortran fftpack, so it will be faster on some systems
+#   or the same speed as numpy in most cases.
+# Version 0.61 - 2016-02-17
 #   Major reformatting - removed up/down symmetic version and
 #   made basex work with only one quadrant.
 # Version 0.6 - 2015-12-01
@@ -155,13 +161,13 @@ def basex_core_transform(rawdata, M_vert, M_horz, Mc_vert,
     """
 
     # Reconstructing image  - This is where the magic happens
-    Ci = vert_left.dot(rawdata).dot(horz_right)
+    Ci = scipy.dot(scipy.dot(vert_left, rawdata), horz_right) # previously: vert_left.dot(rawdata).dot(horz_right)
 
     # use an heuristic scaling factor to match the analytical abel transform
     # For more info see https://github.com/PyAbel/PyAbel/issues/4
     MAGIC_NUMBER = 1.1122244156826457
     Ci *= MAGIC_NUMBER/dr
-    IM = Mc_vert.dot(Ci).dot(Mc_horz.T)
+    IM = scipy.dot(scipy.dot(Mc_vert, Ci), Mc_horz.T)    # Previously: Mc_vert.dot(Ci).dot(Mc_horz.T)
     # P = dot(dot(Mc,Ci),M.T) # This calculates the projection,
     # which should recreate the original image
     return IM
@@ -177,8 +183,13 @@ def _get_left_right_matrices(M_vert, M_horz, Mc_vert, Mc_horz):
     q_vert, q_horz = 0, 0  # No Tikhonov regularization
     E_vert, E_horz = np.identity(nbf_vert)*q_vert, np.identity(nbf_horz)*q_horz
 
-    vert_left = inv(Mc_vert.T.dot(Mc_vert) + E_vert).dot(Mc_vert.T)
-    horz_right = M_horz.dot(inv(M_horz.T.dot(M_horz) + E_horz))
+    vert_left  = scipy.dot( inv(scipy.dot(Mc_vert.T, Mc_vert) + E_vert),  Mc_vert.T)
+    horz_right = scipy.dot( M_horz, inv(scipy.dot(M_horz.T, M_horz) + E_horz) )
+    
+    # previously: 
+    # vert_left = inv(Mc_vert.T.dot(Mc_vert) + E_vert).dot(Mc_vert.T)
+    # horz_right = M_horz.dot(inv(M_horz.T.dot(M_horz) + E_horz))
+    
 
     return vert_left, horz_right
 

--- a/abel/three_point.py
+++ b/abel/three_point.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import os.path
 
 import numpy as np
+import scipy
 from itertools import product
 
 
@@ -56,7 +57,7 @@ def three_point_core_transform(IM, D):
     inv_IM = np.zeros_like(IM)
 
     for i, P in enumerate(IM):
-        inv_IM[i] = np.dot(D, P)
+        inv_IM[i] = scipy.dot(D, P)
     return inv_IM
 
 

--- a/examples/example_basex_step.py
+++ b/examples/example_basex_step.py
@@ -7,7 +7,7 @@ from abel.tools.analytical import StepAnalytical
 fig, ax = plt.subplots(1, 1)
 plt.title('Abel tranforms of a step function')
 
-n = 501
+n = 301
 r_max = 50
 A0 = 10.0
 r1 = 6.0

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,15 @@ else:
 
 
 if sys.platform != 'win32':
-    compile_args =  dict( extra_compile_args=['-O2', '-march=native'],
-                 extra_link_args=['-O2', '-march=native'])
+    compile_args =  dict( extra_compile_args=['-O2', '-march=native',
+                                              '-Wno-unused-function', 
+                                              '-Wno-unneeded-internal-declaration',
+                                              '-Wno-#warnings'],
+                             extra_link_args=['-O2', '-march=native'])
 else:
-    compile_args = {}
+    compile_args = {dict( extra_compile_args=['-Wunused-function', 
+                                              '-Wunneeded-internal-declaration',
+                                              '-Wno-#warnings'])}
 
 # Optional compilation of Cython modules adapted from
 # https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post

--- a/setup.py
+++ b/setup.py
@@ -51,15 +51,15 @@ else:
 
 
 if sys.platform != 'win32':
-    compile_args =  dict( extra_compile_args=['-O2', '-march=native',
-                                              '-Wno-unused-function', 
-                                              '-Wno-unneeded-internal-declaration',
-                                              '-Wno-#warnings'],
+    compile_args = dict( extra_compile_args=['-O2', '-march=native',
+                                             '-Wno-unused-function', 
+                                             '-Wno-unneeded-internal-declaration',
+                                             '-Wno-#warnings'],
                              extra_link_args=['-O2', '-march=native'])
 else:
-    compile_args = {dict( extra_compile_args=['-Wunused-function', 
+    compile_args = dict( extra_compile_args=['-Wunused-function', 
                                               '-Wunneeded-internal-declaration',
-                                              '-Wno-#warnings'])}
+                                              '-Wno-#warnings'])
 
 # Optional compilation of Cython modules adapted from
 # https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post


### PR DESCRIPTION
This is following up on the benchmarking discussion in https://github.com/PyAbel/PyAbel/issues/136. Apparently, the functions (like `dot` and `inv`) in scipy.linalg use a fortran version of LAPACK, which is compiled from fortran. Numpy uses some implementation of BLAS/LAPACK, and the implementation depends on the OS and the python distribution. In most cases (Apple’s Accelerate framework on OS-X, Intel’s MKL libraries in Anaconda, and openBLAS), numpy is just as fast as scipy. However, there are cases where numpy uses versions of BLAS and LAPACK that are not optimized and provide much slower behavior. Since scipy is a requirement anyway, then it makes sense that we just use scipy.

More info:
http://www.scipy.org/scipylib/faq.html#why-both-numpy-linalg-and-scipy-linalg-what-s-the-difference
http://docs.scipy.org/doc/scipy/reference/tutorial/linalg.html