### PR TITLE
fix for readthedocs build fail: memory requirements of example_linbasex.py

### DIFF
--- a/examples/example_linbasex.py
+++ b/examples/example_linbasex.py
@@ -16,7 +16,7 @@ import matplotlib.pylab as plt
 
 # Load image as a numpy array - numpy handles .gz, .bz2 
 IM = np.loadtxt("data/O2-ANU1024.txt.bz2")
-if os.environ.get('READTHEDOCS', None) == True:
+if os.environ.get('READTHEDOCS', None) == 'True':
     IM = IM[::2,::2]
 # the [::2, ::2] reduces the image size x1/2, decreasing processing memory load
 # for the online readthedocs.org


### PR DESCRIPTION
@DanHickstein [synopsis](https://github.com/PyAbel/PyAbel/pull/195#issuecomment-282856378) of `readthedocs` build failure for PR #195 :

The docs failed to build on readthedocs again: https://readthedocs.org/projects/pyabel/builds/5081882/

Same issue with memory on the example_linbasex.py.

We need to change line 19 from
```python
if os.environ.get('READTHEDOCS', None) == True:
```
to
```python
os.environ.get('READTHEDOCS', None) == 'True'
```
(The os.environ.get returns a string instead of a Boolean, apparently. Tricky.)