### PR TITLE
Changing the benchmarks to operate on square whole images

### DIFF
--- a/abel/basex.py
+++ b/abel/basex.py
@@ -148,7 +148,7 @@ def basex_core_transform(rawdata, M_vert, M_horz, Mc_vert,
     Parameters
     ----------
     rawdata : NxM numpy array
-        the raw image.
+        the raw image. This is the full image, both left and right sides.
     M_vert_etc. : Numpy arrays
         2D arrays given by the basis set calculation function
     dr : float

--- a/abel/dasch.py
+++ b/abel/dasch.py
@@ -80,7 +80,7 @@ onion_peeling_transform.__doc__ =\
 
 def _dasch_transform(IM, basis_dir='.', dr=1, direction="inverse", 
                      method="three_point"):
-
+    
     if direction != 'inverse':
         raise ValueError('Forward "two_point" transform not implemented')
 


### PR DESCRIPTION
As discussed in https://github.com/PyAbel/PyAbel/issues/207, I think that it makes the most sense for the benchmarks to operate on square whole-images that possess left/right symmetry. Prior to this PR, `abel.benchmark.AbelTiming(n=[101])` completes a 101x101 transform, which actually corresponds to a transform of a left/right symmetric 101x201 image.

This PR changes that behavior, and completes a transform on the 101x51 half-image. It should make most of the benchmarks faster, since they are operating on a smaller image. BASEX and LinBasex operate on whole images, so they are passed the complete image and maintain their previous benchmark speeds. 