### PR TITLE
hansenlaw vectorization with np.power()

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -149,24 +149,24 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
 
     Nm = (nn+1)/nn          # R0/R
     len_Nm = len(Nm)
-    X = np.zeros((rows, K))
 
-    hkgam = np.zeros((len_Nm, K, 1))
-    phi = np.zeros((len_Nm, K, K))
+    X = np.zeros((K, rows))
+    Gamma = np.zeros((len_Nm, K, 1))
+    Phi = np.zeros((len_Nm, K, K))
 
-    # special case lam = 0
-    hkgam[:, 0, 0] = h[0]*gammagt(Nm, lam[0], nn) 
-    phi[:, 0, 0] = 1
+    # Gamma_n and Phi_n  Eq. (16a) and (16b)
+    # lam = 0.0
+    Gamma[:, 0, 0] = h[0]*gammagt(Nm, lam[0], nn)   
+    Phi[:, 0, 0] = 1
+    # lam < 0.0
+    for k in range(1, K): 
+        Gamma[:, k, 0] = h[k]*gammalt(Nm, lam[k], nn)  
+        Phi[:, k, k] = np.power(Nm, lam[k])   # diagonal matrix Eq. (16a)
 
-    # lam < 0
-    for k in range(1, K):
-        hkgam[:, k, 0] = h[k]*gammalt(Nm, lam[k], nn) 
-        phi[:, k, k] = np.power(Nm, lam[k])
-
-    # Eq. (15) or (17)
+    # Eq. (15) forward, or (17) inverse
     for i, n in enumerate(nn):
-        X = np.dot(X, phi[i]) + np.transpose(hkgam[i]*gp[:, n])
-        AIM[:, n] = X.sum(axis=1)
+        X = np.dot(Phi[i], X) + Gamma[i]*gp[:, n]
+        AIM[:, n] = X.sum(axis=0)
 
     # center pixel column
     AIM[:, 0] = AIM[:, 1]

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -110,11 +110,6 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
 
     rows, cols = N
 
-    # constants listed in Table 1.
-    h = np.array([0.318, 0.19, 0.35, 0.82, 1.8, 3.9, 8.3, 19.6, 48.3])
-    lam = np.array([0.0, -2.1, -6.2, -22.4, -92.5, -414.5, -1889.4, -8990.9,
-                    -47391.1])
-
     # Two alternative Gamma functions for forward/inverse transform
     # Eq. (16c) used for the forward transform
     def fgamma(Nm, lam, n):
@@ -145,6 +140,11 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
     # ------ The Hansen and Law algorithm ------------
     # iterate along columns, starting outer edge (right side)
     # toward the image center
+
+    # constants listed in Table 1.
+    h = np.array([0.318, 0.19, 0.35, 0.82, 1.8, 3.9, 8.3, 19.6, 48.3])
+    lam = np.array([0.0, -2.1, -6.2, -22.4, -92.5, -414.5, -1889.4, -8990.9,
+                    -47391.1])
 
     K = np.size(h)
     X = np.zeros((rows, K))

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -148,11 +148,10 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
     nn = np.arange(cols-2, 0, -1, dtype=int)
 
     Nm = (nn+1)/nn          # R0/R
-    len_Nm = len(Nm)
 
     X = np.zeros((K, rows))
-    Gamma = np.zeros((len_Nm, K, 1))
-    Phi = np.zeros((len_Nm, K, K))
+    Gamma = np.zeros((cols-2, K, 1))
+    Phi = np.zeros((cols-2, K, K))
 
     # Gamma_n and Phi_n  Eq. (16a) and (16b)
     # lam = 0.0

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -149,23 +149,23 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
 
     Nm = (nn+1)/nn          # R0/R
     len_Nm = len(Nm)
-    X = np.zeros(K)
+    X = np.zeros((rows, K))
 
-    hkgam = np.zeros((len_Nm, K))
-    pNm = np.zeros((len_Nm, K))
+    hkgam = np.zeros((len_Nm, K, 1))
+    phi = np.zeros((len_Nm, K, K))
 
     # special case lam = 0
-    hkgam[:, 0] = h[0]*gammagt(Nm, lam[0], nn) 
-    pNm[:, 0] = np.ones_like(Nm)
+    hkgam[:, 0, 0] = h[0]*gammagt(Nm, lam[0], nn) 
+    phi[:, 0, 0] = 1
 
     # lam < 0
     for k in range(1, K):
-        hkgam[:, k] = h[k]*gammalt(Nm, lam[k], nn) 
-        pNm[:, k] = np.power(Nm, lam[k])
+        hkgam[:, k, 0] = h[k]*gammalt(Nm, lam[k], nn) 
+        phi[:, k, k] = np.power(Nm, lam[k])
 
     # Eq. (15) or (17)
     for i, n in enumerate(nn):
-        X = pNm[i]*X + hkgam[i]*np.expand_dims(gp[:, n], axis=1)
+        X = np.dot(X, phi[i]) + np.transpose(hkgam[i]*gp[:, n])
         AIM[:, n] = X.sum(axis=1)
 
     # center pixel column

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -102,8 +102,6 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
         Use ``abel.tools.center.center_image(IM, method='com', odd_size=True)`` 
     """
 
-
-
     IM = np.atleast_2d(IM)
     N = np.shape(IM)         # shape of input quadrant (half)
     AIM = np.zeros(N)        # forward/inverse Abel transform image
@@ -155,7 +153,7 @@ def hansenlaw_transform(IM, dr=1, direction="inverse"):
         hkgam[0, 0] = h[0]*gammagt(Nm, lam[0], n)   # special case lam = 0.0
         hkgam[1:, 0] = h[1:]*gammalt(Nm, lam[1:], n)   # lam < 0.0
 
-        X = np.power(Nm, lam)*X + np.transpose(hkgam*gp[:, n])
+        X = np.power(Nm, lam)*X + np.transpose(hkgam*gp[:, n])  # Eq. (15 or 17)
         AIM[:, n] = X.sum(axis=1)
 
     # special case for the end pixel

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -12,7 +12,8 @@ from scipy.ndimage.interpolation import shift
 from scipy.optimize import curve_fit
 
 
-def angular_integration(IM, origin=None, Jacobian=False, dr=1, dt=None, average=False):
+def angular_integration(IM, origin=None, Jacobian=False, dr=1, dt=None,
+                        average=False):
     """ 
     Angular integration of the image.
 

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -23,11 +23,13 @@ from time import time
 #   dictionary of method: function()
 
 transforms = {
-  "direct": abel.direct.direct_transform,      
-  "onion": abel.dasch.onion_peeling_transform, 
-  "hansenlaw": abel.hansenlaw.hansenlaw_transform,
   "basex": abel.basex.basex_transform,   
+  "direct": abel.direct.direct_transform,      
+  "hansenlaw": abel.hansenlaw.hansenlaw_transform,
+  "onion_bordas": abel.onion_bordas.onion_bordas_transform,
+  "onion_dasch": abel.dasch.onion_peeling_transform, 
   "three_point": abel.dasch.three_point_transform,
+  "two_point" : abel.dasch.two_point_transform,
 }
 # sort dictionary 
 transforms = collections.OrderedDict(sorted(transforms.items()))
@@ -36,28 +38,30 @@ ntrans = np.size(transforms.keys())  # number of transforms
 
 # Image:   O2- VMI 1024x1024 pixel ------------------
 IM = np.loadtxt('data/O2-ANU1024.txt.bz2')
-# recenter the image to an odd size
 
+# recenter the image to mid-pixel (odd image width)
 IModd = abel.tools.center.center_image(IM, center="slice", odd_size=True)
-# np.savetxt("O2-ANU1023.txt", IModd)
 
 h, w = IModd.shape
 print("centered image 'data/O2-ANU2048.txt' shape = {:d}x{:d}".format(h, w))
 
-Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(IModd, reorient=True)
+# split image into quadrants
+Q = abel.tools.symmetry.get_image_quadrants(IModd, reorient=True)
 
+Q0 = Q[0]
 Q0fresh = Q0.copy()    # keep clean copy
 print ("quadrant shape {}".format(Q0.shape))
 
 # Intensity mask used for intensity normalization
 #   quadrant image region of bright pixels 
-
 mask = np.zeros(Q0.shape, dtype=bool)
 mask[500:512, 358:365] = True   
 
 # process Q0 quadrant using each method --------------------
 
 iabelQ = []  # keep inverse Abel transformed image
+sp = []  # speed distributions
+meth = []  # methods
 
 for q, method in enumerate(transforms.keys()):
 
@@ -67,60 +71,65 @@ for q, method in enumerate(transforms.keys()):
     t0 = time()
 
     # inverse Abel transform using 'method'
-    IAQ0 = transforms[method](Q0, direction="inverse") 
-
+    IAQ0 = transforms[method](Q0, direction="inverse", dr=0.5) 
     print ("                    {:.1f} sec".format(time()-t0))
 
-    iabelQ.append(IAQ0)  # store for plot
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0))
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0), dr=0.5)
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0[mask].max()  
     speed /= speed[radial > 50].max()
 
-    # plots    #121 whole image,   #122 speed distributions
-    plt.subplot(121) 
-
-    # method label for each quadrant
-    annot_angle = -(45+q*90)*np.pi/180  # -ve because numpy coords from top
-    if q > 3: 
-        annot_angle += 50*np.pi/180    # shared quadrant - move the label  
-    annot_coord = (h/2+(h*0.9)*np.cos(annot_angle)/2, 
-                   w/2+(w*0.9)*np.sin(annot_angle)/2)
-    plt.annotate(method, annot_coord, color="yellow")
-
-    # plot speed distribution
-    plt.subplot(122) 
-    plt.plot(radial, speed, label=method)
+    # keep data for plots
+    iabelQ.append(IAQ0)  
+    sp.append((radial, speed))
+    meth.append(method)
 
 # reassemble image, each quadrant a different method
 
+# plot inverse Abel transformed image slices, and respective speed distributions
+ax0 = plt.subplot2grid((1, 2), (0, 0))
+ax1 = plt.subplot2grid((1, 2), (0, 1))
+
+def ann_plt (quad, subquad, txt):
+    # -ve because numpy coords from top
+    annot_angle = -(30+30*subquad+quad*90)*np.pi/180
+    annot_coord = (h/2+(h*0.8)*np.cos(annot_angle)/2,
+                   w/2+(w*0.8)*np.sin(annot_angle)/2)
+    ax0.annotate(txt, annot_coord, color="yellow", horizontalalignment='left')
+
 # for < 4 images pad using a blank quadrant
-blank = np.zeros(IAQ0.shape)  
-for q in range(ntrans, 4):
-    iabelQ.append(blank)
+r, c = Q0.shape
+Q = np.zeros((4, r, c))
 
-# more than 4, split quadrant
-if ntrans == 5:
-    # split last quadrant into 2 = upper and lower triangles
-    tmp_img = np.tril(np.flipud(iabelQ[-2])) +\
-              np.triu(np.flipud(iabelQ[-1]))
-    iabelQ[3] = np.flipud(tmp_img)
-# Fix me when > 5 images
- 
+indx = np.triu_indices(iabelQ[0].shape[0])
+iq = 0
+for q in range(4):
+    Q[q] = iabelQ[iq].copy()
+    ann_plt(q, 0, meth[iq])
+    ax1.plot(*(sp[iq]), label=meth[iq])
+    iq += 1
+    if iq < len(transforms):
+        Q[q][indx] = np.triu(iabelQ[iq])[indx] 
+        ann_plt(q, 1, meth[iq])
+        ax1.plot(*(sp[iq]), label=meth[iq])
+    iq += 1
 
-im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
-                                              iabelQ[2], iabelQ[3]), 
+# reassemble image from transformed (part-)quadrants
+im = abel.tools.symmetry.put_image_quadrants((Q[0], Q[1], Q[2], Q[3]), 
                                               original_image_shape=IModd.shape)
 
-plt.subplot(121)
-plt.imshow(im, vmin=0, vmax=0.8)
+ax0.axis('off')
+ax0.set_title("inverse Abel transforms")
+ax0.imshow(im, vmin=0, vmax=0.8)
 
-plt.subplot(122)
-plt.axis(ymin=-0.05, ymax=1.1, xmin=50, xmax=450)
-plt.legend(loc=0, labelspacing=0.1)
+ax1.set_title("speed distribution")
+ax1.axis(ymin=-0.05, ymax=1.1, xmin=50, xmax=450)
+ax1.legend(loc=0, labelspacing=0.1, fontsize=10)
 plt.tight_layout()
+
+# save a copy of the plot
 plt.savefig('example_all_O2.png', dpi=100)
 plt.show()

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -71,12 +71,13 @@ for q, method in enumerate(transforms.keys()):
     t0 = time()
 
     # inverse Abel transform using 'method'
-    IAQ0 = transforms[method](Q0, direction="inverse", dr=0.5) 
+    IAQ0 = transforms[method](Q0, direction="inverse", dr=0.1) 
     print ("                    {:.1f} sec".format(time()-t0))
 
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0), dr=0.5)
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0),
+                                                       dr=0.1)
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0[mask].max()  
@@ -109,12 +110,12 @@ iq = 0
 for q in range(4):
     Q[q] = iabelQ[iq].copy()
     ann_plt(q, 0, meth[iq])
-    ax1.plot(*(sp[iq]), label=meth[iq])
+    ax1.plot(*(sp[iq]), label=meth[iq], alpha=0.3)
     iq += 1
     if iq < len(transforms):
         Q[q][indx] = np.triu(iabelQ[iq])[indx] 
         ann_plt(q, 1, meth[iq])
-        ax1.plot(*(sp[iq]), label=meth[iq])
+        ax1.plot(*(sp[iq]), label=meth[iq], alpha=0.3)
     iq += 1
 
 # reassemble image from transformed (part-)quadrants

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -29,6 +29,7 @@ transforms = {
   "onion": abel.dasch.onion_peeling_transform,
   "basex": abel.basex.basex_transform,   
   "three_point": abel.dasch.three_point_transform,
+  "two_point": abel.dasch.two_point_transform,
 }
 
 # sort dictionary:

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -7,16 +7,15 @@ import numpy as np
 import abel
 import matplotlib.pylab as plt
 
-# Hansen and Law inverse Abel transform of a velocity-map image 
-# O2- photodetachement at 454 nm.
-# The spectrum was recorded in 2010  
-# ANU / The Australian National University
+# Hansen and Law inverse Abel transform of velocity-map imaged electrons
+# from O2- photodetachement at 454 nm. The spectrum was recorded in 2010  
+# at the Australian National University (ANU)
 # J. Chem. Phys. 133, 174311 (2010) DOI: 10.1063/1.3493349
 
-# Load as a numpy array
+# load image as a numpy array
+# use scipy.misc.imread(filename) to load image formats (.png, .jpg, etc)
 print("HL: loading 'data/O2-ANU1024.txt.bz2'")
 IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
-# use plt.imread(filename) to load image formats (.png, .jpg, etc)
 
 rows, cols = IM.shape    # image size
 
@@ -28,7 +27,7 @@ if cols % 2 == 0:
     rows, cols = IM.shape   # new image size
 
 # dr=0.5 may help reduce pixel grid coarseness
-# NB remember to pass to angular_integration
+# NB remember to also pass to angular_integration
 AIM = abel.Transform(IM, method='hansenlaw',
                      use_quadrants=(True, True, True, True),
                      symmetry_axis=None,
@@ -39,9 +38,9 @@ radial, speeds  = abel.tools.vmi.angular_integration(AIM, dr=0.5)
 
 # Set up some axes
 fig = plt.figure(figsize=(15, 4))
-ax1 = plt.subplot(131)
-ax2 = plt.subplot(132)
-ax3 = plt.subplot(133)
+ax1 = plt.subplot2grid((1, 3), (0, 0))
+ax2 = plt.subplot2grid((1, 3), (0, 1))
+ax3 = plt.subplot2grid((1, 3), (0, 2))
 
 # raw image
 im1 = ax1.imshow(IM, aspect='auto')
@@ -69,7 +68,7 @@ ax3.set_title('speed distribution')
 plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89, wspace=0.35,
                     hspace=0.37)
 
-# save an image of the plot
+# save copy of the plot
 plt.savefig("example_hansenlaw.png", dpi=100)
 
 plt.show()


### PR DESCRIPTION
Using the magic of `np.power()` to replace `pow()` allows some vectorization improvement to the `hansenlaw` algorithm.  I imagine/hope these types of code changes may be taken further ...

- removes 'k' for loop

```python
for k in range(K):  # Iterate over k, the eigenvectors?
            X[:, k] = pow(Nm, lam[k])*X[:, k] +\
                      h[k]*gamma(Nm, lam[k], n)*gp[:, n]  # Eq. (15 or 17)
```
- (apparently) no longer requires the pseudo 1-column shift - e.g. run `examples/example_all_O2.py`

 ```python 
  #for some reason shift by 1 pixel aligns better? - FIX ME!
      if direction == "inverse":
          AIM = np.c_[AIM[:, 1:],AIM[:, -1]]
 ```
- faster execution  ~30% improvement (`n=501`) cf [PR #155](https://github.com/PyAbel/PyAbel/pull/155#issuecomment-203097576)
```
In [2]: abel.benchmark.AbelTiming(n=[301, 501, 1001])
Out[2]: 
PyAbel benchmark run on x86_64

time in milliseconds

=========    Basis Abel implementations ==========

Implementation      n = 301           n = 501           n = 1001      
----------------------------------------------------------------------------
        basex_bs    6148.8           20052.1               nan         
onion_peeling_bs       6.5              26.3             172.5         
  three_point_bs      10.8              28.4             135.1         
    two_point_bs       4.3              11.8              43.6         


=========  Forward Abel implementations ==========

Implementation      n = 301           n = 501           n = 1001      
----------------------------------------------------------------------------
   direct_Python      65.0             297.8               nan         
       hansenlaw       9.8              21.6              75.6         


=========  Inverse Abel implementations ==========

Implementation      n = 301           n = 501           n = 1001      
----------------------------------------------------------------------------
           basex      15.0             120.1               nan         
   direct_Python      74.8             313.0               nan         
       hansenlaw      10.1              21.6              71.6         
    onion_bordas     205.2             751.2            3187.9         
   onion_peeling       4.2              18.8             140.6         
     three_point       4.7              19.3             142.1         
       two_point       4.7              19.4             143.7    
```
![pyabel-benchmarks](https://cloud.githubusercontent.com/assets/10932229/14266254/3dc3243e-fb0a-11e5-847e-dbf488d24f92.png)
