### PR TITLE
Fixed the grid for the direct method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,40 @@ Documentation
 General information about the various Abel transforms available in PyAbel is available at the links above. The complete documentation for all of the methods in PyAbel is hosted at https://pyabel.readthedocs.io.
 
 
+Conventions
+-----------
+
+The PyAbel code adheres to the following conventions:
+
+- 
+    **Image orientation:** PyAbel adopts the "television" convention, where ``IM[0,0]`` refers to the **upper** left corner of the image. (This means that ``plt.imshow(IM)`` should display the image in the proper orientation, without the need to use the ``origin='lower'`` keyword.) As an example, the x,y-grid for a 5x5 image can be generated using:
+
+    .. code-block:: python
+
+        x = np.linspace(-2,2,5)
+        X,Y = np.meshgrid(x, -x) # notice the minus sign in front of the y-coordinate
+    
+- 
+    **Angle:** All angles in PyAbel are measured in radians. When an absolute angle is defined, zero-angle corresponds to the upwards, vertical direction. Positive values are on the right side, and negative values on the left side. The range of angles is from -Pi to +Pi. The polar grid for a 5x5 image can be generated (following the code above) using:
+
+    .. code-block:: python
+
+        R = np.sqrt(X**2 + Y**2)
+        THETA = np.arctan2(X, Y)
+
+
+    where the usual ``(Y, X)`` convention of ``arctan2`` has been reversed in order to place zero-angle in the vertical direction. Consequently, to convert the angular grid back to the Cartesian grid, we use:
+  
+    .. code-block:: python
+
+        X = R*np.sin(THETA)
+        Y = R*np.cos(THETA)
+    
+
+- 
+    **Image center:** Fundamentally, the Abel and inverse-Abel transforms in PyAbel consider the center of the image to be located in the center of a pixel. This means that, for a symmetric image, the image will have a width that is an odd number of pixels. (The center pixel is effectively "shared" between both halves of the image.) In most situations, the center is specified using the ``center`` keyword in ``abel.Transform`` (or directly using ``abel.center.center_image`` to find the true center of your image. This processing step takes care of locating the center of the image in the middle of the central pixel. However, if the individual Abel transforms methods are used directly, care must be taken to supply a properly centered image.
+
+
 Support
 -------
 If you have a question or suggestion about PyAbel, the best way to contact the PyAbel Developers Team is to `open a new issue <https://github.com/PyAbel/PyAbel/issues>`_.

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -218,7 +218,7 @@ def _pyabel_direct_integral(f, r, correction, int_func=np.trapz):
         f_r = (f[:, 1:] - f[:, :-1])/np.diff(r)[None, :]
         isqrt = I_sqrt[II+1 == JJ]
 
-        if np.isclose(r[0], 0):  # special case for r[0] = 0
+        if r[0]<(r[1]*1e-8):  # special case for r[0] = 0
             ratio = np.append(np.cosh(1), r[2:]/r[1:-1])
         else:
             ratio = r[1:]/r[:-1]

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -18,12 +18,11 @@ except (ImportError, UnicodeDecodeError):
 # numerical integration
 #
 # Roman Yurchak - Laboratoire LULI, Ecole Polytechnique/CNRS/CEA, France
-#
-# 01.2018: Changed the integration method to trapz
-# 12.2015: Added a pure python implementation following a dissuasion
-#                                                     with Dan Hickstein
-# 11.2015: Moved to PyAbel, added more unit tests, reorganized code base
-#    2012: First implementation in hedp.math.abel
+# 03.2018: DH changed the default grid from 0.5, 1.5 ... to 0, 1, 2.
+# 01.2018: DH dhanged the integration method to trapz
+# 12.2015: RY Added a pure python implementation
+# 11.2015: RY moved to PyAbel, added more unit tests, reorganized code base
+#    2012: RY first implementation in hedp.math.abel
 ###########################################################################
 
 
@@ -42,13 +41,13 @@ def _construct_r_grid(n, dr=None, r=None):
             raise ValueError('The input parameter r should be a 1D array'
                              'of shape = ({},), got shape = {}'.format(
                                                                 n, r.shape))
-        # not so sure about this, needs verification
+        # not so sure about this, needs verification -RY
         dr = np.gradient(r)
 
     else:
         if isinstance(dr, np.ndarray):
             raise NotImplementedError
-        r = (np.arange(n) + 0.5)*dr
+        r = (np.arange(n))*dr
     return r, dr
 
 

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -48,6 +48,7 @@ def _construct_r_grid(n, dr=None, r=None):
         if isinstance(dr, np.ndarray):
             raise NotImplementedError
         r = (np.arange(n))*dr
+        r[0] = 1e-16 # avoids returning np.nan
     return r, dr
 
 

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -179,7 +179,6 @@ def _pyabel_direct_integral(f, r, correction, int_func=np.trapz):
     else:
         int_opts = {'x': r}
 
-    N1 = f.shape[1]
     out = np.zeros(f.shape)
     R, Y = np.meshgrid(r, r, indexing='ij')
 

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -124,11 +124,7 @@ def direct_transform(fr, dr=None, r=None, direction='inverse',
     r, dr = _construct_r_grid(f.shape[1], dr=dr, r=r)
 
     if direction == "inverse":
-        # a derivative function must be provided
-        f = derivative(f)/dr
-        # setting the derivative at the origin to 0
-        # f[:,0] = 0
-    if direction == "inverse":
+        f = derivative(f)/dr 
         f *= - 1./np.pi
     else:
         f *= 2*r[None, :]
@@ -209,28 +205,28 @@ def _pyabel_direct_integral(f, r, correction, int_func=np.trapz):
 
 
     """
-    Compute the correction
-    Pre-calculated analytical integration of the cell with the singular value
-    Assuming a piecewise linear behaviour of the data
+    Compute the correction. Here we apply an
+    analytical integration of the cell with the singular value,
+    assuming a piecewise linear behaviour of the data.
+    The analytical abel transform for this trapezoid is:
     c0*acosh(r1/y) - c_r*y*acosh(r1/y) + c_r*sqrt(r1**2 - y**2)
+    see: https://github.com/luli/hedp/blob/master/hedp/math/abel.py#L87-L104
     """
     if correction == 1:
-        # computing forward derivative of the data
-        f_r = (f[:, 1:] - f[:, :N1-1])/np.diff(r)[None, :]
+
+        # precompute a few variables outside the loop:
+        f_r = (f[:, 1:] - f[:, :-1])/np.diff(r)[None, :]
+        isqrt = I_sqrt[II+1 == JJ]
+
+        if np.isclose(r[0], 0):  # special case for r[0] = 0
+            ratio = np.append(np.cosh(1), r[2:]/r[1:-1])
+        else:
+            ratio = r[1:]/r[:-1]
+        
+        acr = np.arccosh(ratio)
 
         for i, row in enumerate(f):  # loop over rows (z)
-            corr  = I_sqrt[II+1 == JJ]*f_r[i] \
-                    + np.arccosh(r[1:]/r[:-1])*(row[:-1] - f_r[i]*r[:-1])
-
-            
-            if np.isclose(r[0], 0):  # special case for r[0] = 0 
-                corr0 = I_sqrt[II+1 == JJ][0]*f_r[i,0] \
-                        + (row[0] - f_r[i,0]*r[0])
-                out[i, 1:-1] += corr[1:]
-                out[i, 0]    += corr0 
-            else:
-                out[i, :-1] = corr
-            
+            out[i, :-1] += isqrt*f_r[i] + acr*(row[:-1] - f_r[i]*r[:-1])
 
     return out
 

--- a/abel/lib/direct.pyx
+++ b/abel/lib/direct.pyx
@@ -75,8 +75,13 @@ cpdef _cabel_direct_integral(double [:, ::1] f, double [::1] r, int correction):
                    # Integration of the cell with the singular value
                    # Assuming a piecewise linear behaviour of the data
                    # c0*acosh(r1/y) - c_r*y*acosh(r1/y) + c_r*sqrt(r1**2 - y**2)
-                   s = s + I_sqrt[j,j+1]*f_r[i,j] \
-                           + acosh(r[j+1]/r[j])*(f[i,j] - f_r[i,j]*r[j])
+                   
+                   if j == 0 and r[0]<(1e-8*r[1]):
+                       s = s + I_sqrt[j,j+1]*f_r[i,j] \
+                               + 1*(f[i,j] - f_r[i,j]*r[j])
+                   else:
+                       s = s + I_sqrt[j,j+1]*f_r[i,j] \
+                               + acosh(r[j+1]/r[j])*(f[i,j] - f_r[i,j]*r[j])
 
                 out[i,j] = s
 


### PR DESCRIPTION
As discussed in #213 (which followed from our discussion in #211), we decided that the `direct` method was using a "even" grid (`[0.5, 1.5, 2.5, ...]`). I switched one line so that it now operates on an "odd" grid (`[0, 1.0, 2.0, ...]`). 

I also cleaned up a few lines of comments towards the top of `direct.py`.