### PR TITLE
Implement angular_integration  into abel.transform()

### DIFF
--- a/abel/tests/test_direct.py
+++ b/abel/tests/test_direct.py
@@ -6,7 +6,6 @@ from unittest.case import SkipTest
 from numpy.testing import assert_allclose
 import scipy.ndimage as nd
 import abel
-from abel.tools.polar import CythonExtensionsNotBuilt
 
 def test_direct_shape():
     if not abel.direct.cython_ext:

--- a/abel/tests/test_transform.py
+++ b/abel/tests/test_transform.py
@@ -30,11 +30,11 @@ def test_transform_shape():
         pass
 
     iZ = abel.transform(Zodd) 
-    # check odd width
+    # check odd width returned with default transform
     assert iZ['transform'].shape[1] % 2 == 1
 
     iZ = abel.transform(Zeven, center="com")
-    # check odd width
+    # check odd width returned for even image, centered using 'com'
     assert iZ['transform'].shape[1] % 2 == 1
 
 

--- a/abel/tests/test_transform.py
+++ b/abel/tests/test_transform.py
@@ -65,7 +65,7 @@ def test_transform_angular_integration(n=101):
     assert 'angular_integration' in results.keys()
 
     radial = results['angular_integration']
-#    assert np.shape(radial) == (2, 72)   # not sure where 72 comes from
+    assert np.shape(radial) == (2, int(np.sqrt(c2**2+r2**2))) 
 
     max_position = radial[1].argmax()
     assert np.allclose(max_position, c2, rtol=0, atol=2) 

--- a/abel/tests/test_transform.py
+++ b/abel/tests/test_transform.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from numpy.testing import assert_allclose
+import abel
+
+# The role of abel.transform() is to:
+# 0. (optional) center image and make odd-width
+# 1. split an image into quadrants,
+# 2. transform each quadrant
+# 3. reassemble image
+# 4. (optional) evaluate speed profile
+# The specific functions will have been tested separately
+# here we check that the functions combine correctly
+
+def test_transform_shape():
+    Zeven = np.ones((4,4))
+    Zodd = np.ones((4,5))
+
+    try:
+        # even width image should be rejected
+        iZ = abel.transform(Zeven) 
+        # fail if get here
+        assert iZ['transform'].shape[1] % 2 == 1
+    except:
+        pass
+
+    iZ = abel.transform(Zodd) 
+    # check odd width
+    assert iZ['transform'].shape[1] % 2 == 1
+
+    iZ = abel.transform(Zeven, center="com")
+    # check odd width
+    assert iZ['transform'].shape[1] % 2 == 1
+
+
+def test_transform_angular_integration(n=101):
+    gauss = lambda r, r0, sigma: np.exp(-(r-r0)**2/sigma**2)
+
+    image_shape=(n, n)
+    rows, cols = image_shape
+    r2 = rows//2 + rows % 2
+    c2 = cols//2 + cols % 2
+    x = np.linspace(-c2, c2, cols)
+    y = np.linspace(-r2, r2, rows)
+
+    X, Y = np.meshgrid(x, y)
+    R, THETA = abel.tools.polar.cart2polar(X, Y)
+
+    IM = gauss(R, c2, 2) # Gaussian donut located at R=c2
+
+    # forward Abel transform
+    fIM = abel.transform(IM, method="hansenlaw",
+		    direction="forward")['transform']
+
+    # inverse Abel transform, and radial intensity distribution
+    results = abel.transform(fIM, method="hansenlaw", direction="inverse",
+                             angular_integration=True)
+
+    assert 'transform' in results.keys()
+    assert 'angular_integration' in results.keys()
+
+    radial = results['angular_integration']
+#    assert np.shape(radial) == (2, 72)   # not sure where 72 comes from
+
+    max_position = radial[1].argmax()
+    assert np.allclose(max_position, c2, rtol=0, atol=2) 
+        
+
+if __name__ == "__main__":
+    test_transform_shape()
+    test_transform_angular_integration()

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -157,17 +157,3 @@ def polar2cart(r, theta):
     y = r * np.sin(theta)   # θ referenced to vertical
     x = r * np.cos(theta)
     return x, y
-
-
-class CythonExtensionsNotBuilt(Exception):
-    pass
-
-# why is this here??
-CythonExtensionsNotBuilt_msg = CythonExtensionsNotBuilt(
-    "Cython extensions were not propery built.\n"
-    "Either the complilation failed at the setup phase"
-    " (no complier, compiller not found etc),\n"
-    "or you are using Windows 64bit with Anaconda that has a known issue"
-    " with Cython\n"
-    "https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/\
-    3ES7VyW4t3I\n")

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -62,7 +62,7 @@ def angular_integration(IM, origin=None, Jacobian=False, dr=1, dt=None):
     if Jacobian:  # x r sinθ
         polarIM = polarIM * R * np.abs(np.sin(T))
 
-    speeds = np.sum(polarIM, axis=1)
+    speeds = np.sum(polarIM, axis=1)*dr
     n = speeds.shape[0]
 
     return R[:n, 0], speeds   # limit radial coordinates range to match speed

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -92,6 +92,10 @@ def transform(
         See note below for description of quadrants. 
         Default is ``(True, True, True, True)``, which uses all quadrants.
 
+    angular_integration: boolean
+        integrate the image over angle to give the radial (speed) intensity
+        distribution
+
     transform_options : tuple
         Additional arguments passed to the individual transform functions.
         See the documentation for the individual transform method for options.
@@ -165,7 +169,7 @@ def transform(
         ``results['transform']``
                 (always returned) is the 2D forward/reverse Abel transform
         ``results['angular_integration']``
-                tuple: radial coordinates, speed distribution
+                tuple: radial coordinates, radial intensity (speed) distribution
         ``results['residual']``
                 is not currently implemented
     

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -15,13 +15,14 @@ from . import direct
 from . import three_point
 from . import tools
 
-def transform(
-    IM, direction='inverse', method='three_point', center='none',
-        symmetry_axis=None, use_quadrants=(True, True, True, True), 
-        angular_integration=False,
-        transform_options=dict(), center_options=dict(),
-        angular_integration_options=dict(),
-        recast_as_float64=True, verbose=False):
+
+def transform(IM,
+              direction='inverse', method='three_point', center='none',
+              symmetry_axis=None, use_quadrants=(True, True, True, True),
+              angular_integration=False,
+              transform_options=dict(), center_options=dict(),
+              angular_integration_options=dict(),
+              recast_as_float64=True, verbose=False):
     """This is the main function of PyAbel, providing both forward
     and inverse abel transforms for full images. In addition,
     this function can perform image centering and symmetrization.
@@ -38,7 +39,7 @@ def transform(
         ``forward``
             A 'forward' Abel transform takes a (2D) slice of a 3D image
             and returns the 2D projection.
-            
+
         ``inverse``
             An 'inverse' Abel transform takes a 2D projection
             and reconstructs a 2D slice of the 3D image.
@@ -71,7 +72,8 @@ def transform(
         ``image_center``
             center is assumed to be the center of the image.
         ``slice``
-            the center is found my comparing slices in the horizontal and vertical directions
+            the center is found my comparing slices in the horizontal and
+            vertical directions
         ``com``
             the center is calculated as the center of mass
         ``gaussian``
@@ -152,10 +154,11 @@ def transform(
         functions.  See the documentation for angular_integration for options.
 
     recast_as_float64 : boolean
-        True/False that determines if the input image should be recast to ``float64``. 
-        Many images are imported in other formats (such as ``uint8`` or ``uint16``)
-        and this does not always play well with the transorm algorithms. This should
-        probably always be set to True. (Default is True.)
+        True/False that determines if the input image should be recast to 
+        ``float64``. Many images are imported in other formats (such as 
+        ``uint8`` or ``uint16``) and this does not always play well with the 
+        transorm algorithms. This should probably always be set to True. 
+        (Default is True.)
 
     verbose : boolean
         True/False to determine if non-critical output should be printed.
@@ -169,7 +172,8 @@ def transform(
         ``results['transform']``
                 (always returned) is the 2D forward/reverse Abel transform
         ``results['angular_integration']``
-                tuple: radial coordinates, radial intensity (speed) distribution
+                tuple: radial coordinates, radial intensity (speed) 
+                distribution
         ``results['residual']``
                 is not currently implemented
     
@@ -179,8 +183,8 @@ def transform(
     to the the exact abel transform.
     All the the methods should produce similar results, but
     depending on the level and type of noise found in the image,
-    certain methods may perform better than others. Please see the "Transform Methods"
-    section of the documentation for complete information.
+    certain methods may perform better than others. Please see the 
+    "Transform Methods" section of the documentation for complete information.
 
     ``hansenlaw`` 
         This "recursive algorithm" produces reliable results
@@ -233,11 +237,11 @@ def transform(
         much more quickly.
     """
 
-    abel_transform = {\
-      "basex" : basex.basex_transform,
-      "direct" : direct.direct_transform,
-      "hansenlaw" : hansenlaw.hansenlaw_transform,
-      "three_point" : three_point.three_point_transform,
+    abel_transform = {
+        "basex" : basex.basex_transform,
+        "direct" : direct.direct_transform,
+        "hansenlaw" : hansenlaw.hansenlaw_transform,
+        "three_point" : three_point.three_point_transform,
     }
 
     verboseprint = print if verbose else lambda *a, **k: None
@@ -267,7 +271,7 @@ def transform(
 
     #########################
 
-    verboseprint('Calculating {0} Abel transform using {1} method -'\
+    verboseprint('Calculating {0} Abel transform using {1} method -'
                  .format(direction, method), 
                  '\n    image size: {:d}x{:d}'.format(rows, cols))
 
@@ -300,12 +304,11 @@ def transform(
     # reassemble image
     results = {}
     AIM = tools.symmetry.put_image_quadrants((AQ0, AQ1, AQ2, AQ3), 
-                            original_image_shape = IM.shape,
+                            original_image_shape=IM.shape,
                             symmetry_axis=symmetry_axis)
 
     results['transform'] = AIM
     verboseprint("{:.2f} seconds".format(time.time()-t0))
-
 
     # radial intensity distribution
     if angular_integration:
@@ -316,6 +319,5 @@ def transform(
 
         results['angular_integration'] = tools.vmi.angular_integration(AIM, 
                                          **angular_integration_options)
-        
 
     return results

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -310,6 +310,8 @@ def transform(IM,
     results['transform'] = AIM
     verboseprint("{:.2f} seconds".format(time.time()-t0))
 
+    #########################
+
     # radial intensity distribution
     if angular_integration:
         if 'dr' in transform_options and\

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -307,7 +307,12 @@ def transform(
     verboseprint("{:.2f} seconds".format(time.time()-t0))
 
 
+    # radial intensity distribution
     if angular_integration:
+        if 'dr' in transform_options:
+            # must have common grid
+            angular_integration_options['dr'] = transform_options['dr']
+
         results['angular_integration'] = tools.vmi.angular_integration(AIM, 
                                          **angular_integration_options)
         

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -309,8 +309,9 @@ def transform(
 
     # radial intensity distribution
     if angular_integration:
-        if 'dr' in transform_options:
-            # must have common grid
+        if 'dr' in transform_options and\
+           'dr' not in angular_integration_options:
+            # assume user forgot to pass grid size
             angular_integration_options['dr'] = transform_options['dr']
 
         results['angular_integration'] = tools.vmi.angular_integration(AIM, 

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -318,26 +318,3 @@ def transform(
         
 
     return results
-
-
-def main():
-    import matplotlib.pyplot as plt
-    IM0 = tools.analytical.sample_image(n=201, name="dribinski")
-    IM1 = transform(IM0, direction='forward', center='com',
-                    method='hansenlaw')['transform']
-    IM2 = transform(IM1, direction='inverse', method='basex')['transform']
-
-    fig, axs = plt.subplots(2, 3, figsize=(10, 6))
-
-    axs[0, 0].imshow(IM0)
-    axs[0, 1].imshow(IM1)
-    axs[0, 2].imshow(IM2)
-
-    axs[1, 0].plot(*tools.vmi.angular_integration(IM0))
-    axs[1, 1].plot(*tools.vmi.angular_integration(IM1))
-    axs[1, 2].plot(*tools.vmi.angular_integration(IM2))
-
-    plt.show()
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Implemented angular integration (speed distribution) into `abel.transform()`, and updated docs.  
`abe.transform()` now also returns `['angular_integration']` data.

Q: @DanHickstein should I update the `__main__` example at end of the `transform.py` file to use the this call format? 

additional parameters:  `angular_integration=True/False`
                                     `angular_integration_options=dict()`

e.g.
```python
import numpy as np
import abel
import matplotlib.pyplot as plt
IM = np.loadtxt("examples/data/O2-ANU1024.txt.bz2")
res = abel.transform(IM, center="slice", method="hansenlaw", direction="inverse", angular_integration=True)
plt.plot(*res['angular_integration'])
plt.show()
```
