### PR TITLE
Change the default of angular_integration() from Jacobian=False to Jacobian=Ture in tools/vmi.py

### DIFF
--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -12,13 +12,15 @@ from scipy.ndimage.interpolation import shift
 from scipy.optimize import curve_fit
 
 
-def angular_integration(IM, origin=None, Jacobian=False, dr=1, dt=None,
+def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None,
                         average=False):
     """ 
     Angular integration of the image.
 
     Returns the one-dimentional intensity profile as a function of the
     radial coordinate.
+    
+    Note: the use of Jacobian=True applies the correct Jacobian for the integration of a 3D object in spherical coordinates.
 
     Parameters
     ----------


### PR DESCRIPTION
Because in VMI imaging processing, we always use the correct Jacobian r*sin(theta) term when doing Abel inversion.

Yuan