### PR TITLE
anisotropy versus radial coordinate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
     env: DEPS="numpy scipy nose cython"
   - python: '3.4'
     env: DEPS="numpy scipy nose cython"
-  - python: '3.3'
-    env: DEPS="numpy scipy nose cython"
+#  - python: '3.3'
+#    env: DEPS="numpy scipy nose cython"
   - python: '2.7'
     env: DEPS="numpy scipy nose cython"
 install:

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -111,7 +111,7 @@ _linbasex_parameter_docstring = \
 
            Beta[0] vs radius -> speed distribution
 
-           Beta[2] vs radius -> anisotropy of each Newton sphere.
+           Beta[1] vs radius -> anisotropy of each Newton sphere.
 
        projections : are the radial projection profiles at angles `proj_angles`
 

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -5,10 +5,9 @@ from __future__ import print_function
 import os.path
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose, assert_equal, assert_almost_equal
 
-from abel.tools.vmi import angular_integration
-from abel.tools.center import  center_image
+import abel
 from abel.benchmark import is_symmetric
 
 
@@ -27,7 +26,7 @@ def test_speeds():
 
     IM = np.random.randn(n, n)
 
-    angular_integration(IM)
+    abel.tools.vmi.angular_integration(IM)
 
 
 def test_centering_function_shape():
@@ -38,7 +37,7 @@ def test_centering_function_shape():
                     (5, 11),  # pad image
                     (4, 11)]:
         data = np.zeros((y, x))
-        res = center_image(data, (y//2, x//2))
+        res = abel.tools.center.center_image(data, (y//2, x//2))
         assert_equal( res.shape, (y, x),
                     'Centering preserves shapes for ni={}, n={}'.format(y, x))
 
@@ -56,7 +55,7 @@ def test_centering_function():
         # # else:
         arr[n_c-1:n_c+1,n_c-1:n_c+1] = 1.0
 
-        res = center_image(arr, (n_c, n_c), odd_size=False)
+        res = abel.tools.center.center_image(arr, (n_c, n_c), odd_size=False)
         # The print statements  below can be commented after we fix the centering issue
         # print('Original array')
         # print(arr)
@@ -70,7 +69,17 @@ def test_speeds_non_integer_center():
     # ensures that the rest speeds function can work with a non-integer center
     n  = 101
     IM = np.random.randn(n, n)
-    angular_integration(IM, origin=(50.5, 50.5))
+    abel.tools.vmi.angular_integration(IM, origin=(50.5, 50.5))
 
-if __name__ == "__main()__":
-   test_centering_function()
+def test_anisotropy_parameter():
+    # anisotropy parameter from test image (not inverted)
+    IM = abel.tools.analytical.sample_image(name='dribinski')
+    
+    Beta, Amp, Rmid, Ivstheta, theta = abel.tools.vmi.radial_integration(IM,
+                                         radial_ranges=([(0, 33), (92, 108)]))
+
+    assert_almost_equal(-0.13, Beta[0][0], decimal=2)
+
+
+if __name__ == "__main__":
+    test_anisotropy_parameter()

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -72,7 +72,7 @@ def test_speeds_non_integer_center():
     abel.tools.vmi.angular_integration(IM, origin=(50.5, 50.5))
 
 def test_anisotropy_parameter():
-    # anisotropy parameter from test image (not inverted)
+    # anisotropy parameter from test image (not transformed)
     IM = abel.tools.analytical.sample_image(name='dribinski')
     
     Beta, Amp, Rmid, Ivstheta, theta = abel.tools.vmi.radial_integration(IM,

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -74,5 +74,3 @@ def test_speeds_non_integer_center():
 
 if __name__ == "__main()__":
    test_centering_function()
-
-def test_anisotropy():

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -74,3 +74,5 @@ def test_speeds_non_integer_center():
 
 if __name__ == "__main()__":
    test_centering_function()
+
+def test_anisotropy():

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -248,8 +248,8 @@ def anisotropy(AIM, radial_ranges=None):
     Covenience function providing a single call to 'radial_integration' and
     'anisotropy_parameter'
 
-    Note: in general specifying a radial range tuple that encompasses a spectral
-    feature that has good intensity, will provide a more accurate
+    Note: in general specifying a radial range tuple that encompasses a
+    spectral feature that has good intensity, will provide a more accurate
     anisotropy parameter
 
     Parameters
@@ -279,4 +279,5 @@ def anisotropy(AIM, radial_ranges=None):
     IvsTheta, theta, Rbar = radial_integration(AIM, radial_ranges)
     Beta, Amp = anisotropy_parameter(theta, IvsTheta)
 
-    return Beta, Amp, Rbar
+    # tranpose gives beta vs r, ebeta vs r etc
+    return np.transpose(Beta), np.transpose(Amp), Rbar

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -173,16 +173,9 @@ def radial_integration(IM, radial_ranges=None):
         Intensity_vs_theta.append(intensity_vs_theta_at_R)
         radial_midpt.append(np.mean(rr))
 
-        # evaluate anisotropy parameter from intensity_vs_theta_at_R fit to
-        #        amp*(1 + beta P_2(cos theta)) 
-        # returns (beta_i, fit_error_i) for each radial range
         beta, amp = anisotropy_parameter(theta, intensity_vs_theta_at_R)
         Beta.append(beta)
         Amp.append(amp)
-     
-    Beta = np.transpose(Beta)
-    Amp = np.transpose(Amp)
-    Intensity_vs_theta = np.array(Intensity_vs_theta)
 
     return Beta, Amp, radial_midpt, Intensity_vs_theta, theta
 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -13,13 +13,13 @@ from scipy.optimize import curve_fit
 
 
 def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
-    """ 
-    Angular integration of the image.
+    """Angular integration of the image.
 
     Returns the one-dimentional intensity profile as a function of the
     radial coordinate.
-    
-    Note: the use of Jacobian=True applies the correct Jacobian for the integration of a 3D object in spherical coordinates.
+
+    Note: the use of Jacobian=True applies the correct Jacobian for the
+    integration of a 3D object in spherical coordinates.
 
     Parameters
     ----------
@@ -32,17 +32,17 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
 
     Jacobian : boolean
         Include :math:`r\sin\\theta` in the angular sum (integration).
-        Also, ``Jacobian=True`` is passed to 
+        Also, ``Jacobian=True`` is passed to
         :func:`abel.tools.polar.reproject_image_into_polar`,
-        which includes another value of ``r``, thus providing the appropriate 
+        which includes another value of ``r``, thus providing the appropriate
         total Jacobian of :math:`r^2\sin\\theta`.
 
     dr : float
-        Radial coordinate grid spacing, in pixels (default 1). `dr=0.5` may 
+        Radial coordinate grid spacing, in pixels (default 1). `dr=0.5` may
         reduce pixel granularity of the speed profile.
 
     dt : float
-        Theta coordinate grid spacing in degrees. 
+        Theta coordinate grid spacing in degrees.
         if ``dt=None``, dt will be set such that the number of theta values
         is equal to the height of the image (which should typically ensure
         good sampling.)
@@ -58,13 +58,13 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
      """
 
     polarIM, R, T = reproject_image_into_polar(
-        IM, origin, Jacobian=Jacobian, dr=dr, dt=dt)    
+        IM, origin, Jacobian=Jacobian, dr=dr, dt=dt)
 
-    dt = T[0,1] - T[0,0]
+    dt = T[0, 1] - T[0, 0]
 
     if Jacobian:  # x r sinθ
         polarIM = polarIM * R * np.abs(np.sin(T))
-    
+
     speeds = np.trapz(polarIM, axis=1, dx=dt)
 
     n = speeds.shape[0]
@@ -73,11 +73,11 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
 
 
 def average_radial_intensity(IM, **kwargs):
-    """
-    Calculate the average radial intensity of the image, averaged over all angles.
-    This differs form :func:`abel.tools.vmi.angular_integration` only in that it returns
-    the average intensity, and not the integrated intensity of a 3D image. 
-    It is equavalent to calling :func:`abel.tools.vmi.angular_integration` with 
+    """Calculate the average radial intensity of the image, averaged over all
+    angles. This differs form :func:`abel.tools.vmi.angular_integration` only
+    in that it returns the average intensity, and not the integrated intensity
+    of a 3D image. It is equavalent to calling
+    :func:`abel.tools.vmi.angular_integration` with
     `Jacobian=True` and then dividing the result by 2*pi.
 
 
@@ -86,8 +86,9 @@ def average_radial_intensity(IM, **kwargs):
     IM : 2D numpy.array
      The data image.
 
-    kwargs : 
-      additional keyword arguments to be passed to :func:`abel.tools.vmi.angular_integration`
+    kwargs :
+      additional keyword arguments to be passed to
+      :func:`abel.tools.vmi.angular_integration`
 
     Returns
     -------
@@ -106,7 +107,7 @@ def average_radial_intensity(IM, **kwargs):
 def radial_integration(IM, radial_ranges=None):
     """ Intensity variation in the angular coordinate.
 
-    This function is the :math:`\\theta`-coordinate complement to 
+    This function is the :math:`\\theta`-coordinate complement to
     :func:`abel.tools.vmi.angular_integration`
 
     (optionally and more useful) returning intensity vs angle for defined
@@ -124,7 +125,7 @@ def radial_integration(IM, radial_ranges=None):
             ``[(r0, r1), (r2, r3), ...]``
             evaluates the intensity vs angle
             for the radial ranges ``r0_r1``, ``r2_r3``, etc.
-        int - the whole radial range ``(0, step), (step, 2*step), ..`` 
+        int - the whole radial range ``(0, step), (step, 2*step), ..``
 
     Returns
     -------
@@ -164,13 +165,12 @@ def radial_integration(IM, radial_ranges=None):
 
 
 def anisotropy_parameter(theta, intensity, theta_ranges=None):
-    """ 
+    """
     Evaluate anisotropy parameter :math:`\\beta`, for :math:`I` vs :math:`\\theta` data.
 
     .. math::
 
-        I = \\frac{\sigma_\\text{total}}{4\pi} [ 1 + \\beta P_2(\cos\\theta) ]   
-
+        I = \\frac{\sigma_\\text{total}}{4\pi} [ 1 + \\beta P_2(\cos\\theta) ]
 
     where :math:`P_2(x)=\\frac{3x^2-1}{2}` is a 2nd order Legendre polynomial.
 
@@ -223,7 +223,7 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
             beta, amplitude = popt
             error_beta, error_amplitude = np.sqrt(np.diag(pcov))
             # physical range
-            if beta > 2 or beta < -1:  
+            if beta > 2 or beta < -1:
                 beta, error_beta = np.nan, np.nan
         except:
             beta, error_beta = np.nan, np.nan
@@ -233,20 +233,20 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
 
     Beta = np.array(Beta)
     Amp = np.array(Amp)
-  
+
     if Beta.shape[0] == 1:
         # flatten to a vector
         Beta = Beta[0]
         Amp = Amp[0]
-        
-    return Beta, Amp 
+
+    return Beta, Amp
 
 
 def anisotropy(AIM, radial_ranges=None):
     """Evaluates anisotropy parameter for each tuple range of the radial grid.
 
-    Covenience function providing a single call to 'radial_integration' and 
-    'anisotropy_parameter' 
+    Covenience function providing a single call to 'radial_integration' and
+    'anisotropy_parameter'
 
     Note: in general specifying a radial range tuple that encompasses a spectral
     feature that has good intensity, will provide a more accurate
@@ -262,15 +262,15 @@ def anisotropy(AIM, radial_ranges=None):
             ``[(r0, r1), (r2, r3), ...]``
             evaluates the intensity vs angle
             for the radial ranges ``r0_r1``, ``r2_r3``, etc.
-        int - the whole radial range ``(0, step), (step, 2*step), ...`` 
+        int - the whole radial range ``(0, step), (step, 2*step), ...``
 
     Returns
     -------
     Beta : array of tuples
-        (beta0, error_beta_fit0), (beta1, error_beta_fit1), ... 
+        (beta0, error_beta_fit0), (beta1, error_beta_fit1), ...
         corresponding to the radial ranges
     Amplitude : array of tuples
-        (amp0, error_amp_fit0), (amp1, error_amp_fit1), ... 
+        (amp0, error_amp_fit0), (amp1, error_amp_fit1), ...
         corresponding to the radial ranges
     Rbar : numpy float 1d array
          radial-mid point of each radial range

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -218,8 +218,8 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
         beta, amplitude = popt
         error_beta, error_amplitude = np.sqrt(np.diag(pcov))
     except:
-        beta, error_beta = nan, nan
-        amplitude, error_amplitude = nan, nan
+        beta, error_beta = np.nan, np.nan
+        amplitude, error_amplitude = np.nan, np.nan
 
     return (beta, error_beta), (amplitude, error_amplitude)
 
@@ -227,7 +227,7 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
 def anisotropy(AIM, radial_step):
     """
     Combines `radial_intensity()` and `anisotropy_parameter()` to return the
-    anisotropy parameter for each of the radial ranges.
+    anisotropy parameter for the whole radial range.
 
     Parameters
     ----------
@@ -244,19 +244,21 @@ def anisotropy(AIM, radial_step):
     amplitude : array of tuples
         (amp0, error_amp_fit0), (amp1, error_amp_fit1), ... 
         corresponding to the radial ranges
+    Rbar : numpy float 1d array
+         radial-mid point of each radial range
 
     """
     rows, cols = AIM.shape
-    radial_grid = np.arange(0, cols//2)
+    radial_grid = np.arange(0, cols//2, radial_step)
     # clever code from @DanHickstein
     radial_ranges = zip(radial_grid[:-radial_step], radial_grid[radial_step:])
 
     IvsTheta, theta, Rbar = radial_integration(AIM, radial_ranges)
     Beta = []
     Amp = []
-    for i, angle in enumerate(theta):
-        (beta, ebeta), (amp, eamp) = anisotropy_parameter(angle, IvsTheta[i])
+    for i, Ith in enumerate(IvsTheta):
+        (beta, ebeta), (amp, eamp) = anisotropy_parameter(theta, Ith)
         Beta.append((beta, ebeta))
         Amp.append((amp, eamp))
 
-    return Beta, Amp
+    return Beta, Amp, Rbar

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -459,18 +459,21 @@ class Transform(object):
         if self.method == "linbasex" and\
            "return_Beta" in transform_options.keys():
             # linbasex evaluates speed and anisotropy parameters
-            Beta0 = AQ0[1]
-            Beta1 = AQ1[1]
-            Beta2 = AQ2[1]
-            Beta3 = AQ3[1]
+            # AQi == AIM, R, Beta, QLz
+            Beta0 = AQ0[2]
+            Beta1 = AQ1[2]
+            Beta2 = AQ2[2]
+            Beta3 = AQ3[2]
             # rconstructed images of each quadrant
             AQ0 = AQ0[0]
             AQ1 = AQ1[0]
             AQ2 = AQ2[0]
             AQ3 = AQ3[0]
-            self.linbasex_angular_integration =\
+            # speed
+            self.linbasex_angular_integration = self.Beta[0]\
                  (Beta0[0] + Beta1[0] + Beta2[0] + Beta3[0])/4
-            self.linbasex_anisotropy_parameter =\
+            # anisotropy
+            self.linbasex_anisotropy_parameter = self.Beta[1]\
                  (Beta0[1] + Beta1[1] + Beta2[1] + Beta3[1])/4
 
         # reassemble image

--- a/doc/anisotropy_parameter.rst
+++ b/doc/anisotropy_parameter.rst
@@ -8,7 +8,7 @@ For linearly polarized light the angular distribution of photodetached electrons
   I(\epsilon, \theta) = \frac{\sigma_{\rm total}(\epsilon)}{4\pi} [ 1 + \beta(\epsilon) P_2(\cos\theta)]
 
 
-where :math:`\beta(\epsilon)` is the electron kinetic energy anisotropy parameter, that varies between -1 and +2, and :math:`P_2(\cos\theta)` is the 2nd order Legendre polynomial in :math:`\cos\theta`. :math:`\sigma_{\rm total}` is the total photodetachment cross section.
+where :math:`\beta(\epsilon)` is the electron kinetic energy (:math:`\epsilon`) dependent anisotropy parameter, that varies between -1 and +2, and :math:`P_2(\cos\theta)` is the 2nd order Legendre polynomial in :math:`\cos\theta`. :math:`\sigma_{\rm total}` is the total photodetachment cross section.
 
 
 ``PyAbel`` provides two methods to determine the anisotropy parameter :math:`\beta`:

--- a/doc/anisotropy_parameter.rst
+++ b/doc/anisotropy_parameter.rst
@@ -1,0 +1,30 @@
+Anisotropy Parameter
+====================
+
+For linearly polarized light the angular distribution of photodetached electrons from negative-ions is given by:
+
+.. math::
+
+  I(\epsilon, \theta) = \frac{\sigma_{\rm total}(\epsilon)}{4\pi} [ 1 + \beta(\epsilon) P_2(\cos\theta)]
+
+
+where :math:`\beta(\epsilon)` is the electron kinetic energy anisotropy parameter, that varies between -1 and +2, and :math:`P_2(\cos\theta)` is the 2nd order Legendre polynomial in :math:`\cos\theta`. :math:`\sigma_{\rm total}` is the total photodetachment cross section.
+
+
+``PyAbel`` provides two methods to determine the anisotropy parameter :math:`\beta`:
+
+   1. :doc:`linbasex <transform_methods/linbasex>` directly evaluates :math:`\beta`, available as the class attribute `Beta[1]`.
+
+       This method fits spherical harmonic functions to the velocity-image to directly determine the anisotropy parameter as a function of the radial coordinate.
+
+
+   2. `abel.tools.vmi.radial_integration()` 
+
+       This method determines the anisotropy parameter from the inverse Abel transformed image, by extracting intensity vs angle for each specified radial range (tuples) and then fitting the intensity formula given above. This method is best applied to the radial ranges the correspond to strong spectral (intensity) in the image. It has the advantage of providing the least-squares fit error estimate for the parameter(s).
+
+
+
+Example
+-------
+
+.. plot:: ../examples/example_PAD.py 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,7 @@ Contents:
    contributing_link
    abel
    transform_methods
+   anisotropy_parameter
    examples
    
 

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -98,6 +98,7 @@ class PyAbel:  #(tk.Tk):
         # duplicates the button interface
         self.menubar = tk.Menu(self.parent)
         self.transform_method = tk.IntVar()
+        self.center_method = tk.IntVar()
 
         # File - menu
         self.filemenu = tk.Menu(self.menubar, tearoff=0)
@@ -109,7 +110,16 @@ class PyAbel:  #(tk.Tk):
 
         # Process - menu
         self.processmenu = tk.Menu(self.menubar, tearoff=0)
-        self.processmenu.add_command(label="Center image", command=self._center)
+        #self.processmenu.add_command(label="Center image", command=self._center)
+
+        self.subcent=tk.Menu(self.processmenu)
+        for cent in center_methods:
+            self.subcent.add_radiobutton(label=cent,
+                 var=self.center_method, val=center_methods.index(cent),
+                 command=self._center)
+        self.processmenu.add_cascade(label="Center image",
+                 menu=self.subcent, underline=0)
+        
         self.submenu=tk.Menu(self.processmenu)
         for method in Abel_methods:
             self.submenu.add_radiobutton(label=method,

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -259,13 +259,13 @@ class PyAbel:  #(tk.Tk):
                          " be incomplete ...\n")
         self.text.insert(tk.END, "To start: load an image data file using"
                          " e.g. data/O2-ANU1024.txt.bz2\n"
-                         " '(1) load image' button (or file menu)\n"
-                         " '(2) center image'\n"
-                         " '(3) Abel transform'\n"
-                         " '(4) speed'\n"
-                         " '(5) anisotropy'\n"
-                         " '(6) Abel transform <- change'\n"
-                         " '(:) repeat'\n")
+                         " (1) load image button (or file menu)\n"
+                         " (2) center image\n"
+                         " (3) Abel transform\n"
+                         " (4) speed\n"
+                         " (5) anisotropy\n"
+                         " (6) Abel transform <- change\n"
+                         " (:) repeat\n")
         self.text.grid(row=3, column=1, columnspan=3, padx=5)
 
 

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -28,8 +28,10 @@ from matplotlib import gridspec
 
 from scipy.ndimage.interpolation import shift
 
-Abel_methods = ['basex', 'direct', 'hansenlaw', 'onion_peeling', 
+Abel_methods = ['basex', 'direct', 'hansenlaw', 'linbasex', 'onion_peeling', 
                 'onion_bordas', 'two_point', 'three_point']
+
+center_methods = ['center-of-mass', 'convolution', 'gaussian', 'slice']
 
 
 class PyAbel:  #(tk.Tk):
@@ -168,7 +170,7 @@ class PyAbel:  #(tk.Tk):
         self.center.grid(row=0, column=1, padx=(0, 20), pady=(5, 0))
         self.center_method = ttk.Combobox(master=self.button_frame,
                          font=self.font,
-                         values=["com", "slice", "gaussian", "image_center"],
+                         values=center_methods,
                          width=10, height=4)
         self.center_method.current(1)
         self.center_method.grid(row=1, column=1, padx=(0, 20))

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -351,7 +351,7 @@ class PyAbel:  #(tk.Tk):
         # center image via chosen method
         self.IM = abel.tools.center.center_image(self.IM, center=center_method,
                                   odd_size=True)
-        self.text.insert(tk.END, "\ncenter offset = {:}".format(self.offset))
+        #self.text.insert(tk.END, "\ncenter offset = {:}".format(self.offset))
         self.text.see(tk.END)
     
         self._display()

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -349,7 +349,7 @@ class PyAbel:  #(tk.Tk):
         self.canvas.show()
     
         # center image via chosen method
-        self.IM = abel.tools.center.center_image(self.IM, method=center_method,
+        self.IM = abel.tools.center.center_image(self.IM, center=center_method,
                                   odd_size=True)
         self.text.insert(tk.END, "\ncenter offset = {:}".format(self.offset))
         self.text.see(tk.END)
@@ -463,7 +463,7 @@ class PyAbel:  #(tk.Tk):
         
         self.plt[3].plot(self.theta, self.intensity[0], 'r-')
         self.plt[3].plot(self.theta, PAD(self.theta, self.beta[0][0], self.amp[0][0]), 'b-', lw=2)
-        self.plt[3].annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(*self.rmx+self.beta[0]), (-2.5, self.intensity[0].max()/0.8))
+        self.plt[3].annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(*self.rmx+self.beta[0]), (-3, self.intensity[0].min()/0.8))
         self.plt[3].set_title("anisotropy", fontsize=12)
         self.plt[3].set_xlabel("angle", fontsize=9)
         self.plt[3].set_ylabel("intensity")

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -49,9 +49,9 @@ class PyAbel:  #(tk.Tk):
         self.rmx = (368, 393)
 
         # matplotlib figure
-        self.f = Figure(figsize=(2, 4))
+        self.f = Figure(figsize=(2, 8))
         self.gs = gridspec.GridSpec(2, 2, width_ratios=[1, 2])
-        self.gs.update(wspace=0.2, hspace=0.5)
+        self.gs.update(wspace=0.2, hspace=0.2)
 
         self.plt = []
         self.plt.append(self.f.add_subplot(self.gs[0]))
@@ -183,7 +183,7 @@ class PyAbel:  #(tk.Tk):
                          font=self.font,
                          values=center_methods,
                          width=11, height=4)
-        self.center_method.current(0)
+        self.center_method.current(1)
         self.center_method.grid(row=1, column=1, padx=(0, 20))
 
         # column 2 -----------

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -160,8 +160,9 @@ class PyAbel:  #(tk.Tk):
         self.load.grid(row=0, column=0, sticky=tk.W, padx=(5, 10), pady=(5, 0))
         self.sample_image = ttk.Combobox(master=self.button_frame,
                          font=self.font,
-                         values=["from file", "from transform", "sample dribinski", "sample Ominus"],
-                         width=14, height=4)
+                         values=["from file", "from transform",
+                                 "sample dribinski", "sample Ominus"],
+                         width=10, height=4)
         self.sample_image.current(0)
         self.sample_image.grid(row=1, column=0, padx=(5, 10))
 
@@ -181,8 +182,8 @@ class PyAbel:  #(tk.Tk):
         self.center_method = ttk.Combobox(master=self.button_frame,
                          font=self.font,
                          values=center_methods,
-                         width=10, height=4)
-        self.center_method.current(1)
+                         width=11, height=4)
+        self.center_method.current(0)
         self.center_method.grid(row=1, column=1, padx=(0, 20))
 
         # column 2 -----------
@@ -435,7 +436,12 @@ class PyAbel:  #(tk.Tk):
         self.plt[1].axis("on")
         self.plt[1].plot(self.radial, self.speed_dist/self.speed_dist[10:].max(),
                          label=self.method)
-        self.plt[1].axis(xmax=500, ymin=-0.05)
+        # make O2- look nice
+        if self.fn.find('O2-ANU1024') > -1:
+            self.plt[1].axis(xmax=500, ymin=-0.05)
+        elif self.fn.find('VMI_art1') > -1:
+            self.plt[1].axis(xmax=260, ymin=-0.05)
+
         self.plt[1].set_xlabel("radius (pixels)", fontsize=9)
         self.plt[1].set_ylabel("normalized intensity")
         self.plt[1].set_title("radial speed distribution", fontsize=12)
@@ -465,13 +471,15 @@ class PyAbel:  #(tk.Tk):
         self._transform()
 
         if self.method == 'linbasex':
-            self.rmx = (0, self.radial[-1])
+            self.text.insert(tk.END,
+                        "\nanisotropy parameter pixel range 0 to {}: "\
+                        .format(self.rmx[1]))
         else:
             # radial range over which to follow the intensity variation with angle
             self.rmx = (int(self.rmin.get()), int(self.rmax.get()))
-    
-        self.text.insert(tk.END,"\nanisotropy parameter pixel range {:} to {:}: "\
-                               .format(*self.rmx))
+            self.text.insert(tk.END,
+                        "\nanisotropy parameter pixel range {:} to {:}: "\
+                        .format(*self.rmx))
         self.canvas.show()
     
         # inverse Abel transform
@@ -486,7 +494,11 @@ class PyAbel:  #(tk.Tk):
             self.plt[3].set_title("anisotropy", fontsize=12)
             self.plt[3].set_xlabel("radius", fontsize=9)
             self.plt[3].set_ylabel("anisotropy parameter")
-            self.plt[3].axis(xmax=500, ymin=-1.1, ymax=0.1)
+            # make O2- look nice
+            if self.fn.find('O2-ANU1024') > -1:
+                self.plt[3].axis(xmax=500, ymin=-1.1, ymax=0.1)
+            elif self.fn.find('VMI_art1') > -1:
+                self.plt[3].axis(xmax=260, ymin=-1.1, ymax=2)
         else:
             # intensity vs angle
             self.beta, self.amp, self.rad, self.intensity, self.theta =\
@@ -499,8 +511,10 @@ class PyAbel:  #(tk.Tk):
             self.plt[3].axis("on")
         
             self.plt[3].plot(self.theta, self.intensity[0], 'r-')
-            self.plt[3].plot(self.theta, PAD(self.theta, self.beta[0][0], self.amp[0][0]), 'b-', lw=2)
-            self.plt[3].annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(*self.rmx+self.beta[0]), (-3, self.intensity[0].min()/0.8))
+            self.plt[3].plot(self.theta, PAD(self.theta, self.beta[0][0],
+                             self.amp[0][0]), 'b-', lw=2)
+            self.plt[3].annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".
+             format(*self.rmx+self.beta[0]), (-3, self.intensity[0].min()/0.8))
             self.plt[3].set_title("anisotropy", fontsize=12)
             self.plt[3].set_xlabel("angle", fontsize=9)
             self.plt[3].set_ylabel("intensity")

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -8,12 +8,14 @@ import abel
 import sys
 if sys.version_info[0] < 3:
     import Tkinter as tk
+    from tkFileDialog import askopenfilename
 else:
     import tkinter as tk
-from tkFileDialog import askopenfilename
-import ttk
-import tkFont
-from ScrolledText import *
+    from tkinter.filedialog import askopenfilename
+import tkinter.ttk as ttk
+import tkinter.font as tkFont
+from tkinter.scrolledtext import *
+#from ScrolledText import *
 
 import matplotlib
 matplotlib.use('TkAgg')
@@ -415,7 +417,7 @@ class PyAbel:  #(tk.Tk):
         self.plt[1].set_xlabel("radius (pixels)", fontsize=9)
         self.plt[1].set_ylabel("normalized intensity")
         self.plt[1].set_title("radial speed distribution", fontsize=12)
-        self.plt[1].legend(fontsize=9)
+        self.plt[1].legend(fontsize=9, loc=0, frameon=False)
 
         self.action = None
         self.canvas.show()
@@ -450,21 +452,18 @@ class PyAbel:  #(tk.Tk):
         self._transform()
     
         # intensity vs angle
-        self.intensity, self.theta, self.rad  = abel.tools.vmi.\
-                                     radial_integration(self.AIM.transform,\
-                                     radial_ranges=[self.rmx,])
+        self.beta, self.amp, self.rad, self.intensity, self.theta =\
+           abel.tools.vmi.radial_integration(self.AIM.transform,\
+                                             radial_ranges=[self.rmx,])
     
-        # fit to P2(cos theta)
-        self.beta, self.amp = abel.tools.vmi.anisotropy_parameter(self.theta, self.intensity[0])
-    
-        self.text.insert(tk.END," beta = {:g}+-{:g}".format(*self.beta))
+        self.text.insert(tk.END," beta = {:g}+-{:g}".format(*self.beta[0]))
     
         self._clr_plt(3)
         self.plt[3].axis("on")
         
         self.plt[3].plot(self.theta, self.intensity[0], 'r-')
-        self.plt[3].plot(self.theta, PAD(self.theta, self.beta[0], self.amp[0]), 'b-', lw=2)
-        self.plt[3].annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(*self.rmx+self.beta), (-np.pi/2,-2))
+        self.plt[3].plot(self.theta, PAD(self.theta, self.beta[0][0], self.amp[0][0]), 'b-', lw=2)
+        self.plt[3].annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(*self.rmx+self.beta[0]), (-2.5, self.intensity[0].max()/0.8))
         self.plt[3].set_title("anisotropy", fontsize=12)
         self.plt[3].set_xlabel("angle", fontsize=9)
         self.plt[3].set_ylabel("intensity")

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -49,7 +49,7 @@ class PyAbel:  #(tk.Tk):
         self.rmx = (368, 393)
 
         # matplotlib figure
-        self.f = Figure(figsize=(2, 8))
+        self.f = Figure(figsize=(2, 6))
         self.gs = gridspec.GridSpec(2, 2, width_ratios=[1, 2])
         self.gs.update(wspace=0.2, hspace=0.2)
 
@@ -379,17 +379,16 @@ class PyAbel:  #(tk.Tk):
             # Abel transform of whole image
             self.text.insert(tk.END,"\n{:s} {:s} Abel transform:".\
                              format(self.method, self.fi))
-            if "basex" in self.method:
+            if self.method == "basex":
                 self.text.insert(tk.END,
                               "\nbasex: first time calculation of the basis"
                               " functions may take a while ...")
-            if "direct" in self.method:
-               self.text.insert(tk.END,"\ndirect: calculation is slowed if Cython"
-                                       " unavailable ...")
+            elif self.method == "direct":
+               self.text.insert(tk.END,
+                 "\ndirect: calculation is slowed if Cython unavailable ...")
             self.canvas.show()
     
             if self.method == 'linbasex':
-
                 self.AIM = abel.Transform(self.IM, method=self.method, 
                                 direction=self.fi,
                                 transform_options=dict(return_Beta=True))

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -155,20 +155,20 @@ class PyAbel:  #(tk.Tk):
         # column 0 ---------
         # load image file button
         self.load = tk.Button(master=self.button_frame, text="load image",
-                              font=self.fontB,
+                              font=self.fontB, fg="dark blue",
                               command=self._loadimage)
         self.load.grid(row=0, column=0, sticky=tk.W, padx=(5, 10), pady=(5, 0))
         self.sample_image = ttk.Combobox(master=self.button_frame,
                          font=self.font,
                          values=["from file", "from transform",
                                  "sample dribinski", "sample Ominus"],
-                         width=10, height=4)
+                         width=14, height=4)
         self.sample_image.current(0)
         self.sample_image.grid(row=1, column=0, padx=(5, 10))
 
         # quit
-        self.quit = tk.Button(master=self.button_frame, text="quit",
-                              font=self.fontB,
+        self.quit = tk.Button(master=self.button_frame, text="Quit",
+                              font=self.fontB, fg="dark red",
                               command=self._quit)
         self.quit.grid(row=3, column=0, sticky=tk.W, padx=(5, 10), pady=(0, 5))
    
@@ -176,7 +176,7 @@ class PyAbel:  #(tk.Tk):
         # center image
         self.center = tk.Button(master=self.button_frame, text="center image",
                                 anchor=tk.W, 
-                                font=self.fontB,
+                                font=self.fontB, fg="dark blue",
                                 command=self._center)
         self.center.grid(row=0, column=1, padx=(0, 20), pady=(5, 0))
         self.center_method = ttk.Combobox(master=self.button_frame,
@@ -190,7 +190,7 @@ class PyAbel:  #(tk.Tk):
         # Abel transform image
         self.recond = tk.Button(master=self.button_frame,
                                 text="Abel transform image",
-                                font=self.fontB,
+                                font=self.fontB, fg="dark blue",
                                 command=self._transform)
         self.recond.grid(row=0, column=2, padx=(0, 10), pady=(5, 0))
 
@@ -212,7 +212,7 @@ class PyAbel:  #(tk.Tk):
         # column 3 -----------
         # speed button
         self.speed = tk.Button(master=self.button_frame, text="speed",
-                               font=self.fontB,
+                               font=self.fontB, fg="dark blue",
                                command=self._speed)
         self.speed.grid(row=0, column=5, padx=20, pady=(5, 0))
         
@@ -223,7 +223,7 @@ class PyAbel:  #(tk.Tk):
         # column 4 -----------
         # anisotropy button
         self.aniso = tk.Button(master=self.button_frame, text="anisotropy",
-                               font=self.fontB,
+                               font=self.fontB, fg="dark blue",
                                command=self._anisotropy)
         self.aniso.grid(row=0, column=6, pady=(5, 0))
 
@@ -246,20 +246,26 @@ class PyAbel:  #(tk.Tk):
         # turn off button interface
         self.hide_buttons = tk.Button(master=self.button_frame,
                                       text="hide buttons",
-                                      font=self.fontB,
+                                      font=self.fontB, fg='grey',
                                       command=self._hide_buttons)
         self.hide_buttons.grid(row=3, column=6, sticky=tk.E, pady=(0, 20))
 
     def _text_info_box(self):
         # text info box ---------------------
-        self.text = ScrolledText(master=self.button_frame, height=4, 
+        self.text = ScrolledText(master=self.button_frame, height=6, 
                             fg="mediumblue",
                             bd=1, relief=tk.SUNKEN)
         self.text.insert(tk.END, "Work in progress, some features may"
-                         " be incomplete\n\n")
-        self.text.insert(tk.END, "To start load an image data file using"
-                         " 'load image' button (or file menu)\n")
-        self.text.insert(tk.END, "e.g. data/O2-ANU1024.txt.bz2\n")
+                         " be incomplete ...\n")
+        self.text.insert(tk.END, "To start: load an image data file using"
+                         " e.g. data/O2-ANU1024.txt.bz2\n"
+                         " '(1) load image' button (or file menu)\n"
+                         " '(2) center image'\n"
+                         " '(3) Abel transform'\n"
+                         " '(4) speed'\n"
+                         " '(5) anisotropy'\n"
+                         " '(6) Abel transform <- change'\n"
+                         " '(:) repeat'\n")
         self.text.grid(row=3, column=1, columnspan=3, padx=5)
 
 

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -57,7 +57,8 @@ for rr, intensity in zip(r_range, intensities):
     # evaluate anisotropy parameter from least-squares fit to
     # intensity vs angle
     beta, amp = abel.tools.vmi.anisotropy_parameter(theta, intensity)
-    result = "    {:3d}-{:3d}        {:+.2f}+-{:.2f}".format(*rr+beta)
+    result = "    {:3d}-{:3d}        {:+.2f}+-{:.2f}"\
+             .format(rr[0], rr[1], beta[0], beta[1])
     print(result)
 
 # plots of the analysis

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -50,13 +50,10 @@ r_range = [(93, 111), (145, 162), (255, 280), (330, 350), (350, 370),
            (370, 390), (390, 410), (410, 430)]
 
 # map to intensity vs theta for each radial range
-intensities, theta, rad = abel.tools.vmi.radial_integration(AIM, radial_ranges=r_range)
+Beta, Amp, rad,intensities, theta = abel.tools.vmi.radial_integration(AIM, radial_ranges=r_range)
 
 print("radial-range      anisotropy parameter (beta)")
-for rr, intensity in zip(r_range, intensities):
-    # evaluate anisotropy parameter from least-squares fit to
-    # intensity vs angle
-    beta, amp = abel.tools.vmi.anisotropy_parameter(theta, intensity)
+for beta, rr in zip(Beta, r_range):
     result = "    {:3d}-{:3d}        {:+.2f}+-{:.2f}"\
              .format(rr[0], rr[1], beta[0], beta[1])
     print(result)
@@ -73,7 +70,7 @@ AIM *= vmax/AIM[:, c2+100:].max()
 JIM = np.concatenate((IM[:, :c2], AIM[:, c2:]), axis=1)
 rr = r_range[-3]
 intensity = intensities[-3]
-beta, amp = abel.tools.vmi.anisotropy_parameter(theta, intensity) 
+beta, amp = Beta[-3], Amp[-3]
 
 # Prettify the plot a little bit:
 # Plot the raw data

--- a/examples/example_PAD.py
+++ b/examples/example_PAD.py
@@ -8,6 +8,10 @@ import abel
 
 import matplotlib.pylab as plt
 
+# Demonstration of two techniques to determine the anisotropy parameter
+# (a) directly, using `linbasex`
+# (b) from the inverse Abel transformed image
+
 # Load image as a numpy array - numpy handles .gz, .bz2
 IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
 # use scipy.misc.imread(filename) to load image formats (.png, .jpg, etc)
@@ -33,6 +37,7 @@ LIM = abel.Transform(IM, method='linbasex', center='slice',
 HIM = abel.Transform(IM, center="slice", method="hansenlaw",
                      symmetry_axis=None, angular_integration=True)
 
+# speed distribution
 radial, speed = HIM.angular_integration
 
 # normalize to max intensity peak

--- a/examples/example_PAD.py
+++ b/examples/example_PAD.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+import abel
+
+import matplotlib.pylab as plt
+
+# Load image as a numpy array - numpy handles .gz, .bz2 
+IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
+# use scipy.misc.imread(filename) to load image formats (.png, .jpg, etc)
+
+# Hansen & Law inverse Abel transform
+AIM = abel.Transform(IM, center="slice", method="hansenlaw",
+                     symmetry_axis=None).transform
+
+# PES - photoelectron speed distribution  -------------
+print('Calculating speed distribution:')
+
+r, speed  = abel.tools.vmi.angular_integration(AIM)
+
+# normalize to max intensity peak
+speed /= speed[200:].max()  # exclude transform noise near centerline of image
+
+# PAD - photoelectron angular distribution  ------------
+# radial ranges (of spectral features) to follow intensity vs angle
+# view the speed distribution to determine radial ranges
+r_range = [(93, 111), (145, 162), (255, 280), (330, 350), (350, 370), 
+           (370, 390), (390, 410), (410, 430)]
+
+# anisotropy parameter for each tuple r_range
+Beta, Amp, R = abel.tools.vmi.anisotropy(AIM, r_range)
+
+# OR  anisotropy parameter for ranges (0, 20), (20, 40) ...
+Br, Ar, Rr = abel.tools.vmi.anisotropy(AIM, 20)
+
+# plots of the analysis
+fig = plt.figure(figsize=(8, 4))
+ax1 = plt.subplot(121)
+ax2 = plt.subplot(122)
+
+# join 1/2 raw data : 1/2 inversion image
+rows, cols = IM.shape
+c2 = cols//2
+vmax = IM[:, :c2-100].max()
+AIM *= vmax/AIM[:, c2+100:].max()
+JIM = np.concatenate((IM[:, :c2], AIM[:, c2:]), axis=1)
+
+# Prettify the plot a little bit:
+# Plot the raw data
+im1 = ax1.imshow(JIM, origin='lower', aspect='auto', vmin=0, vmax=vmax)
+fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
+ax1.set_xlabel('x (pixels)')
+ax1.set_ylabel('y (pixels)')
+ax1.set_title('VMI, inverse Abel: {:d}x{:d}'\
+              .format(rows, cols))
+
+# Plot the 1D speed distribution
+ax2.plot(speed, label='speed')
+BT = np.transpose(Beta)
+ax2.errorbar(R, BT[0], BT[1], fmt='o', color='r', label='specific radii')
+BrT = np.transpose(Br)
+ax2.plot(Rr, BrT[0], '-g', label='stepped')
+ax2.axis(xmax=450, ymin=-1.2, ymax=1.2)
+ax2.set_xlabel('radial pixel')
+ax2.set_ylabel('speed/anisotropy')
+ax2.set_title('speed/anisotropy distribution')
+ax2.legend(frameon=False, labelspacing=0.1, numpoints=1, loc=3, fontsize='small')
+
+plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89, 
+                    wspace=0.35, hspace=0.37)
+
+# Save a image of the plot
+plt.savefig("example_PAD.png", dpi=100)
+
+# Show the plots
+plt.show()

--- a/examples/example_PAD.py
+++ b/examples/example_PAD.py
@@ -8,17 +8,17 @@ import abel
 
 import matplotlib.pylab as plt
 
-# Load image as a numpy array - numpy handles .gz, .bz2 
+# Load image as a numpy array - numpy handles .gz, .bz2
 IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
 # use scipy.misc.imread(filename) to load image formats (.png, .jpg, etc)
 
-#=== linbasex transform ===================================
+# === linbasex transform ===================================
 legendre_orders = [0, 2, 4]  # Legendre polynomial orders
 proj_angles = range(0, 180, 10)  # projection angles in 10 degree steps
 radial_step = 1  # pixel grid
 smoothing = 1  # smoothing 1/e-width for Gaussian convolution smoothing
 threshold = 0.2  # threshold for normalization of higher order Newton spheres
-clip=0  # clip first vectors (smallest Newton spheres) to avoid singularities
+clip = 0  # clip first vectors (smallest Newton spheres) to avoid singularities
 
 # linbasex method - center and center_options ensure image has odd square shape
 LIM = abel.Transform(IM, method='linbasex', center='slice',
@@ -38,18 +38,23 @@ radial, speed = HIM.angular_integration
 # normalize to max intensity peak
 speed /= speed[200:].max()  # exclude transform noise near centerline of image
 
-# PAD - photoelectron angular distribution  ------------
+# PAD - photoelectron angular distribution from image ======================
+# Note: `linbasex` provides the anisotropy parameter directly LIM.Beta[1]
+#       here we extract I vs theta for given radial ranges
+#       and use fitting to determine the anisotropy parameter
+#
 # radial ranges (of spectral features) to follow intensity vs angle
 # view the speed distribution to determine radial ranges
-r_range = [(145, 162), (200, 218), (230, 250), (255, 280), (280, 310), 
+r_range = [(145, 162), (200, 218), (230, 250), (255, 280), (280, 310),
            (310, 330), (330, 350), (350, 370), (370, 390), (390, 410),
            (410, 430)]
 
-# anisotropy parameter for each tuple r_range
-Beta, Amp, R = abel.tools.vmi.anisotropy(HIM.transform, r_range)
+# anisotropy parameter from image for each tuple r_range
+Beta, Amp, Rmid, Ivstheta, theta =\
+              abel.tools.vmi.radial_integration(HIM.transform, r_range)
 
 # OR  anisotropy parameter for ranges (0, 20), (20, 40) ...
-#Beta_whole_grid, Amp_whole_grid, Radial_midpoints =\
+# Beta_whole_grid, Amp_whole_grid, Radial_midpoints =\
 #                         abel.tools.vmi.anisotropy(AIM.transform, 20)
 
 # plots of the analysis
@@ -70,22 +75,23 @@ im1 = ax1.imshow(JIM, origin='lower', aspect='auto', vmin=0, vmax=vmax)
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
 ax1.set_ylabel('y (pixels)')
-ax1.set_title('VMI, inverse Abel: {:d}x{:d}'\
-              .format(rows, cols))
+ax1.set_title('VMI, inverse Abel: {:d}x{:d}'.format(rows, cols))
 
 # Plot the 1D speed distribution
 ax2.plot(LIM.Beta[0], 'r-', label='linbasex-Beta[0]')
 ax2.plot(speed, 'b-', label='speed')
 ax2.plot(LIM.Beta[1], 'r-', label='linbasex-Beta[2]')
-ax2.errorbar(R, Beta[0], Beta[1], fmt='o', color='g', label='specific radii')
-#ax2.plot(Radial_midpoints, Beta_whole_grid[0], '-g', label='stepped')
+ax2.errorbar(Rmid, Beta[0], Beta[1], fmt='o', color='g',
+             label='specific radii')
+# ax2.plot(Radial_midpoints, Beta_whole_grid[0], '-g', label='stepped')
 ax2.axis(xmin=100, xmax=450, ymin=-1.2, ymax=1.2)
 ax2.set_xlabel('radial pixel')
 ax2.set_ylabel('speed/anisotropy')
 ax2.set_title('speed/anisotropy distribution')
-ax2.legend(frameon=False, labelspacing=0.1, numpoints=1, loc=3, fontsize='small')
+ax2.legend(frameon=False, labelspacing=0.1, numpoints=1, loc=3,
+           fontsize='small')
 
-plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89, 
+plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89,
                     wspace=0.35, hspace=0.37)
 
 # Save a image of the plot

--- a/examples/example_PAD.py
+++ b/examples/example_PAD.py
@@ -34,7 +34,8 @@ r_range = [(93, 111), (145, 162), (255, 280), (330, 350), (350, 370),
 Beta, Amp, R = abel.tools.vmi.anisotropy(AIM, r_range)
 
 # OR  anisotropy parameter for ranges (0, 20), (20, 40) ...
-Br, Ar, Rr = abel.tools.vmi.anisotropy(AIM, 20)
+Beta_whole_grid, Amp_whole_grid, Radial_midpoints =\
+                         abel.tools.vmi.anisotropy(AIM, 20)
 
 # plots of the analysis
 fig = plt.figure(figsize=(8, 4))
@@ -61,8 +62,8 @@ ax1.set_title('VMI, inverse Abel: {:d}x{:d}'\
 ax2.plot(speed, label='speed')
 BT = np.transpose(Beta)
 ax2.errorbar(R, BT[0], BT[1], fmt='o', color='r', label='specific radii')
-BrT = np.transpose(Br)
-ax2.plot(Rr, BrT[0], '-g', label='stepped')
+BrT = np.transpose(Beta_whole_grid)
+ax2.plot(Radial_midpoints, BrT[0], '-g', label='stepped')
 ax2.axis(xmax=450, ymin=-1.2, ymax=1.2)
 ax2.set_xlabel('radial pixel')
 ax2.set_ylabel('speed/anisotropy')

--- a/examples/example_PAD.py
+++ b/examples/example_PAD.py
@@ -86,7 +86,8 @@ ax1.set_title('VMI, inverse Abel: {:d}x{:d}'.format(rows, cols))
 ax2.plot(LIM.Beta[0], 'r-', label='linbasex-Beta[0]')
 ax2.plot(speed, 'b-', label='speed')
 ax2.plot(LIM.Beta[1], 'r-', label='linbasex-Beta[2]')
-ax2.errorbar(Rmid, Beta[0], Beta[1], fmt='o', color='g',
+BetaT = np.transpose(Beta)
+ax2.errorbar(Rmid, BetaT[0], BetaT[1], fmt='o', color='g',
              label='specific radii')
 # ax2.plot(Radial_midpoints, Beta_whole_grid[0], '-g', label='stepped')
 ax2.axis(xmin=100, xmax=450, ymin=-1.2, ymax=1.2)

--- a/examples/example_PAD.py
+++ b/examples/example_PAD.py
@@ -60,10 +60,8 @@ ax1.set_title('VMI, inverse Abel: {:d}x{:d}'\
 
 # Plot the 1D speed distribution
 ax2.plot(speed, label='speed')
-BT = np.transpose(Beta)
-ax2.errorbar(R, BT[0], BT[1], fmt='o', color='r', label='specific radii')
-BrT = np.transpose(Beta_whole_grid)
-ax2.plot(Radial_midpoints, BrT[0], '-g', label='stepped')
+ax2.errorbar(R, Beta[0], Beta[1], fmt='o', color='r', label='specific radii')
+ax2.plot(Radial_midpoints, Beta_whole_grid[0], '-g', label='stepped')
 ax2.axis(xmax=450, ymin=-1.2, ymax=1.2)
 ax2.set_xlabel('radial pixel')
 ax2.set_ylabel('speed/anisotropy')

--- a/examples/example_PAD.py
+++ b/examples/example_PAD.py
@@ -12,14 +12,28 @@ import matplotlib.pylab as plt
 IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
 # use scipy.misc.imread(filename) to load image formats (.png, .jpg, etc)
 
-# Hansen & Law inverse Abel transform
-AIM = abel.Transform(IM, center="slice", method="hansenlaw",
-                     symmetry_axis=None).transform
+#=== linbasex transform ===================================
+legendre_orders = [0, 2, 4]  # Legendre polynomial orders
+proj_angles = range(0, 180, 10)  # projection angles in 10 degree steps
+radial_step = 1  # pixel grid
+smoothing = 1  # smoothing 1/e-width for Gaussian convolution smoothing
+threshold = 0.2  # threshold for normalization of higher order Newton spheres
+clip=0  # clip first vectors (smallest Newton spheres) to avoid singularities
 
-# PES - photoelectron speed distribution  -------------
-print('Calculating speed distribution:')
+# linbasex method - center and center_options ensure image has odd square shape
+LIM = abel.Transform(IM, method='linbasex', center='slice',
+                     center_options=dict(square=True),
+                     transform_options=dict(basis_dir=None,
+                     proj_angles=proj_angles, radial_step=radial_step,
+                     smoothing=smoothing, threshold=threshold, clip=clip,
+                     return_Beta=True, verbose=True))
 
-r, speed  = abel.tools.vmi.angular_integration(AIM)
+
+# === Hansen & Law inverse Abel transform ==================
+HIM = abel.Transform(IM, center="slice", method="hansenlaw",
+                     symmetry_axis=None, angular_integration=True)
+
+radial, speed = HIM.angular_integration
 
 # normalize to max intensity peak
 speed /= speed[200:].max()  # exclude transform noise near centerline of image
@@ -27,15 +41,16 @@ speed /= speed[200:].max()  # exclude transform noise near centerline of image
 # PAD - photoelectron angular distribution  ------------
 # radial ranges (of spectral features) to follow intensity vs angle
 # view the speed distribution to determine radial ranges
-r_range = [(93, 111), (145, 162), (255, 280), (330, 350), (350, 370), 
-           (370, 390), (390, 410), (410, 430)]
+r_range = [(145, 162), (200, 218), (230, 250), (255, 280), (280, 310), 
+           (310, 330), (330, 350), (350, 370), (370, 390), (390, 410),
+           (410, 430)]
 
 # anisotropy parameter for each tuple r_range
-Beta, Amp, R = abel.tools.vmi.anisotropy(AIM, r_range)
+Beta, Amp, R = abel.tools.vmi.anisotropy(HIM.transform, r_range)
 
 # OR  anisotropy parameter for ranges (0, 20), (20, 40) ...
-Beta_whole_grid, Amp_whole_grid, Radial_midpoints =\
-                         abel.tools.vmi.anisotropy(AIM, 20)
+#Beta_whole_grid, Amp_whole_grid, Radial_midpoints =\
+#                         abel.tools.vmi.anisotropy(AIM.transform, 20)
 
 # plots of the analysis
 fig = plt.figure(figsize=(8, 4))
@@ -46,11 +61,11 @@ ax2 = plt.subplot(122)
 rows, cols = IM.shape
 c2 = cols//2
 vmax = IM[:, :c2-100].max()
+AIM = HIM.transform
 AIM *= vmax/AIM[:, c2+100:].max()
 JIM = np.concatenate((IM[:, :c2], AIM[:, c2:]), axis=1)
 
-# Prettify the plot a little bit:
-# Plot the raw data
+# Plot the image data VMI | inverse Abel
 im1 = ax1.imshow(JIM, origin='lower', aspect='auto', vmin=0, vmax=vmax)
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
@@ -59,10 +74,12 @@ ax1.set_title('VMI, inverse Abel: {:d}x{:d}'\
               .format(rows, cols))
 
 # Plot the 1D speed distribution
-ax2.plot(speed, label='speed')
-ax2.errorbar(R, Beta[0], Beta[1], fmt='o', color='r', label='specific radii')
-ax2.plot(Radial_midpoints, Beta_whole_grid[0], '-g', label='stepped')
-ax2.axis(xmax=450, ymin=-1.2, ymax=1.2)
+ax2.plot(LIM.Beta[0], 'r-', label='linbasex-Beta[0]')
+ax2.plot(speed, 'b-', label='speed')
+ax2.plot(LIM.Beta[1], 'r-', label='linbasex-Beta[2]')
+ax2.errorbar(R, Beta[0], Beta[1], fmt='o', color='g', label='specific radii')
+#ax2.plot(Radial_midpoints, Beta_whole_grid[0], '-g', label='stepped')
+ax2.axis(xmin=100, xmax=450, ymin=-1.2, ymax=1.2)
 ax2.set_xlabel('radial pixel')
 ax2.set_ylabel('speed/anisotropy')
 ax2.set_title('speed/anisotropy distribution')

--- a/examples/example_basex_photoelectron.py
+++ b/examples/example_basex_photoelectron.py
@@ -74,7 +74,7 @@ ax3.plot(*speeds)
 ax3.set_xlabel('Speed (pixel)')
 ax3.set_ylabel('Yield (log)')
 ax3.set_yscale('log')
-ax3.set_ylim(1e2,1e5)
+#ax3.set_ylim(1e2,1e5)
 
 # Prettify the plot a little bit:
 plt.subplots_adjust(left=0.06,bottom=0.17,right=0.95,top=0.89,wspace=0.35,hspace=0.37)

--- a/examples/example_dasch_methods.py
+++ b/examples/example_dasch_methods.py
@@ -48,6 +48,6 @@ for method in dasch_transform.keys():
 
 plt.title("Dasch methods for Dribinski sample image $n={:d}$".format(n))
 plt.axis(xmax=250, ymin=-0.1)
-plt.legend(loc=0)
+plt.legend(loc=0, frameon=False, labelspacing=0.1, fontsize='small')
 plt.savefig("example_dasch_methods.png",dpi=100)
 plt.show()

--- a/examples/example_linbasex_hansenlaw.py
+++ b/examples/example_linbasex_hansenlaw.py
@@ -28,19 +28,8 @@ HIM = abel.Transform(IM, method="hansenlaw", center='convolution',
 
 # alternative derivation of anisotropy parameters via integration
 rrange = [(20, 50), (60, 80), (85, 100), (125, 155), (185, 205), (220, 240)]
-intensity, theta, rr  = abel.tools.vmi.radial_integration(HIM.transform,
-                   radial_ranges=rrange)
-
-# anisotropy parameter from integrated intensity (from hansenlaw method)
-beta = []
-ebeta = []
-rr = []
-for i, inten in enumerate(intensity):
-    betax, amp = abel.tools.vmi.anisotropy_parameter(theta, inten)
-    ar = np.average(rrange[i])
-    beta.append(betax[0])
-    ebeta.append(betax[1])
-    rr.append(ar)
+Beta, Amp, rr, intensity, theta =\
+      abel.tools.vmi.radial_integration(HIM.transform, radial_ranges=rrange)
 
 plt.figure(figsize=(12, 6))
 ax0 = plt.subplot2grid((2,4), (0,0))
@@ -71,7 +60,8 @@ ax1.axis(ymin=-0.1, ymax=1.2)
 ax1.set_xlabel("radial coordinate (pixels)")
 
 ax2.plot(LIM.radial, LIM.Beta[1], 'r-', label='linbasex')
-ax2.errorbar(x=rr, y=beta, yerr=ebeta, color='b', lw=2, fmt='o',
+beta = np.transpose(Beta)
+ax2.errorbar(x=rr, y=beta[0], yerr=beta[1], color='b', lw=2, fmt='o',
              label='hansenlaw')
 ax2.set_title(r"$\beta$-parameter  (Beta2 norm)", fontsize=10)
 ax2.legend(loc=0, labelspacing=0.1, frameon=False, numpoints=1, fontsize=10)

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -156,28 +156,36 @@ def _anisotropy():
     def PAD(theta, beta, amp):
         return amp*(1 + beta*P2(np.cos(theta)))
 
-    # radial range over which to follow the intensity variation with angle
-    rmx = (int(rmin.get()), int(rmax.get()))
+    # inverse Abel transform
+    _transform()
+
+    method = transform.get()
+    if method != 'linbasex':
+        # radial range over which to follow the intensity variation with angle
+        rmx = (int(rmin.get()), int(rmax.get()))
+
+    else:
+        rmx = (0, AIM.radial[-1])
+
 
     text.delete(1.0, tk.END)
     text.insert(tk.END,"anisotropy parameter pixel range {:} to {:}\n".format(*rmx))
     canvas.show()
 
-    # inverse Abel transform
-    _transform()
-
     f.clf()
     a = f.add_subplot(111)
-    if transform.get not in ['linbasex']:
+    if method not in ['linbasex']:
         # intensity vs angle
         beta, amp, rad, intensity, theta =\
             abel.tools.vmi.radial_integration(AIM.transform, radial_ranges=[rmx,])
 
-        text.insert(tk.END,"beta = {:g}+-{:g}\n".format(*beta[0]))
+        beta = beta[0]
+        amp = amp[0]
+        text.insert(tk.END,"beta = {:g}+-{:g}\n".format(beta[0],beta[1]))
 
         a.plot(theta, intensity[0], 'r-')
-        a.plot(theta, PAD(theta, beta[0][0], amp[0][0]), 'b-', lw=2)
-        a.annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(*rmx+beta), (-np.pi/2,-2))
+        a.plot(theta, PAD(theta, beta[0], amp[0]), 'b-', lw=2)
+        a.annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(rmx[0], rmx[1],beta[0], beta[1]), (-np.pi/2,-2))
     else:
         beta = AIM.Beta[1]
         radial = AIM.radial
@@ -206,7 +214,7 @@ cent.current(3)
 cent.place(anchor=tk.W, relx=0.65, rely=0.05)
 
 # display raw input image
-tk.Button(master=root, text='raw image', command=_display).pack(anchor=tk.N)
+tk.Button(master=root, text='raw image', command=_display).pack(anchor=tk.W, padx=0.1)
 
 # Abel transform
 tk.Button(master=root, text='inverse Abel transform', command=_transform)\

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -12,10 +12,11 @@ from scipy.ndimage.interpolation import shift
 import sys
 if sys.version_info[0] < 3:
     import Tkinter as tk
+    from tkFileDialog import askopenfilename
 else:
     import tkinter as tk
-from tkFileDialog import askopenfilename
-import ttk
+    from tkinter.filedialog import askopenfilename
+import tkinter.ttk as ttk
 
 import matplotlib
 matplotlib.use('TkAgg')
@@ -24,7 +25,7 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg,\
 from matplotlib.figure import Figure
 from matplotlib.pyplot import imread
 
-Abel_methods = ['basex', 'direct', 'hansenlaw', 'onion_peeling', 
+Abel_methods = ['basex', 'direct', 'hansenlaw', 'linbasex', 'onion_peeling', 
                 'onion_bordas', 'two_point', 'three_point']
 
 # GUI window -------------------
@@ -154,18 +155,15 @@ def _anisotropy():
     _transform()
 
     # intensity vs angle
-    intensity, theta, rad = abel.tools.vmi.radial_integration(AIM,\
-                                                  radial_ranges=[rmx,])
+    beta, amp, rad, intensity, theta =\
+        abel.tools.vmi.radial_integration(AIM, radial_ranges=[rmx,])
 
-    # fit to P2(cos theta)
-    beta, amp = abel.tools.vmi.anisotropy_parameter(theta, intensity[0])
-
-    text.insert(tk.END,"beta = {:g}+-{:g}\n".format(*beta))
+    text.insert(tk.END,"beta = {:g}+-{:g}\n".format(*beta[0]))
 
     f.clf()
     a = f.add_subplot(111)
     a.plot(theta, intensity[0], 'r-')
-    a.plot(theta, PAD(theta, beta[0], amp[0]), 'b-', lw=2)
+    a.plot(theta, PAD(theta, beta[0][0], amp[0][0]), 'b-', lw=2)
     a.annotate("$\\beta({:d},{:d})={:.2g}\pm{:.2g}$".format(*rmx+beta), (-np.pi/2,-2))
     canvas.show()
 
@@ -202,11 +200,11 @@ tk.Button(master=root, text='speed distribution', command=_speed)\
 tk.Button(master=root, text='anisotropy parameter', command=_anisotropy)\
    .pack(anchor=tk.N)
 rmin = tk.Entry(master=root, text='rmin')
-rmin.place(anchor=tk.W, relx=0.66, rely=0.22, width=40)
+rmin.place(anchor=tk.W, relx=0.66, rely=0.20, width=40)
 rmin.insert(0, 368)
-tk.Label(master=root, text="to").place(relx=0.74, rely=0.20)
+tk.Label(master=root, text="to").place(relx=0.74, rely=0.18)
 rmax = tk.Entry(master=root, text='rmax')
-rmax.place(anchor=tk.W, relx=0.78, rely=0.22, width=40)
+rmax.place(anchor=tk.W, relx=0.78, rely=0.20, width=40)
 rmax.insert(0, 389)
 
 tk.Button(master=root, text='Quit', command=_quit).pack(anchor=tk.SW)


### PR DESCRIPTION
From issue #176. This is really @DanHickstein's baby, that I somehow hijacked.  It simply allows the determination of the anisotropy parameter for a radial grid, determined from @DanHickstein clever code [example](https://github.com/PyAbel/PyAbel/issues/176#issue-153615099):
```python
r = np.arange(0,300,2)
r_range = list(zip(r[:-1], r[1:]))
```
In this PR I have:
 1. Created new function `abel.tools.vmi.anisotropy()` to provide a single call to obtain the anisotropy parameter. Previously, 2 steps were required, one to evaluate intensity vs angle (for a given radial range) `abel.tools.vmi.radial_integration()`, the second to evaluate the anisotropy parameter from a fit to the intensity variation `abel.tools.vmi.anisotropy_parameter()`. See `examples/example_O2_PES_PAD.py`

 2. Modified `abel.tools.vmi.anisotropy_parameter()` to accept an array of intensity vs thetas
    previously this required a for loop to process the return arrays of `abel.tools.vmi.angular_integration()`. Again, see `examples/example_O2_PES_PAD.py`

 3. (Yet) another example  'example_PAD.py` demonstrating the new function calls
  Individual peaks (red points, with error bars in plot below):
     ```python
     r_range = [(93, 111), (145, 162), (255, 280), (330, 350), (350, 370),
           (370, 390), (390, 410), (410, 430)]

     # anisotropy parameter for each tuple r_range
      Beta, Amp, R = abel.tools.vmi.anisotropy(AIM, r_range)
    ```
    and the whole radial grid (to emulate `basex`/`linbasex`), (green line in plot below):
    ```python
    # OR  anisotropy parameter for ranges (0, 20), (20, 40) ...
    Br, Ar, Rr = abel.tools.vmi.anisotropy(AIM, 20)
    ```

![example_pad](https://cloud.githubusercontent.com/assets/10932229/16575486/ec3b1734-42cb-11e6-8ae4-7cc291de442e.png)

I am not 100% happy with the whole radial-grid output (green line in plot), I would prefer it to look like the output from `basex`/`linbasex`.  I guess  I should plot the anisotropy parameter outputs from `basex`/`linbasex` for comparison. 

Open for comment ...