### PR TITLE
linbasex: remove the basis calculation

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -54,8 +54,7 @@ class AbelTiming(object):
             'direct_Python': direct.direct_transform,
             'direct_C': direct.direct_transform,
             'hansenlaw': hansenlaw.hansenlaw_transform,
-            'linbasex': linbasex._linbasex_transform_with_basis,
-            'linbasex_bs': linbasex._bs_linbasex,
+            'linbasex': linbasex.linbasex_transform,
             'onion_bordas': onion_bordas.onion_bordas_transform,
             'onion_peeling': dasch.dasch_transform,
             'onion_peeling_bs': dasch._bs_onion_peeling,
@@ -67,7 +66,7 @@ class AbelTiming(object):
 
         # result dicts
         res = {}
-        res['bs'] = {'basex_bs': [], 'linbasex_bs': [], 'onion_peeling_bs': [], 
+        res['bs'] = {'basex_bs': [], 'onion_peeling_bs': [], 
                      'two_point_bs': [], 'three_point_bs': []}
         res['forward'] = {'direct_Python': [], 'hansenlaw': []}
         res['inverse'] = {'basex': [], 'direct_Python': [], 'hansenlaw': [],

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -177,12 +177,10 @@ def linbasex_transform_full(IM, proj_angles=[0, np.pi/2],
         raise ValueError('image has shape ({}, {}), '.format(rows, cols) +
                          'must be square for a "linbasex" transform')
 
-    # generate basis or read from file if available
-    Basis = abel.tools.basis.get_bs_cached("linbasex", cols,
-                  basis_dir=basis_dir,
-                  basis_options=dict(proj_angles=proj_angles,
-                  legendre_orders=legendre_orders, radial_step=radial_step,
-                  clip=clip, verbose=verbose))
+    # generate basis
+    Basis =  _bs_linbasex(cols, proj_angles=proj_angles,
+                          legendre_orders=legendre_orders,
+                          radial_step=radial_step, clip=clip)
 
     return _linbasex_transform_with_basis(IM, Basis, proj_angles=proj_angles,
                                     legendre_orders=legendre_orders,

--- a/abel/tests/test_linbasex.py
+++ b/abel/tests/test_linbasex.py
@@ -16,7 +16,7 @@ def test_linbasex_shape():
     n = 21
     x = np.ones((n, n), dtype='float32')
 
-    recon = abel.linbasex.linbasex_transform_full(x, basis_dir=None)
+    recon = abel.linbasex.linbasex_transform_full(x)
 
     assert recon[0].shape == (n+1, n+1)   # NB shape+1
 

--- a/abel/tools/basis.py
+++ b/abel/tools/basis.py
@@ -14,21 +14,14 @@ def get_bs_cached(method, cols, basis_dir='.', basis_options=dict(),
 
     Checks whether file ``{method}_basis_{cols}_{cols}*.npy`` is present in 
     `basis_dir` 
-    (*) special case for ``linbasex``
-         _{legendre_orders}_{proj_angles}_{radial_step}_{clip} 
-        where {legendre_orders} = str of the list elements, typically '02'
-              (proj_angles} = str of the list elements, typically '04590135'
-              {radial_step} = pixel grid size, usually 1
-              {clip} = clipping size, usually 0
 
     Either, read basis array or generate basis, saving it to the file.
-        
 
     Parameters
     ----------
     method : str
-        Abel transform method, currently ``linbasex``, ``onion_peeling``,
-        ``three_point``, and ``two_point``
+        Abel transform method, currently ``onion_peeling``, ``three_point``,
+        and ``two_point``
     cols : int
         width of image
     basis_dir : str
@@ -43,12 +36,10 @@ def get_bs_cached(method, cols, basis_dir='.', basis_options=dict(),
 
     file.npy: file
        saves basis to file name ``{method}_basis_{cols}_{cols}*.npy``
-       * == ``__{legendre_orders}_{proj_angles}_{radial_step}_{clip}`` for ``linbasex`` method
 
     """
 
     basis_generator = {
-        "linbasex": abel.linbasex._bs_linbasex,
         "onion_peeling": abel.dasch._bs_onion_peeling,
         "three_point": abel.dasch._bs_three_point,
         "two_point": abel.dasch._bs_two_point
@@ -59,30 +50,6 @@ def get_bs_cached(method, cols, basis_dir='.', basis_options=dict(),
                          .format(method))
 
     basis_name = "{}_basis_{}_{}".format(method, cols, cols)
-    # special case linbasex requires additional identifying parameters
-    # 
-    # linbasex_basis_cols_cols_02_090_0.npy
-    if method == "linbasex": 
-       # Fix Me! not a simple unique naming mechanism
-        for key in ['legendre_orders', 'proj_angles', 'radial_step', 'clip']:
-            if key in basis_options.keys():
-                if key == 'legendre_orders':
-                    value = ''.join(map(str, basis_options[key]))
-                elif key == 'proj_angles':
-                    # in radians, convert to % of pi
-                    proj_angles_fractpi =\
-                         np.array(basis_options['proj_angles'])*100/np.pi
-                    
-                    value = ''.join(map(str, proj_angles_fractpi.astype(int)))
-                else: 
-                    value = basis_options[key]
-            else:
-                # missing option, use defaults
-                default = {'legendre_orders':'02', 'proj_angles':'050', 'radial_step':1, 'clip':0}
-                value = default[key]
-
-            basis_name += "_{}".format(value)
-
     basis_name += ".npy"
 
     D = None

--- a/examples/example_linbasex.py
+++ b/examples/example_linbasex.py
@@ -36,7 +36,7 @@ clip = 0
 # linbasex inverse Abel transform
 LIM = abel.Transform(IM, method="linbasex", center="convolution",
                      center_options=dict(square=True),
-                     transform_options=dict(basis_dir=None, return_Beta=True,
+                     transform_options=dict(return_Beta=True,
                                             un=un, proj_angles=proj_angles,
                                             smoothing=smoothing,
                                             radial_step=radial_step, clip=clip,

--- a/examples/example_linbasex_hansenlaw.py
+++ b/examples/example_linbasex_hansenlaw.py
@@ -16,7 +16,7 @@ clip=0  # clip first vectors (smallest Newton spheres) to avoid singularities
 #                 - speed and anisotropy parameters evaluated by method
 LIM = abel.Transform(IM, method='linbasex', center='convolution',
                      center_options=dict(square=True),
-                     transform_options=dict(basis_dir=None,
+                     transform_options=dict(
                      proj_angles=proj_angles, radial_step=radial_step,
                      smoothing=smoothing, threshold=threshold, clip=clip, 
                      return_Beta=True, verbose=True))


### PR DESCRIPTION
 @DanHickstein  PyAbelPaper [#12](https://github.com/DanHickstein/PyAbelPaper/issues/12) (developer access only)
> In our benchmarks, the computation time for the Lin-BASEX transform is significantly longer than the      basis set generation time. So, this leads me to believe that Lin-BASEX is not a method that benefits from pre-computation

>[@stggh] Yes, in fact, it may be better to drop the pre-calculation altogether, since the "basis" changes with the slightest parameter change, generating very long filenames, more easily leading to error.


This PR removes the basis calculation from `linbasex`, which included the call to `Basis = abel.tools.basis.get_bs_cached()`, the `linbasex` specific code in `abel.tools.basis.py`, and the basis timing calculation in `benchmark.py`. 

Good call @DanHickstein,  goodbye to obnoxious/obscure  `linbasex` basis filenames `linbasex_basis_1023_1023_02_050_1_0.npy` etc

![plot_example_linbasex](https://user-images.githubusercontent.com/10932229/35304619-43c7c12c-00ea-11e8-9b3f-49cf83a3d3f6.png)


