### PR TITLE
FIX Cython extension not building on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,13 @@ init:
 
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  # Remove cygwin because it clashes with conda
+  # see http://help.appveyor.com/discussions/problems/3712-git-remote-https-seems-to-be-broken
+  - rmdir C:\\cygwin /s /q
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n abel-env python=%PYTHON_VERSION% numpy scipy nose cython==0.24.1 libpython"
+  - "conda create -q -n abel-env python=%PYTHON_VERSION% numpy scipy nose cython==0.24.1"
   - activate abel-env
   - pip install coverage
   - dir 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,18 +7,18 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
   matrix:
-      #- PYTHON_VERSION: 2.7
-      #- PYTHON_ARCH: "32"
-      #- MINICONDA: C:\Miniconda
-      #- PYTHON_VERSION: 2.7
-      #- PYTHON_ARCH: "64"
-      #- MINICONDA: C:\Miniconda-x64
-    - PYTHON_VERSION: 3.4
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda-x64
+    - PYTHON_VERSION: 3.5
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda3
-      #- PYTHON_VERSION: 3.4
-      #- PYTHON_ARCH: "64"
-      #- MINICONDA: C:\Miniconda3-x64
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
@@ -28,7 +28,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n abel-env python=%PYTHON_VERSION% numpy scipy nose cython libpython"
+  - "conda create -q -n abel-env python=%PYTHON_VERSION% numpy scipy nose cython==0.24.1 libpython"
   - activate abel-env
   - pip install coverage
   - dir 

--- a/setup.py
+++ b/setup.py
@@ -51,15 +51,10 @@ else:
 
 
 if sys.platform != 'win32':
-    compile_args = dict( extra_compile_args=['-O2', '-march=native',
-                                             '-Wno-unused-function',
-                                             '-Wno-unneeded-internal-declaration',
-                                             '-Wno-#warnings'],
+    compile_args = dict( extra_compile_args=['-O2', '-march=native'],
                              extra_link_args=['-O2', '-march=native'])
 else:
-    compile_args = dict( extra_compile_args=['-Wunused-function',
-                                              '-Wunneeded-internal-declaration',
-                                              '-Wno-#warnings'])
+    compile_args = dict( extra_compile_args=[])
 
 # Optional compilation of Cython modules adapted from
 # https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post


### PR DESCRIPTION
This PR fixes issue #183 (and possibly #125, if that was still an issue) with the compilation on Windows. All windows builds are tested again, which takes some time with appveyor but is probably safer.

The solution was to remove the `libpython` (mingw compiler) from the list of installed packages so that the already present Visual Studio compiler gets used. 

Also removing all flags to hide warnings (as those might actually be useful),  reverting to the default flags. 