### PR TITLE
BASEX improvements

### DIFF
--- a/abel/basex.py
+++ b/abel/basex.py
@@ -71,7 +71,7 @@ def basex_transform(data, nbf='auto', reg=0.0, bs_correction=False,
                     verbose=True, direction='inverse'):
     """
     This function performs the BASEX (BAsis Set EXpansion)
-    Abel Transform. It works on a "right side" image. I.e.,
+    Abel transform. It works on a "right side" image. I.e.,
     it works on just half of a cylindrically symmetric
     object, and ``data[0,0]`` should correspond to a central pixel.
     To perform a BASEX transorm on
@@ -384,6 +384,30 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
         _Ai = Ai
 
     return Ai
+
+
+def basex_cleanup():
+    """
+    Utility function.
+
+    Frees the memory caches created by ``get_bs_basex_cached()``.
+    This is usually pointless, but might be required after working
+    with very large images, if more RAM is needed for further tasks.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+    """
+    global _prm, _M, _reg, _Ai
+
+    _prm = None
+    _M = None
+    _reg = None
+    _Ai = None
 
 
 MAX_BASIS_SET_OFFSET = 4000

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -16,8 +16,6 @@ import sys
 import numpy as np
 from scipy.special import gammaln
 from scipy.linalg import inv
-from scipy.ndimage import median_filter, gaussian_filter, center_of_mass
-import scipy
 
 from ._version import __version__
 
@@ -31,6 +29,8 @@ from ._version import __version__
 #
 # 2018-10-07
 #   MR added intensity correction.
+#   Also smaller basis sets are now reused when generating larger ones.
+#   Removed unnecessary scipy methods (scipy.dot is actually numpy.dot).
 # 2018-10-03
 #   MR completely rewrote basis generation (half-width, efficiency).
 #   Switched from (n, nbf) to (n, sigma) basis specification;
@@ -192,7 +192,7 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
     # its overall effect is an identity transform.
 
     # Reconstructing image  - This is where the magic happens
-    IM = scipy.dot(rawdata, Ai) / dr
+    IM = rawdata.dot(Ai) / dr
     # P = dot(dot(Mc,Ci),M.T) # This calculates the projection, !! not
     # which should recreate the original image                  !! really
     return IM

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -99,14 +99,14 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
 
     Parameters
     ----------
-    data : an m x n numpy array
+    data : ``m`` × ``n`` numpy array
         the image to be transformed.
         ``data[:,0]`` should correspond to the central column of the image.
     sigma : float
         width parameter for basis functions, see equation (14) in the article.
         Determines the number of basis functions (``n / sigma`` rounded).
-        Can be any positive number, but using sigma < 1 is not very meaningful
-        and requires regularization.
+        Can be any positive number, but using ``sigma`` < 1
+        is not very meaningful and requires regularization.
     reg : float
         regularization parameter, square of the Tikhonov factor.
         ``reg=0`` means no regularization,
@@ -115,13 +115,13 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
         apply intensity correction in order to reduce method artifacts
         (intensity normalization and oscillations)
     basis_dir : str
-        path to the directory for saving / loading the basis set coefficients.
-        If None, the basis set will not be saved to disk.
+        path to the directory for saving / loading the basis-set coefficients.
+        If ``None``, the basis set will not be saved to disk.
     dr : float
         size of one pixel in the radial direction.
         This only affects the absolute scaling of the transformed image.
     verbose : boolean
-        determines whether statements should be printed.
+        determines whether statements should be printed
     direction : str
         the type of Abel transform to be performed.
         Currently only accepts value ``'inverse'``.
@@ -129,7 +129,7 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
 
     Returns
     -------
-    recon : m x n numpy array
+    recon : ``m`` × ``n`` numpy array
         the transformed (half) image
 
     """
@@ -175,9 +175,9 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
 
     Parameters
     ----------
-    rawdata : m x n numpy array
+    rawdata : ``m`` × ``n`` numpy array
         the raw image. This is the right half (with the axis) of the image.
-    Ai : n x n numpy array
+    Ai : ``n`` × ``n`` numpy array
         2D array given by the transform-calculation function
     dr : float
         pixel size. This only affects the absolute scaling of the output.
@@ -186,7 +186,7 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
     Returns
     -------
     IM : m x n numpy array
-        The Abel-transformed image, a slice of the 3D distribution
+        the Abel-transformed image, a slice of the 3D distribution
     """
 
     # Note that our images are stored with matrix rows corresponding to
@@ -270,16 +270,17 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
         regularization parameter
     correction : boolean
         apply intensity correction.
-        Corrects wrong intensity normalization (seen for narrow basis sets)
-        and intensity oscillations (seen for broad basis sets).
+        Corrects wrong intensity normalization (seen for narrow basis sets),
+        intensity oscillations (seen for broad basis sets),
+        and intensity drop-off near *r* = 0 due to regularization.
     basis_dir : str
         path to the directory for saving / loading the basis sets.
-        If None, the basis sets will not be saved to disk.
+        If ``None``, the basis sets will not be saved to disk.
 
     Returns
     -------
-    Ai : n x n numpy array
-        the matrix of the inverse Abel transform.
+    Ai : ``n`` × ``n`` numpy array
+        the matrix of the inverse Abel transform
     """
 
     global _bs_prm, _bs, _tr_prm, _tr
@@ -433,15 +434,15 @@ def get_basex_correction(Ai, sigma):
 
     Parameters
     ----------
-    Ai : n x n numpy array
-        matrix of the inverse Abel transform.
+    Ai : ``n`` × ``n`` numpy array
+        matrix of the inverse Abel transform
     sigma : float
-        basis sigma parameter
+        basis width parameter
 
     Returns
     -------
-    cor : 1 x n numpy array
-        intensity correction profile.
+    cor : 1 × ``n`` numpy array
+        intensity correction profile
     """
     n = Ai.shape[0]
     nbf = _nbf(n, sigma)

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -298,7 +298,7 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
                 # Find the best (smallest among sufficient)
                 # and the largest (to extend if not sufficient)
                 best_file = None
-                best_n = sys.maxint
+                best_n = sys.maxsize
                 largest_file = None
                 largest_n = 0
                 mask = re.compile(r'basex_basis_(\d+)_{}.npy$'.format(sigma))
@@ -346,14 +346,12 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
                           'it will be saved to disk for future use.')
 
             # Try to extend the largest available
-            oldM = None  # (old Mc is not needed)
-            if largest_file:
-                try:
-                    oldM, oldMc, M_version = np.load(largest_file)
-                    if verbose:
-                        print('(extending {})'.format(largest_file))
-                except ValueError:
-                    pass
+            try:
+                oldM, oldMc, M_version = np.load(largest_file)
+                if verbose:
+                    print('(extending {})'.format(largest_file))
+            except:
+                oldM = None  # (old Mc is not needed)
 
             M, Mc = _bs_basex(n, sigma, oldM, verbose=verbose)
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -336,7 +336,8 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
 
                 # crop if loaded larger
                 if M.shape != (n, nbf):
-                    print('(cropped from {})'.format(best_file))
+                    if verbose:
+                        print('(cropped from {})'.format(best_file))
                     M = M[:n, :nbf]
                     Mc = Mc[:n, :nbf]
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -29,6 +29,10 @@ from ._version import __version__
 # Review of Scientific Instruments 73, 2634 (2002).
 #
 #
+# 2018-10-03
+#   MR completely rewrote basis generation (half-width, efficiency).
+#   Switched from (n, nbf) to (n, sigma) basis specification;
+#   nbf is now determined automatically, and nbf != n actually works.
 # 2018-09-29
 #   MR improved loading cached basis sets:
 #   If the required basis is not available, but a larger compatible is,
@@ -66,7 +70,7 @@ from ._version import __version__
 #############################################################################
 
 
-def basex_transform(data, nbf='auto', reg=0.0, bs_correction=False,
+def basex_transform(data, sigma=1.0, reg=0.0, bs_correction=False,
                     basis_dir='./', dr=1.0,
                     verbose=True, direction='inverse'):
     """
@@ -90,11 +94,11 @@ def basex_transform(data, nbf='auto', reg=0.0, bs_correction=False,
     data : an m x n numpy array
         the image to be transformed.
         ``data[:,0]`` should correspond to the central column of the image.
-    nbf : str or int
-        number of basis functions. If ``nbf='auto'``, it is set to ``n``.
-        *This is what you should always use*, since this BASEX implementation
-        does not work reliably in other situations!
-        In the future, you could use other numbers
+    sigma : float
+        width parameter for basis functions, see equation (14) in the article.
+        Determines the number of basis functions (``n / sigma`` rounded).
+        Can be any positive number, but using sigma < 1 is not very meaningful
+        and requires regularization.
     reg : float
         regularization parameter, square of the Tikhonov factor.
         ``reg=0`` means no regularization,
@@ -141,7 +145,8 @@ def basex_transform(data, nbf='auto', reg=0.0, bs_correction=False,
     n = data.shape[1]
 
     # load the basis sets:
-    Ai = get_bs_basex_cached(n, nbf=nbf, reg=reg, bs_correction=bs_correction,
+    Ai = get_bs_basex_cached(n, sigma=sigma, reg=reg,
+                             bs_correction=bs_correction,
                              basis_dir=basis_dir, verbose=verbose)
 
     # Do the actual transform:
@@ -174,7 +179,7 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
     Returns
     -------
     IM : m x n numpy array
-        The abel-transformed image, a slice of the 3D distribution
+        The Abel-transformed image, a slice of the 3D distribution
     """
 
     # Note that our images are stored with matrix rows corresponding to
@@ -197,61 +202,45 @@ def _get_Ai(M, Mc, reg):
         given basis sets M, Mc,
         return matrix of inverse Abel transform
     """
-
     # Ai  is the overall (horizontal) transform matrix,
-    #     corresponds to A^T Z in the article
-    # reg corresponds to q_1^2 in the article
+    #     corresponds to A^T Z in the article.
+    # reg corresponds to q_1^2 in the article.
 
-    if reg == 0.0:
-        Ai = scipy.dot(inv(M.T), Mc.T)  # (this works only for nbf == n)
+    n, nbf = M.shape
+    if reg == 0.0 and nbf == n:
+        Ai = inv(M.T).dot(Mc.T)
     else:
-        nbf = np.shape(M)[1]
         # square of Tikhonov matrix
         E = np.diag([reg] * nbf)
         # regularized inverse of basis projection
-        R = scipy.dot(M, inv(scipy.dot(M.T, M) + E))
+        R = M.dot(inv((M.T).dot(M) + E))
         # {expansion coefficients} = projection . R
         # image = {expansion coefficients} . {image basis}
         # so: image = projection . (R . {image basis})
         #     image = projection . Ai
         #     Ai = R . {image basis}
         # Ai is the matrix of the inverse Abel transform
-        Ai = scipy.dot(R, Mc.T)
-
-    # use an heuristic scaling factor to match the analytical abel transform
-    # For more info see https://github.com/PyAbel/PyAbel/issues/4
-    MAGIC_NUMBER = 1.1122244156826457
-    Ai *= MAGIC_NUMBER
+        Ai = R.dot(Mc.T)
 
     return Ai
 
 
-def _nbf_default(n, nbf):
-    """ An internal helper function for the asymmetric case
-        to check that nbf = n and print a warning otherwise
+def _nbf(n, sigma):
     """
-    if nbf == 'auto':
-        nbf = n
-    elif isinstance(nbf, (int, long)):
-        if nbf != n:
-            print('Warning: the number of basis functions '
-                  'nbf = {} != n  = {}\n'.format(nbf, n))
-            print('This behaviour is currently not tested '
-                  'and should not be used '
-                  'unless you know exactly what you are doing. '
-                  'Setting nbf="auto" is best for now.')
-    else:
-        raise ValueError('nbf must be set to "auto" or an integer')
-    return nbf
+    Internal helper function.
+    Calculates the number of basis functions ``nbf`` from
+    the half-image width ``n`` and the basis width parameter ``sigma``.
+    """
+    return int(round(n / sigma))
 
 
 # Cached matrices and their parameters
-_prm = None  # [n, nbf, bs_correction]
+_prm = None  # [n, sigma, bs_correction]
 _M = None    # [M, Mc]
 _reg = None  # reg
 _Ai = None   # Ai
 
-def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
+def get_bs_basex_cached(n, sigma=1.0, reg=0.0, bs_correction=False,
                         basis_dir='.', verbose=False):
     """
     Internal function.
@@ -268,9 +257,8 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
     n : int
         Abel inverse transform will be performed on an
         ``n`` pixels wide area of the (half) image
-    nbf : int
-        number of basis functions. If ``nbf='auto'``,
-        ``nbf`` is set to ``n``.
+    sigma : float
+        width parameter for basis functions
     reg : float
         regularization parameter
     bs_correction : boolean
@@ -287,18 +275,17 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
 
     global _prm, _M, _reg, _Ai
 
-    # Sanitize nbf
-    nbf = _nbf_default(n, nbf)
-
+    sigma = float(sigma)  # (ensure FP format)
+    nbf = _nbf(n, sigma)
     M = None
     # Check whether basis for these parameters is already loaded
-    if _prm == [n, nbf, bs_correction]:
+    if _prm == [n, sigma, bs_correction]:
         if verbose:
             print('Using memory-cached basis sets')
         M, Mc = _M
     else:  # try to load basis
         if basis_dir is not None:
-            basis_name = 'basex_basis_{}_{}.npy'.format(n, nbf)
+            basis_name = 'basex_basis_{}_{}.npy'.format(n, sigma)
             path_to_basis_file = os.path.join(basis_dir, basis_name)
 
             # Try to find a suitable existing basis set
@@ -307,22 +294,22 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
             else:
                 # Find the best (smallest among sufficient)
                 best_file = None
-                best_nbf = sys.maxint
+                best_n = sys.maxint
                 for f in listdir(basis_dir):
                     # filter BASEX basis files
-                    match = re.match(r'basex_basis_(\d+)_(\d+).npy$', f)
+                    match = re.match(r'basex_basis_(\d+)_(\d+\.\d+).npy$', f)
                     if not match:
                         continue
                     # extract basis parameters
-                    f_n, f_nbf = map(int, match.groups())
+                    f_n, f_sigma = int(match.group(1)), float(match.group(2))
                     # must be large enough and smaller than previous best
-                    if f_nbf < nbf or f_nbf > best_nbf:
+                    if f_n < n or f_n > best_n:
                         continue
-                    # must be for a proper image size
-                    if f_n == f_nbf:  # !! modify accordingly for nbf != n
+                    # must have the same sigma
+                    if f_sigma == sigma:
                         # remember as new best
                         best_file = f
-                        best_nbf = f_nbf
+                        best_n = f_n
 
             # If found, try to use it
             if best_file:
@@ -349,7 +336,7 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
                     print('But don\'t worry, '
                           'it will be saved to disk for future use.')
 
-            M, Mc = _bs_basex(n, nbf, verbose=verbose)
+            M, Mc = _bs_basex(n, sigma, verbose=verbose)
 
             if basis_dir is not None:
                 np.save(path_to_basis_file,
@@ -360,7 +347,7 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
 
         # Apply basis correction
         if bs_correction:
-            # This is a dirty hack!
+            # This is a dirty hack!  ?? what if sigma != 1.0?
             # See https://github.com/PyAbel/PyAbel/issues/230
             l = min(nbf, 5)  # modifying at most 5 first points (what fits)
             # image basis function k = 0
@@ -368,7 +355,7 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
             # its projection
             M[:l, 0] = [1.65, 0.18, -0.15, -0.09, -0.04][:l]
 
-        _prm = [n, nbf, bs_correction]
+        _prm = [n, sigma, bs_correction]
         _M = [M, Mc]
         _reg = None
 
@@ -410,108 +397,99 @@ def basex_cleanup():
     _Ai = None
 
 
-MAX_BASIS_SET_OFFSET = 4000
-
-def _bs_basex(n=251, nbf=251, verbose=True):
+def _bs_basex(n=251, sigma=1.0, verbose=True):
     """
-    Generates basis sets for the BASEX method
-    without assuming up/down symmetry.
+    Generates horizontal basis sets for the BASEX method.
 
     Parameters:
     -----------
     n : integer
         horizontal dimensions of the half-width image in pixels.
-        Must inglude the axial pixel.
+        Must include the axial pixel.
         See https://github.com/PyAbel/PyAbel/issues/34
-    nbf : integer
-        number of basis functions in the x direction.
-        Must be less than or equal (default) to n
+    sigma : float
+        width parameter for basis functions
 
     Returns:
     --------
-      M, Mc : numpy arrays
+    M, Mc : numpy arrays
+        ``Mc`` is the reconstructed-image basis rho_k(r_i) (~Gaussians),
+               corresponds to Z^T in the article.
+        ``M``  is the projected basis chi_k(x_i),
+               corresponds to X^T in the article.
     """
 
-    # Mc is the reconstructed-image basis (Gaussians),
-    #    corresponds to Z^T in the article
-    # M  is the basis projection,
-    #    corresponds to X^T in the article
-
-    if nbf > n:
-        raise ValueError('The number of horizontal basis functions (nbf) '
-                         'cannot be greater than n')
-
-    nf = 2 * n - 1  # full width
-
-    Rm_h = n
-
-    I_h = np.arange(1, nf + 1)
-
-    R2_h = (I_h - Rm_h)**2
-    M = np.zeros((nf, nbf))
-    Mc = np.zeros((nf, nbf))
-
-    M[:, 0] = 2*np.exp(-R2_h)
-    Mc[:, 0] = np.exp(-R2_h)
-
-    gammaln_0o5 = gammaln(0.5)
+    sigma = float(sigma)  # (ensure FP type)
+    nbf = _nbf(n, sigma)  # number of basis functions
 
     if verbose:
         print('Generating horizontal BASEX basis sets for '
-              'n = {}:\n'.format(n))
-        sys.stdout.write('0')
+              'n = {}, sigma = {} (nbf = {}):'.format(n, sigma, nbf))
+        print('k = 0...', end='')
         sys.stdout.flush()
 
-    # the number of elements used to calculate the projected coefficeints
-    delta = np.fmax(np.arange(nbf)*32 - MAX_BASIS_SET_OFFSET,
-                    MAX_BASIS_SET_OFFSET)
+    # Precompute tables of ln Gamma(...) terms;
+    # notice that index i corresponds to argument i + 1 (and i + 1/2).
+    maxk2 = (nbf - 1)**2
+    # for Gamma(k^2 + 1) and Gamma(l + 1)
+    lngamma = gammaln(np.arange(maxk2 + 1) + 1)
+    # for Gamma(k^2 - l + 1) - Gamma(k^2 - l + 1/2)
+    Dlngamma = lngamma - gammaln(np.arange(maxk2 + 1) + 1/2)
+
+    # reduced coordinates u = x/sigma (or r/sigma) and their squares
+    U = np.arange(float(n)) / sigma
+    U2 = U * U
+
+    Mc = np.empty((n, nbf))
+    M = np.empty((n, nbf))
+    # (indexing is Mc[r, k], M[x, k])
+
+    # Cases k = 0 and x = 0 (r = 0) are special, since general expressions
+    # are valid only if considered as limits; here they are computed
+    # separately, using expressions that result from taking these limits.
+    # In all cases the sigma factor in projections is applied afterwards.
+
+    # rho_0(r) = exp(-u^2)
+    Mc[:, 0] = np.exp(-U2)
+    # chi_0(x) = sqrt(pi) sigma exp(-u^2) = Gamma(1/2) sigma exp(-u^2)
+    M[:, 0] = np.exp(gammaln(1/2) - U2)
+
     for k in range(1, nbf):
-        k2 = k*k  # so we don't recalculate it all the time
-        log_k2 = log(k2)
-        angn = exp(k2 * (1 - log_k2) +
-                   gammaln(k2 + 0.5) - gammaln_0o5)
-        M[Rm_h-1, k] = 2 * angn
-        for l in range(1, nf - Rm_h + 1):
-            l2 = l*l
-            log_l2 = log(l2)
+        k2 = k * k
+        # prefactor ln[(e/k^2)^(k^2)]
+        ek = (1 - log(k2)) * k2 if k2 else 1.0
 
-            val = exp(k2 * (1 + log(l2/k2)) - l2)
+        # Basis function rho_k(r)
+        Mc[0, k] = 0
+        Mc[1:, k] = np.exp(ek + np.log(U[1:]) * 2 * k2 - U2[1:])
 
-            Mc[Rm_h - 1 + l, k] = val  # All rows below center
-            # Mc[Rm_h - 1 - l, k] = val  # All rows above center
-
-            aux = val + angn * Mc[Rm_h - 1 + l, 0]
-
-            p = np.arange(max(1, l2 - delta[k]),
-                          min(k2 - 1,  l2 + delta[k]) + 1)
-            """
-            We use here the fact that for p, k real and positive
-            np.log(np.arange(p, k)).sum() == gammaln(k) - gammaln(p)
-            where gammaln is scipy.misc.gammaln
-            (i.e. the log of the Gamma function)
-            The following line corresponds to the vectorized third
-            loop of the original BASIS2.m matlab file.
-            """
-            aux += np.exp(
-                k2 - l2 - k2*log_k2 + p*log_l2 +
-                gammaln(k2 + 1) - gammaln(p + 1) + gammaln(k2 - p + 0.5) -
-                gammaln_0o5 - gammaln(k2 - p + 1)).sum()
-            # End of vectorized third loop
-            aux *= 2
-
-            M[Rm_h - 1 + l, k] = aux  # All rows below center
-            # M[Rm_h - 1 - l, k] = aux  # All rows above center
+        # Projected basis function chi_k(x)
+        # full range of l
+        L = np.arange(k2 + 1)
+        # all ln Gamma(...) terms
+        G = lngamma[k2] - lngamma[L] - Dlngamma[k2 - L]
+        # Calculate chi_k(x) at each x_i
+        M[0, k] = exp(ek + G[0])  # (u^(2l) = 1 for l = 0, otherwise 0)
+        for i, u2 in enumerate(U2[1:], 1):
+            # index of the largest component
+            lmax = min(int(u2), k2)
+            # halfwidth of the important range
+            delta = 7 * k  # "7" reproduces the old method accuracy (~1e-8 abs)
+            # summation limits: +-delta from the maximum, but within [0, k^2]
+            minl = max(0, lmax - delta)
+            maxl = min(lmax + delta, k2)
+            # list of ln[u^(2l)]
+            lnu2L = log(u2) * L[minl:maxl+1]
+            # sum over the important range
+            M[i, k] = np.exp(ek - u2 + G[minl:maxl+1] + lnu2L).sum()
 
         if verbose and k % 50 == 0:
-            sys.stdout.write('...{}'.format(k))
+            print('{}...'.format(k), end='')
             sys.stdout.flush()
 
     if verbose:
-        print('...{}'.format(k+1))
+        print(k + 1)
 
-    # taking only needed halves
-    # (all the code above must be modified to work with halves throughout)
-    M = M[n-1:, :]
-    Mc = Mc[n-1:, :]
+    M *= sigma  # applying the sigma factor
 
     return M, Mc

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -331,15 +331,14 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
                     # saved as a .npy file
                 try:
                     M, Mc, M_version = np.load(best_file)
+                    # crop if loaded larger
+                    if M.shape != (n, nbf):
+                        M = M[:n, :nbf]
+                        Mc = Mc[:n, :nbf]
+                        if verbose:
+                            print('(cropped from {})'.format(best_file))
                 except ValueError:
                     print('Cached basis file incompatible.')
-
-                # crop if loaded larger
-                if M.shape != (n, nbf):
-                    if verbose:
-                        print('(cropped from {})'.format(best_file))
-                    M = M[:n, :nbf]
-                    Mc = Mc[:n, :nbf]
 
         if M is None:  # generate the basis set
             if verbose:

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -301,7 +301,7 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
                 best_n = sys.maxsize
                 largest_file = None
                 largest_n = 0
-                mask = re.compile(r'basex_basis_(\d+)_{}.npy$'.format(sigma))
+                mask = re.compile(r'basex_basis_(\d+)_{}\.npy$'.format(sigma))
                 for f in listdir(basis_dir):
                     # filter BASEX basis files
                     match = mask.match(f)

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -294,12 +294,15 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
         M, Mc = _bs
     else:  # try to load basis
         if basis_dir is not None:
-            basis_name = 'basex_basis_{}_{}.npy'.format(n, sigma)
-            path_to_basis_file = os.path.join(basis_dir, basis_name)
+            basis_file = 'basex_basis_{}_{}.npy'.format(n, sigma)
+
+            def full_path(file_name):
+                return os.path.join(basis_dir, file_name)
 
             # Try to find a suitable existing basis set
-            if os.path.exists(path_to_basis_file):  # have exactly needed
-                best_file = path_to_basis_file
+            if os.path.exists(full_path(basis_file)):
+                # have exactly needed
+                best_file = basis_file
             else:
                 # Find the best (smallest among sufficient)
                 # and the largest (to extend if not sufficient)
@@ -332,7 +335,7 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
                     print('Loading basis sets...')
                     # saved as a .npy file
                 try:
-                    M, Mc, M_version = np.load(best_file)
+                    M, Mc, M_version = np.load(full_path(best_file))
                     # crop if loaded larger
                     if M.shape != (n, nbf):
                         M = M[:n, :nbf]
@@ -353,7 +356,7 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
 
             # Try to extend the largest available
             try:
-                oldM, oldMc, M_version = np.load(largest_file)
+                oldM, oldMc, M_version = np.load(full_path(largest_file))
                 if verbose:
                     print('(extending {})'.format(largest_file))
             except:
@@ -362,11 +365,11 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
             M, Mc = _bs_basex(n, sigma, oldM, verbose=verbose)
 
             if basis_dir is not None:
-                np.save(path_to_basis_file,
+                np.save(full_path(basis_file),
                         (M, Mc, np.array(__version__)))
                 if verbose:
                     print('Basis set saved for later use to')
-                    print('  {}'.format(path_to_basis_file))
+                    print('  {}'.format(basis_file))
 
         _bs_prm = [n, sigma]
         _bs = [M, Mc]
@@ -407,7 +410,7 @@ def cache_cleanup():
     -------
     None
     """
-    global _prm, _M, _reg, _Ai
+    global _bs_prm, _bs, _tr_prm, _tr
 
     _bs_prm = None
     _bs = None

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -24,9 +24,11 @@ from ._version import __version__
 #############################################################################
 # This is adapted from the BASEX Matlab code provided by the Reisler group.
 #
-# Please cite: "The Gaussian basis-set expansion Abel transform method"
+# Please cite: "Reconstruction of Abel-transformable images:
+# The Gaussian basis-set expansion Abel transform method"
 # V. Dribinski, A. Ossadtchi, V. A. Mandelshtam, and H. Reisler,
 # Review of Scientific Instruments 73, 2634 (2002).
+# https://doi.org/10.1063/1.1482156
 #
 #
 # 2018-10-07

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -99,13 +99,13 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
 
     Parameters
     ----------
-    data : ``m`` × ``n`` numpy array
+    data : **m** × **n** numpy array
         the image to be transformed.
         ``data[:,0]`` should correspond to the central column of the image.
     sigma : float
         width parameter for basis functions, see equation (14) in the article.
-        Determines the number of basis functions (``n / sigma`` rounded).
-        Can be any positive number, but using ``sigma`` < 1
+        Determines the number of basis functions (**n**/**sigma** rounded).
+        Can be any positive number, but using **sigma** < 1
         is not very meaningful and requires regularization.
     reg : float
         regularization parameter, square of the Tikhonov factor.
@@ -129,7 +129,7 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
 
     Returns
     -------
-    recon : ``m`` × ``n`` numpy array
+    recon : **m** × **n** numpy array
         the transformed (half) image
 
     """
@@ -175,9 +175,9 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
 
     Parameters
     ----------
-    rawdata : ``m`` × ``n`` numpy array
+    rawdata : **m** × **n** numpy array
         the raw image. This is the right half (with the axis) of the image.
-    Ai : ``n`` × ``n`` numpy array
+    Ai : **n** × **n** numpy array
         2D array given by the transform-calculation function
     dr : float
         pixel size. This only affects the absolute scaling of the output.
@@ -185,7 +185,7 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
 
     Returns
     -------
-    IM : m x n numpy array
+    IM : **m** × **n** numpy array
         the Abel-transformed image, a slice of the 3D distribution
     """
 
@@ -235,8 +235,8 @@ def _get_Ai(M, Mc, reg):
 def _nbf(n, sigma):
     """
     Internal helper function.
-    Calculates the number of basis functions ``nbf`` from
-    the half-image width ``n`` and the basis width parameter ``sigma``.
+    Calculates the number of basis functions **nbf** from
+    the half-image width **n** and the basis width parameter **sigma**.
     """
     return int(round(n / sigma))
 
@@ -263,7 +263,7 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
     ----------
     n : int
         Abel inverse transform will be performed on an
-        ``n`` pixels wide area of the (half) image
+        **n** pixels wide area of the (half) image
     sigma : float
         width parameter for basis functions
     reg : float
@@ -279,7 +279,7 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
 
     Returns
     -------
-    Ai : ``n`` × ``n`` numpy array
+    Ai : **n** × **n** numpy array
         the matrix of the inverse Abel transform
     """
 
@@ -425,23 +425,23 @@ def get_basex_correction(Ai, sigma):
 
     The default BASEX basis and the way its projection is calculated
     leads to artifacts in the reconstructed distribution --
-    incorrect overall intensity for ``sigma`` = 1,
-    intensity oscillations for other ``sigma`` values,
-    intensity fluctuations (and drop-off for ``reg`` > 0) near r = 0.
+    incorrect overall intensity for **sigma** = 1,
+    intensity oscillations for other **sigma** values,
+    intensity fluctuations (and drop-off for **reg** > 0) near *r* = 0.
     This function generates the intensity correction profile
     from the BASEX result for a step function with a soft edge (to avoid
     ringing) aligned with the last basis function.
 
     Parameters
     ----------
-    Ai : ``n`` × ``n`` numpy array
+    Ai : **n** × **n** numpy array
         matrix of the inverse Abel transform
     sigma : float
         basis width parameter
 
     Returns
     -------
-    cor : 1 × ``n`` numpy array
+    cor : 1 × **n** numpy array
         intensity correction profile
     """
     n = Ai.shape[0]

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -27,6 +27,8 @@ from ._version import __version__
 # Review of Scientific Instruments 73, 2634 (2002).
 #
 #
+# 2018-09-25
+#   MR added basis correction near r = 0
 # 2018-09-19
 #   MR switched to half-width transform.
 #   The results now match BASEX.exe.
@@ -80,8 +82,8 @@ def basex_transform(data, nbf='auto', reg=0.0, bs_correction=False,
     Parameters
     ----------
     data : an m x n numpy array
-        The image to be inverse transformed. ``data[:,0]``
-        should correspond to the central column of the image.
+        the image to be transformed.
+        ``data[:,0]`` should correspond to the central column of the image.
     nbf : str or int
         number of basis functions. If ``nbf='auto'``, it is set to ``n``.
         *This is what you should always use*, since this BASEX implementation
@@ -101,9 +103,9 @@ def basex_transform(data, nbf='auto', reg=0.0, bs_correction=False,
         size of one pixel in the radial direction.
         This only affects the absolute scaling of the transformed image.
     verbose : boolean
-        Determines if statements should be printed.
+        determines whether statements should be printed.
     direction : str
-        The type of Abel transform to be performed.
+        the type of Abel transform to be performed.
         Currently only accepts value ``'inverse'``.
 
 
@@ -258,7 +260,7 @@ def get_bs_basex_cached(n, nbf='auto', reg=0.0, bs_correction=False,
     Parameters
     ----------
     n : int
-        Abel inverse transform will be performed on a
+        Abel inverse transform will be performed on an
         ``n`` pixels wide area of the (half) image
     nbf : int
         number of basis functions. If ``nbf='auto'``,
@@ -358,11 +360,11 @@ def _bs_basex(n=251, nbf=251, verbose=True):
     Parameters:
     -----------
     n : integer
-        Horizontal dimensions of the half-width image in pixels.
+        horizontal dimensions of the half-width image in pixels.
         Must inglude the axial pixel.
         See https://github.com/PyAbel/PyAbel/issues/34
     nbf : integer
-        Number of basis functions in the x direction.
+        number of basis functions in the x direction.
         Must be less than or equal (default) to n
 
     Returns:

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -514,7 +514,7 @@ def _bs_basex(n=251, sigma=1.0, oldM=None, verbose=True):
     for k in range(1, nbf):
         k2 = k * k
         # prefactor ln[(e/k^2)^(k^2)]
-        ek = (1 - log(k2)) * k2 if k2 else 1.0
+        ek = (1 - log(k2)) * k2
 
         # Basis function rho_k(r)
         Mc[0, k] = 0

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -391,7 +391,7 @@ def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
     return Ai
 
 
-def basex_cleanup():
+def cache_cleanup():
     """
     Utility function.
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -99,7 +99,7 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
 
     Parameters
     ----------
-    data : **m** × **n** numpy array
+    data : m × n numpy array
         the image to be transformed.
         ``data[:,0]`` should correspond to the central column of the image.
     sigma : float
@@ -129,7 +129,7 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
 
     Returns
     -------
-    recon : **m** × **n** numpy array
+    recon : m × n numpy array
         the transformed (half) image
 
     """
@@ -175,9 +175,9 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
 
     Parameters
     ----------
-    rawdata : **m** × **n** numpy array
+    rawdata : m × n numpy array
         the raw image. This is the right half (with the axis) of the image.
-    Ai : **n** × **n** numpy array
+    Ai : n × n numpy array
         2D array given by the transform-calculation function
     dr : float
         pixel size. This only affects the absolute scaling of the output.
@@ -185,7 +185,7 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
 
     Returns
     -------
-    IM : **m** × **n** numpy array
+    IM : m × n numpy array
         the Abel-transformed image, a slice of the 3D distribution
     """
 
@@ -279,7 +279,7 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=False,
 
     Returns
     -------
-    Ai : **n** × **n** numpy array
+    Ai : n × n numpy array
         the matrix of the inverse Abel transform
     """
 
@@ -434,7 +434,7 @@ def get_basex_correction(Ai, sigma):
 
     Parameters
     ----------
-    Ai : **n** × **n** numpy array
+    Ai : n × n numpy array
         matrix of the inverse Abel transform
     sigma : float
         basis width parameter

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -78,7 +78,7 @@ from ._version import __version__
 #############################################################################
 
 
-def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
+def basex_transform(data, sigma=1.0, reg=0.0, correction=True,
                     basis_dir='./', dr=1.0,
                     verbose=True, direction='inverse'):
     """
@@ -247,7 +247,7 @@ _bs = None      # [M, Mc]
 _tr_prm = None  # [reg, correction]
 _tr = None      # Ai
 
-def get_bs_cached(n, sigma=1.0, reg=0.0, correction=False,
+def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
                   basis_dir='.', verbose=False):
     """
     Internal function.

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -153,8 +153,8 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=False,
     n = data.shape[1]
 
     # load the basis sets:
-    Ai = get_bs_basex_cached(n, sigma=sigma, reg=reg, correction=correction,
-                             basis_dir=basis_dir, verbose=verbose)
+    Ai = get_bs_cached(n, sigma=sigma, reg=reg, correction=correction,
+                       basis_dir=basis_dir, verbose=verbose)
 
     # Do the actual transform:
     recon = basex_core_transform(data, Ai, dr)
@@ -247,8 +247,8 @@ _bs = None      # [M, Mc]
 _tr_prm = None  # [reg, correction]
 _tr = None      # Ai
 
-def get_bs_basex_cached(n, sigma=1.0, reg=0.0, correction=False,
-                        basis_dir='.', verbose=False):
+def get_bs_cached(n, sigma=1.0, reg=0.0, correction=False,
+                  basis_dir='.', verbose=False):
     """
     Internal function.
 
@@ -399,7 +399,7 @@ def cache_cleanup():
     """
     Utility function.
 
-    Frees the memory caches created by ``get_bs_basex_cached()``.
+    Frees the memory caches created by ``get_bs_cached()``.
     This is usually pointless, but might be required after working
     with very large images, if more RAM is needed for further tasks.
 

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -50,7 +50,7 @@ class AbelTiming(object):
 
         transform = {
             'basex': basex.basex_core_transform,
-            'basex_bs': basex.get_bs_basex_cached,
+            'basex_bs': basex.get_bs_cached,
             'direct_Python': direct.direct_transform,
             'direct_C': direct.direct_transform,
             'hansenlaw': hansenlaw.hansenlaw_transform,

--- a/abel/dasch.py
+++ b/abel/dasch.py
@@ -386,7 +386,7 @@ def cache_cleanup():
     None
     """
 
-    global _D, _method
+    global _D, _method, _source
 
     _D = None
     _method = None

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -546,7 +546,7 @@ def get_bs_cached(cols, basis_dir=None, legendre_orders=[0, 2],
     return _basis
 
 
-def basis_cache_cleanup():
+def cache_cleanup():
     """
     Utility function.
 

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -15,9 +15,11 @@ DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
 
 def test_basex_basis_sets_cache():
     # n = 61  (121 full width)
-    # nbf = 61
+    # sigma = 1  (nbf = 61)
     n = 61
-    file_name = os.path.join(DATA_DIR, "basex_basis_{}_{}.npy".format(n, n))
+    sigma = 1.0
+    file_name = os.path.join(DATA_DIR,
+                             "basex_basis_{}_{}.npy".format(n, sigma))
     if os.path.exists(file_name):
         os.remove(file_name)
     # 1st call generate and save
@@ -48,7 +50,7 @@ def test_basex_zeros():
     assert_allclose(recon, 0)
 
 
-def test_basex_gaussian(sigma, reg, cor, tol):
+def basex_gaussian(sigma, reg, cor, tol):
     """Check a gaussian solution for BASEX"""
     n = 100
     r_max = n - 1
@@ -78,24 +80,44 @@ def test_basex_gaussian(sigma, reg, cor, tol):
     assert_allclose(recon, ref, atol=tol)
 
 
+def test_basex_gaussian():
+    """Check a gaussian solution for BASEX:
+       default parameters"""
+    # (intensity correction using "magic number",
+    #  see https://github.com/PyAbel/PyAbel/issues/230)
+    basex_gaussian(sigma=1, reg=0, cor=1.015, tol=3e-3)
+
+
+def test_basex_gaussian_corrected():
+    """Check a gaussian solution for BASEX:
+       default parameters, corrected"""
+    basex_gaussian(sigma=1, reg=0, cor=True, tol=7e-4)
+
+
+def test_basex_gaussian_sigma_3():
+    """Check a gaussian solution for BASEX:
+       large sigma (oscillating)"""
+    basex_gaussian(sigma=3, reg=0, cor=1, tol=3e-2)
+
+
+def test_basex_gaussian_sigma_3_corrected():
+    """Check a gaussian solution for BASEX:
+       large sigma (oscillating)"""
+    basex_gaussian(sigma=3, reg=0, cor=True, tol=2e-3)
+
+
+def test_basex_gaussian_sigma_07_reg_10_corrected():
+    """Check a gaussian solution for BASEX:
+       small sigma, regularized, corrected"""
+    basex_gaussian(sigma=0.7, reg=10, cor=True, tol=6e-3)
+
+
 if __name__ == '__main__':
     test_basex_basis_sets_cache()
     test_basex_shape()
     test_basex_zeros()
-
-    # default parameters
-    # (intensity correction using "magic number",
-    #  see https://github.com/PyAbel/PyAbel/issues/230)
-    test_basex_gaussian(sigma=1, reg=0, cor=1.015, tol=3e-3)
-
-    # default parameters, corrected
-    test_basex_gaussian(sigma=1, reg=0, cor=True, tol=7e-4)
-
-    # large sigma (oscillating)
-    test_basex_gaussian(sigma=3, reg=0, cor=1, tol=3e-2)
-
-    # large sigma, corrected
-    test_basex_gaussian(sigma=3, reg=0, cor=True, tol=2e-3)
-
-    # small sigma, regularized, corrected
-    test_basex_gaussian(sigma=0.7, reg=10, cor=True, tol=6e-3)
+    test_basex_gaussian()
+    test_basex_gaussian_corrected()
+    test_basex_gaussian_sigma_3()
+    test_basex_gaussian_sigma_3_corrected()
+    test_basex_gaussian_sigma_07_reg_10_corrected()

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -8,26 +8,68 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import abel
+from abel.basex import get_bs_basex_cached, cache_cleanup
 from abel.tools.analytical import GaussianAnalytical
 
 
 DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
+
+
+def get_basis_file_name(n, sigma):
+    return os.path.join(DATA_DIR, 'basex_basis_{}_{}.npy'.format(n, sigma))
+
 
 def test_basex_basis_sets_cache():
     # n = 61  (121 full width)
     # sigma = 1  (nbf = 61)
     n = 61
     sigma = 1.0
-    file_name = os.path.join(DATA_DIR,
-                             "basex_basis_{}_{}.npy".format(n, sigma))
+    file_name = get_basis_file_name(n, sigma)
     if os.path.exists(file_name):
         os.remove(file_name)
     # 1st call generate and save
-    abel.basex.get_bs_basex_cached(n, basis_dir=DATA_DIR, verbose=False)
+    get_bs_basex_cached(n, basis_dir=DATA_DIR, verbose=False)
     # 2nd call load from file
-    abel.basex.get_bs_basex_cached(n, basis_dir=DATA_DIR, verbose=False)
+    get_bs_basex_cached(n, basis_dir=DATA_DIR, verbose=False)
     if os.path.exists(file_name):
         os.remove(file_name)
+
+
+def test_basex_basis_sets_resize():
+    n_s = 50
+    n_l = 100
+    sigma = 1.0
+    file_name_s = get_basis_file_name(n_s, sigma)
+    file_name_l = get_basis_file_name(n_l, sigma)
+
+    # (remove both basis files)
+    def remove_files():
+        if os.path.exists(file_name_s):
+            os.remove(file_name_s)
+        if os.path.exists(file_name_l):
+            os.remove(file_name_l)
+
+    # make sure that basis files do not exist
+    remove_files()
+    # generate small basis and save
+    Ai_s = get_bs_basex_cached(n_s, basis_dir=DATA_DIR, verbose=False)
+    cache_cleanup()
+    # extend to large basis and save
+    Ai_s_l = get_bs_basex_cached(n_l, basis_dir=DATA_DIR, verbose=False)
+    cache_cleanup()
+    # delete basis files
+    remove_files()
+    # generate large basis and save
+    Ai_l = get_bs_basex_cached(n_l, basis_dir=DATA_DIR, verbose=False)
+    cache_cleanup()
+    # crop large basis to small
+    Ai_l_s = get_bs_basex_cached(n_s, basis_dir=DATA_DIR, verbose=False)
+    cache_cleanup()
+    # delete basis files (clean-up)
+    remove_files()
+
+    assert np.array_equal(Ai_s, Ai_l_s)
+    assert np.array_equal(Ai_l, Ai_s_l)
 
 
 def test_basex_shape():
@@ -114,6 +156,7 @@ def test_basex_gaussian_sigma_07_reg_10_corrected():
 
 if __name__ == '__main__':
     test_basex_basis_sets_cache()
+    test_basex_basis_sets_resize()
     test_basex_shape()
     test_basex_zeros()
     test_basex_gaussian()

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -52,24 +52,24 @@ def basex_basis_sets_resize(sigma):
     remove_files()
     cache_cleanup()
     # generate small basis and save
-    Ai_s = get_bs_cached(n_s, basis_dir=DATA_DIR, verbose=False)
+    Ai_s = get_bs_cached(n_s, sigma, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # extend to large basis and save
-    Ai_s_l = get_bs_cached(n_l, basis_dir=DATA_DIR, verbose=False)
+    Ai_s_l = get_bs_cached(n_l, sigma, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # delete basis files
     remove_files()
     # generate large basis and save
-    Ai_l = get_bs_cached(n_l, basis_dir=DATA_DIR, verbose=False)
+    Ai_l = get_bs_cached(n_l, sigma, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # crop large basis to small
-    Ai_l_s = get_bs_cached(n_s, basis_dir=DATA_DIR, verbose=False)
+    Ai_l_s = get_bs_cached(n_s, sigma, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # delete basis files (clean-up)
     remove_files()
 
-    assert np.array_equal(Ai_s, Ai_l_s)
-    assert np.array_equal(Ai_l, Ai_s_l)
+    assert_allclose(Ai_s, Ai_l_s, atol=1e-15, rtol=1e-15)
+    assert_allclose(Ai_l, Ai_s_l, atol=1e-15, rtol=1e-15)
 
 
 def test_basex_basis_sets_resize_1():

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -35,10 +35,9 @@ def test_basex_basis_sets_cache():
         os.remove(file_name)
 
 
-def test_basex_basis_sets_resize():
+def basex_basis_sets_resize(sigma):
     n_s = 50
     n_l = 100
-    sigma = 1.0
     file_name_s = get_basis_file_name(n_s, sigma)
     file_name_l = get_basis_file_name(n_l, sigma)
 
@@ -49,8 +48,9 @@ def test_basex_basis_sets_resize():
         if os.path.exists(file_name_l):
             os.remove(file_name_l)
 
-    # make sure that basis files do not exist
+    # make sure that basis files do not exist and are not cached
     remove_files()
+    cache_cleanup()
     # generate small basis and save
     Ai_s = get_bs_cached(n_s, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
@@ -70,6 +70,17 @@ def test_basex_basis_sets_resize():
 
     assert np.array_equal(Ai_s, Ai_l_s)
     assert np.array_equal(Ai_l, Ai_s_l)
+
+
+def test_basex_basis_sets_resize_1():
+    """Test basis resize with default sigma=1"""
+    basex_basis_sets_resize(1)
+
+
+def test_basex_basis_sets_resize_1_5():
+    """Test basis resize with sigma=1.5
+       (with n not aligned)"""
+    basex_basis_sets_resize(1.5)
 
 
 def test_basex_shape():
@@ -156,7 +167,8 @@ def test_basex_gaussian_sigma_07_reg_10_corrected():
 
 if __name__ == '__main__':
     test_basex_basis_sets_cache()
-    test_basex_basis_sets_resize()
+    test_basex_basis_sets_resize_1()
+    test_basex_basis_sets_resize_1_5()
     test_basex_shape()
     test_basex_zeros()
     test_basex_gaussian()

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -16,7 +16,8 @@ DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
 
 
 def get_basis_file_name(n, sigma):
-    return os.path.join(DATA_DIR, 'basex_basis_{}_{}.npy'.format(n, sigma))
+    return os.path.join(DATA_DIR,
+                        'basex_basis_{}_{}.npy'.format(n, float(sigma)))
 
 
 def test_basex_basis_sets_cache():
@@ -52,18 +53,22 @@ def basex_basis_sets_resize(sigma):
     remove_files()
     cache_cleanup()
     # generate small basis and save
-    Ai_s = get_bs_cached(n_s, sigma, basis_dir=DATA_DIR, verbose=False)
+    Ai_s = get_bs_cached(n_s, sigma, correction=False,
+                         basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # extend to large basis and save
-    Ai_s_l = get_bs_cached(n_l, sigma, basis_dir=DATA_DIR, verbose=False)
+    Ai_s_l = get_bs_cached(n_l, sigma, correction=False,
+                           basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # delete basis files
     remove_files()
     # generate large basis and save
-    Ai_l = get_bs_cached(n_l, sigma, basis_dir=DATA_DIR, verbose=False)
+    Ai_l = get_bs_cached(n_l, sigma, correction=False,
+                         basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # crop large basis to small
-    Ai_l_s = get_bs_cached(n_s, sigma, basis_dir=DATA_DIR, verbose=False)
+    Ai_l_s = get_bs_cached(n_s, sigma, correction=False,
+                           basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # delete basis files (clean-up)
     remove_files()
@@ -121,7 +126,7 @@ def basex_gaussian(sigma, reg, cor, tol):
     recon = recon[n // 2 + n % 2]
 
     ref = ref.func
-    if not isinstance(cor, bool):
+    if cor is not True:
         # old-style intensity correction
         recon /= cor
         # skip artifact from k = 0 near r = 0
@@ -138,18 +143,18 @@ def test_basex_gaussian():
        default parameters"""
     # (intensity correction using "magic number",
     #  see https://github.com/PyAbel/PyAbel/issues/230)
-    basex_gaussian(sigma=1, reg=0, cor=1.015, tol=3e-3)
-
-
-def test_basex_gaussian_corrected():
-    """Check a gaussian solution for BASEX:
-       default parameters, corrected"""
     basex_gaussian(sigma=1, reg=0, cor=True, tol=7e-4)
+
+
+def test_basex_gaussian_uncorrected():
+    """Check a gaussian solution for BASEX:
+       default parameters, without correction"""
+    basex_gaussian(sigma=1, reg=0, cor=1.015, tol=3e-3)
 
 
 def test_basex_gaussian_sigma_3():
     """Check a gaussian solution for BASEX:
-       large sigma (oscillating)"""
+       large sigma (oscillating), without correction"""
     basex_gaussian(sigma=3, reg=0, cor=1, tol=3e-2)
 
 
@@ -172,7 +177,7 @@ if __name__ == '__main__':
     test_basex_shape()
     test_basex_zeros()
     test_basex_gaussian()
-    test_basex_gaussian_corrected()
+    test_basex_gaussian_uncorrected()
     test_basex_gaussian_sigma_3()
     test_basex_gaussian_sigma_3_corrected()
     test_basex_gaussian_sigma_07_reg_10_corrected()

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import abel
-from abel.basex import get_bs_basex_cached, cache_cleanup
+from abel.basex import get_bs_cached, cache_cleanup
 from abel.tools.analytical import GaussianAnalytical
 
 
@@ -28,9 +28,9 @@ def test_basex_basis_sets_cache():
     if os.path.exists(file_name):
         os.remove(file_name)
     # 1st call generate and save
-    get_bs_basex_cached(n, basis_dir=DATA_DIR, verbose=False)
+    get_bs_cached(n, basis_dir=DATA_DIR, verbose=False)
     # 2nd call load from file
-    get_bs_basex_cached(n, basis_dir=DATA_DIR, verbose=False)
+    get_bs_cached(n, basis_dir=DATA_DIR, verbose=False)
     if os.path.exists(file_name):
         os.remove(file_name)
 
@@ -52,18 +52,18 @@ def test_basex_basis_sets_resize():
     # make sure that basis files do not exist
     remove_files()
     # generate small basis and save
-    Ai_s = get_bs_basex_cached(n_s, basis_dir=DATA_DIR, verbose=False)
+    Ai_s = get_bs_cached(n_s, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # extend to large basis and save
-    Ai_s_l = get_bs_basex_cached(n_l, basis_dir=DATA_DIR, verbose=False)
+    Ai_s_l = get_bs_cached(n_l, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # delete basis files
     remove_files()
     # generate large basis and save
-    Ai_l = get_bs_basex_cached(n_l, basis_dir=DATA_DIR, verbose=False)
+    Ai_l = get_bs_cached(n_l, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # crop large basis to small
-    Ai_l_s = get_bs_basex_cached(n_s, basis_dir=DATA_DIR, verbose=False)
+    Ai_l_s = get_bs_cached(n_s, basis_dir=DATA_DIR, verbose=False)
     cache_cleanup()
     # delete basis files (clean-up)
     remove_files()
@@ -75,7 +75,7 @@ def test_basex_basis_sets_resize():
 def test_basex_shape():
     n = 21
     x = np.ones((n, n), dtype='float32')
-    Ai = abel.basex.get_bs_basex_cached(n, basis_dir=None, verbose=False)
+    Ai = abel.basex.get_bs_cached(n, basis_dir=None, verbose=False)
 
     recon = abel.basex.basex_core_transform(x, Ai)
 
@@ -85,7 +85,7 @@ def test_basex_shape():
 def test_basex_zeros():
     n = 21
     x = np.zeros((n, n), dtype='float32')
-    Ai = abel.basex.get_bs_basex_cached(n, basis_dir=None, verbose=False)
+    Ai = abel.basex.get_bs_cached(n, basis_dir=None, verbose=False)
 
     recon = abel.basex.basex_core_transform(x, Ai)
 
@@ -102,9 +102,9 @@ def basex_gaussian(sigma, reg, cor, tol):
 
     correction = cor if isinstance(cor, bool) else False
 
-    Ai = abel.basex.get_bs_basex_cached(n, sigma=sigma, reg=reg,
-                                        correction=correction,
-                                        basis_dir=None, verbose=False)
+    Ai = abel.basex.get_bs_cached(n, sigma=sigma, reg=reg,
+                                  correction=correction,
+                                  basis_dir=None, verbose=False)
 
     recon = abel.basex.basex_core_transform(tr, Ai)
     recon = recon[n // 2 + n % 2]

--- a/abel/tests/test_tools_polynomial.py
+++ b/abel/tests/test_tools_polynomial.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 from scipy.special import hermite
 from math import factorial
 
+import abel
 from abel.tools.polynomial import Polynomial, PiecewisePolynomial
 
 
@@ -81,8 +82,32 @@ def test_polynomial_gaussian():
     assert_allclose(P.abel, abel, atol=1.0e-4)
 
 
+def test_polynomial_smoothstep():
+    """
+    Testing cubic smoothstep function,
+    using ``direct`` inverse transform.
+    """
+    n = 100
+    r = np.arange(float(n))
+    r_min = 20
+    r_max = 80
+    w = 10
+    h = 3
+
+    c = [1/2, 3/4, 0, -1/4]
+    P = PiecewisePolynomial(r, [(r_min - w, r_min + w, c, r_min, w),
+                                (r_min + w, r_max - w, [1]),
+                                (r_max - w, r_max + w, c, r_max, -w)])
+    P *= h
+
+    recon = abel.direct.direct_transform(P.abel, backend='python')
+
+    assert_allclose(P.func, recon, atol=2.0e-2)
+
+
 if __name__ == '__main__':
     test_polynomial_shape()
     test_polynomial_zeros()
     test_polynomial_step()
     test_polynomial_gaussian()
+    test_polynomial_smoothstep()

--- a/abel/tests/test_tools_polynomial.py
+++ b/abel/tests/test_tools_polynomial.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy.special import hermite
+from math import factorial
+
+from abel.tools.polynomial import Polynomial, PiecewisePolynomial
+
+
+def test_polynomial_shape():
+    """
+    Testing that func and abel have the same shape as r.
+    """
+    n = 20
+    r = np.linspace(0, n/2, n)
+    P = Polynomial(r, 0, n, [1])
+
+    assert P.func.shape == r.shape
+    assert P.abel.shape == r.shape
+
+
+def test_polynomial_zeros():
+    """
+    Testing that zero coefficients produce zero func and abel.
+    """
+    n = 20
+    r = np.linspace(0, n/2, n)
+    P = Polynomial(r, 0, n, [0, 0])
+
+    assert_allclose(P.func, 0)
+    assert_allclose(P.abel, 0)
+
+
+def test_polynomial_step():
+    """
+    Testing step function (and multiplication).
+    """
+    n = 50
+    r = np.linspace(0, n/2, n)
+    r_min = 10
+    r_max = 20
+    A = 2
+
+    P = A * Polynomial(r, r_min, r_max, [1/A])
+
+    func = np.zeros_like(r)
+    func[(r >= r_min) * (r <= r_max)] = 1
+
+    def sqrt0(x): return np.sqrt(x, np.zeros_like(x), where=x > 0)
+    abel = 2 * (sqrt0(r_max**2 - r**2) - sqrt0(r_min**2 - r**2))
+
+    assert_allclose(P.func, func)
+    assert_allclose(P.abel, abel)
+
+
+def test_polynomial_gaussian():
+    """
+    Testing shifted and scaled Taylor expansion of a Gaussian,
+    in reduced coordinates.
+    """
+    n = 100
+    r = np.linspace(0, n/2, n)
+    sigma = 15
+
+    # coefficients of Taylor series around r = 1
+    c = []
+    for k in range(50):
+        c.append(np.exp(-1.0) * hermite(k)(-1.0) / factorial(k))
+
+    P = Polynomial(r, 0, r[-1] + 2, c, sigma, sigma, reduced=True)
+    # scaling and shifting by sigma should produce exp(-(r/σ)^2),
+    # its Abel transform is √π σ exp(-(r/σ)^2)
+
+    func = np.exp(-(r / sigma)**2)
+    abel = np.sqrt(np.pi) * sigma * func
+
+    assert_allclose(P.func, func, atol=1.0e-7)
+    assert_allclose(P.abel, abel, atol=1.0e-4)
+
+
+if __name__ == '__main__':
+    test_polynomial_shape()
+    test_polynomial_zeros()
+    test_polynomial_step()
+    test_polynomial_gaussian()

--- a/abel/tools/__init__.py
+++ b/abel/tools/__init__.py
@@ -10,5 +10,6 @@ from . import io
 from . import math
 from . import polar
 from . import symmetry
+from . import polynomial
 from . import transform_pairs
 from . import vmi

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -54,35 +54,32 @@ class BaseAnalytical(object):
 
 
 class StepAnalytical(BaseAnalytical):
+    """
+    Define a symmetric step function and calculate its analytical
+    Abel transform. See examples/example_step.py
+
+    Parameters
+    ----------
+    n : int
+        number of points along the r axis
+    r_max : float
+        range of the r interval
+    symmetric : boolean
+        if True, the r interval is [-r_max, r_max] (and n should be odd),
+        otherwise the r interval is [0, r_max]
+    r1, r2 : float
+        bounds of the step function if r > 0
+        (symmetric function is constructed for r < 0)
+    A0: float
+        height of the step
+    ratio_valid_step: float
+        in the benchmark take only the central ratio*100% of the step
+        (exclude possible artefacts on the edges)
+    """
+    # see https://github.com/PyAbel/PyAbel/pull/16
 
     def __init__(self, n, r_max, r1, r2, A0=1.0,
                  ratio_valid_step=1.0, symmetric=True):
-        """
-        Define a symmetric step function and calculate its analytical
-        Abel transform. See examples/example_step.py
-
-        Parameters
-        ----------
-        n : int
-            number of points along the r axis
-        r_max : float
-            range of the r interval
-        symmetric : boolean
-            if True, the r interval is [-r_max, r_max] (and n should be odd),
-            otherwise the r interval is [0, r_max]
-        r1, r2 : float
-            bounds of the step function if r > 0
-            (symmetric function is constructed for r < 0)
-        A0: float
-            height of the step
-        ratio_valid_step: float
-            in the benchmark take only the central ratio*100% of the step
-            (exclude possible artefacts on the edges)
-
-        see https://github.com/PyAbel/PyAbel/pull/16
-
-        """
-
         super(StepAnalytical, self).__init__(n, r_max, symmetric)
 
         self.r1, self.r2 = r1, r2
@@ -163,40 +160,41 @@ class StepAnalytical(BaseAnalytical):
 
 
 class Polynomial(BaseAnalytical):
+    """
+    Define a polynomial function and calculate its analytical
+    Abel transform.
+
+    Parameters
+    ----------
+    n : int
+        number of points along the *r* axis
+    r_max : float
+        range of the *r* interval
+    symmetric : boolean
+        if ``True``, the *r* interval is [−\ **r_max**, +\ **r_max**]
+        (and **n** should be odd),
+        otherwise the *r* interval is [0, **r_max**]
+    r_1, r_2 : float
+        *r* bounds of the polynomial function if *r* > 0;
+        outside [**r_1**, **r_2**] the function is set to zero
+        (symmetric function is constructed for *r* < 0)
+    c: numpy array
+        polynomial coefficients in order of increasing degree:
+        [c₀, c₁, c₂] means c₀ + c₁ *r* + c₂ *r*\ ²
+    r_0 : float, optional
+        origin shift: the polynomial is defined as
+        c₀ + c₁ (*r* − **r_0**) + c₂ (*r* − **r_0**)² + ...
+    s : float, optional
+        *r* stretching factor (around **r_0**): the polynomial is defined as
+        c₀ + c₁ (*r*/s) + c₂ (*r*/s)² + ...
+    reduced : boolean, optional
+        internally rescale the *r* range to [0, 1];
+        useful to avoid floating-point overflows for high degrees
+        at large *r* (and might improve numerical accuracy)
+    """
     def __init__(self, n, r_max,
                  r_1, r_2, c, r_0=0.0, s=1.0, reduced=False,
                  symmetric=True):
-        """
-        Define a polynomial function and calculate its analytical
-        Abel transform.
-
-        Parameters
-        ----------
-        n : int
-            number of points along the r axis
-        r_max : float
-            range of the r interval
-        symmetric : boolean
-            if True, the r interval is [-r_max, r_max] (and n should be odd),
-            otherwise the r interval is [0, r_max]
-        r_1, r_2 : float
-            r bounds of the polynomial function if r > 0,
-            outside [r_1, r_2] the function is set to zero
-            (symmetric function is constructed for r < 0)
-        c: numpy array
-            polynomial coefficients in order of increasing degree:
-            [c_0, c_1, c_2] means c_1 + c_1 r + c_2 r^2
-        r_0 : float, optional
-            origin shift: the polynomial is defined as
-            c_1 + c_1 (r - r_0) + c_2 (r - r_0)^2 + ...
-        s : float, optional
-            r stretching factor (around r_0): the polynomial is defined as
-            c_1 + c_1 (r/s) + c_2 (r/s)^2 + ...
-        reduced : boolean, optional
-            internally reduce the r range to [0, 1];
-            useful to avoid floating-point overflows for high degrees
-            at large r (and might improve numerical accuracy)
-        """
         super(Polynomial, self).__init__(n, r_max, symmetric)
 
         # take r >= 0 part
@@ -218,33 +216,36 @@ class Polynomial(BaseAnalytical):
 
 
 class PiecewisePolynomial(BaseAnalytical):
+    """
+    Define a piecewise polynomial function (sum of ``Polynomial``\ s)
+    and calculate its analytical Abel transform.
+
+    Parameters
+    ----------
+    n : int
+        number of points along the *r* axis
+    r_max : float
+        range of the *r* interval
+    symmetric : boolean
+        if ``True``, the *r* interval is [−\ **r_max**, +\ **r_max**]
+        (and **n** should be odd),
+        otherwise the *r* interval is [0, **r_max**]
+    ranges : iterable of unpackable
+        (list of tuples of) polynomial parameters for each piece::
+
+           [(r_1_1st, r_2_1st, c_1st),
+            (r_1_2nd, r_2_2nd, c_2nd),
+            ...
+            (r_1_nth, r_2_nth, c_nth)]
+
+        according to ``Polynomial`` conventions.
+        All ranges are independent (may overlap and have gaps, may define
+        polynomials of any degrees) and may include optional ``Polynomial``
+        parameters
+    """
     def __init__(self, n, r_max,
                  ranges,
                  symmetric=True):
-        """
-        Define a piecewise polynomial function (sum of ``Polynomial``s)
-        and calculate its analytical Abel transform.
-
-        Parameters
-        ----------
-        n : int
-            number of points along the r axis
-        r_max : float
-            range of the r interval
-        symmetric : boolean
-            if True, the r interval is [-r_max, r_max] (and n should be odd),
-            otherwise the r interval is [0, r_max]
-        ranges : iterable of unpackable
-            (list of tuples of) polynomial parameters for each piece:
-            [(r_1_1st, r_2_1st, c_1st),
-             (r_1_2nd, r_2_2nd, c_2nd),
-             ...
-             (r_1_nth, r_2_nth, c_nth)]
-            according to ``Polynomial`` conventions.
-            All ranges are independent (may overlap and have gaps, may define
-            polynomials of any degrees) and may include optional ``Polynomial``
-            parameters
-        """
         super(PiecewisePolynomial, self).__init__(n, r_max, symmetric)
 
         # take r >= 0 part
@@ -266,33 +267,32 @@ class PiecewisePolynomial(BaseAnalytical):
 
 
 class GaussianAnalytical(BaseAnalytical):
+    """
+    Define a gaussian function and calculate its analytical
+    Abel transform. See examples/example_gaussian.py
+
+    Parameters
+    ----------
+    n : int
+        number of points along the r axis
+    r_max : float
+        range of the r interval
+    symmetric : boolean
+        if True, the r interval is [-r_max, r_max] (and n should be odd),
+        otherwise, the r interval is [0, r_max]
+    sigma : floats
+        sigma parameter for the gaussian
+    A0 : float
+        amplitude of the gaussian
+    ratio_valid_sigma : float
+        in the benchmark ta
+        0 < r < ration_valid_sigma * sigma
+        (exclude possible artefacts on the axis, and )
+    """
+    # Source: http://mathworld.wolfram.com/AbelTransform.html
+
     def __init__(self, n, r_max, sigma=1.0, A0=1.0,
                  ratio_valid_sigma=2.0, symmetric=True):
-        """
-        Define a gaussian function and calculate its analytical
-        Abel transform. See examples/example_gaussian.py
-
-        Parameters
-        ----------
-        n : int
-            number of points along the r axis
-        r_max : float
-            range of the r interval
-        symmetric : boolean
-            if True, the r interval is [-r_max, r_max] (and n should be odd),
-            otherwise, the r interval is [0, r_max]
-        sigma : floats
-            sigma parameter for the gaussian
-        A0 : float
-            amplitude of the gaussian
-        ratio_valid_sigma : float
-            in the benchmark ta
-            0 < r < ration_valid_sigma * sigma
-            (exclude possible artefacts on the axis, and )
-
-        Source: http://mathworld.wolfram.com/AbelTransform.html
-        """
-
         super(GaussianAnalytical, self).__init__(n, r_max, symmetric)
 
         self.sigma = sigma
@@ -378,35 +378,34 @@ class TransformPair(BaseAnalytical):
 
 
 class SampleImage(BaseAnalytical):
+    """
+    Sample images, made up of Gaussian functions
 
+    Parameters
+    ----------
+    n : integer
+        image size n rows x n cols
+
+    name : str
+        one of "dribinski" or "Ominus"
+
+    sigma : float
+        Gaussian 1/e width (pixels)
+
+    temperature : float
+        for 'Ominus' only
+        anion levels have Boltzmann population weight
+        (2J+1) exp(-177.1 h c 100/k/temperature)
+
+    Attributes
+    ----------
+    image : 2D numpy array
+         image
+
+    name : str
+         sample image name
+    """
     def __init__(self, n=361, name="dribinski", sigma=2, temperature=200):
-        """
-        Sample images, made up of Gaussian functions
-
-        Parameters
-        ----------
-        n : integer
-            image size n rows x n cols
-
-        name : str
-            one of "dribinski" or "Ominus"
-
-        sigma : float
-            Gaussian 1/e width (pixels)
-
-        temperature : float
-            for 'Ominus' only
-            anion levels have Boltzmann population weight
-            (2J+1) exp(-177.1 h c 100/k/temperature)
-
-        Attributes
-        ----------
-        image : 2D numpy array
-             image
-
-        name : str
-             sample image name
-        """
 
         def _gauss(r, r0, sigma):
             return np.exp(-(r-r0)**2/sigma**2)

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -7,7 +7,7 @@ import scipy.constants as const
 import scipy.interpolate
 
 # This file includes functions that have a known analytical Abel transform.
-# They are used in unit testing as well for comparing different Abel
+# They are used in unit testing and for comparing different Abel
 # impementations.
 
 
@@ -37,8 +37,8 @@ class BaseAnalytical(object):
             maximum r interval
 
         symmetric: boolean
-            if True the r interval is [-r_max, r_max]  (and n should be odd)
-                          otherwise the r interval is [0, r_max]
+            if True, the r interval is [-r_max, r_max] (and n should be odd),
+            otherwise, the r interval is [0, r_max]
         """
         self.n = n
         self.r_max = r_max
@@ -58,22 +58,21 @@ class StepAnalytical(BaseAnalytical):
     def __init__(self, n, r_max, r1, r2, A0=1.0,
                  ratio_valid_step=1.0, symmetric=True):
         """
-        Define a a symmetric step function and calculate it's analytical
+        Define a symmetric step function and calculate its analytical
         Abel transform. See examples/example_step.py
 
         Parameters
         ----------
         n : int
             number of points along the r axis
-        r_max: float
-            range of the symmetric r interval
-        symmetric: if True
-            the r interval is [-r_max, r_max]
-            (and n should be odd)
+        r_max : float
+            range of the r interval
+        symmetric : boolean
+            if True, the r interval is [-r_max, r_max] (and n should be odd),
             otherwise the r interval is [0, r_max]
-        r1, r2: floats
+        r1, r2 : float
             bounds of the step function if r > 0
-            (symetic function is constructed for r < 0)
+            (symmetric function is constructed for r < 0)
         A0: float
             height of the step
         ratio_valid_step: float
@@ -104,7 +103,7 @@ class StepAnalytical(BaseAnalytical):
 
     def abel_step_analytical(self, r, A0, r0, r1):
         """
-        Directed Abel transform of a step function located between r0 and r1,
+        Forward Abel transform of a step function located between r0 and r1,
         with a height A0
 
         ::
@@ -119,17 +118,17 @@ class StepAnalytical(BaseAnalytical):
 
         Parameters
         ----------
-        r1 : 1D array,
+        r1 : 1D array
             vecor of positions along the r axis. Must start with 0.
-        r0, r1 : floats,
+        r0, r1 : float
             positions of the step along the r axis
-        A0 : float or 1D array:
-            height of the step. If 1D array the height can be variable
-            along the Z axis
+        A0 : float or 1D array
+            height of the step. If 1D array, the height can be variable
+            along the z axis
 
         Returns
         -------
-            1D array if A0 is a float, a 2D array otherwise
+            1D array, if A0 is a float, a 2D array otherwise
         """
 
         if np.all(r[[0, -1]]):
@@ -151,7 +150,7 @@ class StepAnalytical(BaseAnalytical):
 
     def sym_abel_step_1d(self, r, A0, r0, r1):
         """
-        Produces a symmetrical analytical transform of a 1d step
+        Produces a symmetrical analytical transform of a 1D step
         """
         A0 = np.atleast_1d(A0)
         d = np.empty(A0.shape + r.shape)
@@ -176,15 +175,14 @@ class Polynomial(BaseAnalytical):
         n : int
             number of points along the r axis
         r_max : float
-            range of the symmetric r interval
-        symmetric : if True
-            the r interval is [-r_max, r_max]
-            (and n should be odd)
+            range of the r interval
+        symmetric : boolean
+            if True, the r interval is [-r_max, r_max] (and n should be odd),
             otherwise the r interval is [0, r_max]
         r_1, r_2 : float
-            r bounds of the polynomial function if r > 0
-            (symetic function is constructed for r < 0),
+            r bounds of the polynomial function if r > 0,
             outside [r_1, r_2] the function is set to zero
+            (symmetric function is constructed for r < 0)
         c: numpy array
             polynomial coefficients in order of increasing degree:
             [c_0, c_1, c_2] means c_1 + c_1 r + c_2 r^2
@@ -232,10 +230,9 @@ class PiecewisePolynomial(BaseAnalytical):
         n : int
             number of points along the r axis
         r_max : float
-            range of the symmetric r interval
-        symmetric : if True
-            the r interval is [-r_max, r_max]
-            (and n should be odd)
+            range of the r interval
+        symmetric : boolean
+            if True, the r interval is [-r_max, r_max] (and n should be odd),
             otherwise the r interval is [0, r_max]
         ranges : iterable of unpackable
             (list of tuples of) polynomial parameters for each piece:
@@ -279,17 +276,16 @@ class GaussianAnalytical(BaseAnalytical):
         ----------
         n : int
             number of points along the r axis
-        r_max: float
-            range of the symmetric r interval
-        symmetric: if True
-            the r interval is [-r_max, r_max]
-            (and n should be odd)
-            otherwise the r interval is [0, r_max]
-        sigma: floats
+        r_max : float
+            range of the r interval
+        symmetric : boolean
+            if True, the r interval is [-r_max, r_max] (and n should be odd),
+            otherwise, the r interval is [0, r_max]
+        sigma : floats
             sigma parameter for the gaussian
-        A0: float
+        A0 : float
             amplitude of the gaussian
-        ratio_valid_sigma: float
+        ratio_valid_sigma : float
             in the benchmark ta
             0 < r < ration_valid_sigma * sigma
             (exclude possible artefacts on the axis, and )
@@ -347,7 +343,7 @@ class TransformPair(BaseAnalytical):
     """
 
     def __init__(self, n, profile=5):
-        """Create Abel transform pair for profile `n`.
+        """Create Abel transform pair for given profile number.
 
         Parameters
         ----------
@@ -369,7 +365,7 @@ class TransformPair(BaseAnalytical):
         r[-1] -= 1.0e-8
 
         if profile > 8:
-            raise ValueError('only 1-8 profiles:'
+            raise ValueError('Only 1-8 profiles: '
                              'see "abel/tools/transform_pairs.py"')
 
         self.label = 'profile{}'.format(profile)
@@ -405,7 +401,7 @@ class SampleImage(BaseAnalytical):
 
         Attributes
         ----------
-        image : 2D np.array
+        image : 2D numpy array
              image
 
         name : str
@@ -420,7 +416,7 @@ class SampleImage(BaseAnalytical):
             Sample test image used in the BASEX paper
             Rev. Sci. Instrum. 73, 2634 (2002)
 
-            9x Gaussian functions of half-width 4 pixel +
+            9 Gaussian functions of half-width 4 pixel +
             1 background Gaussian of width 3600
 
             anisotropy - ß = -1  for cosθ term
@@ -462,7 +458,7 @@ class SampleImage(BaseAnalytical):
             t6 = _gauss(r, 324*rfact, sigma)  # 3P0 <- 2P1/2
 
             # intensities = fine-structure known ratios
-            # 2P1/2 transtions scaled by temperature dependent Boltzmann factor
+            # 2P1/2 transtions scaled by temperature-dependent Boltzmann factor
             t = t1 + 0.8*t2 + 0.36*t3 + (0.2*t4 + 0.36*t5 + 0.16*t6)*boltzmann
 
             # anisotropy
@@ -490,4 +486,4 @@ class SampleImage(BaseAnalytical):
                         / 2
             self.image = _Ominus(R, THETA, sigma=sigma, boltzmann=boltzmann)
         else:
-            raise ValueError('sample image name not recognized')
+            raise ValueError('Sample image name not recognized')

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -285,9 +285,9 @@ class GaussianAnalytical(BaseAnalytical):
     A0 : float
         amplitude of the gaussian
     ratio_valid_sigma : float
-        in the benchmark ta
+        in the benchmark take only the range
         0 < r < ration_valid_sigma * sigma
-        (exclude possible artefacts on the axis, and )
+        (exclude possible artefacts on the axis and the possibly clipped tail)
     """
     # Source: http://mathworld.wolfram.com/AbelTransform.html
 

--- a/abel/tools/polynomial.py
+++ b/abel/tools/polynomial.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+
+import numpy as np
+from scipy.linalg import pascal, toeplitz
+from scipy.special import binom
+
+
+class Polynomial(object):
+    def __init__(self, r, r_min, r_max, c, r_0=0.0, s=1.0, reduced=False):
+        """
+        Polynomial function and its Abel transform.
+
+        Parameters
+        ----------
+        r : numpy array
+            r values at which the function is generated
+            (and x values for its Abel transform);
+            must be non-negative and in ascending order
+        r_min, r_max : float
+            r domain:
+            the function is defined as the polynomial on [r_min, r_max]
+            and zero outside it;
+            0 <= ``r_min`` < ``r_max`` <~ max r
+            (``r_max`` might exceed maximal ``r``, but usually by < 1 pixel)
+        c: numpy array
+            polynomial coefficients in order of increasing degree:
+            [c_0, c_1, c_2] means c_1 + c_1 r + c_2 r^2
+        r_0 : float, optional
+            origin shift: the polynomial is defined as
+            c_1 + c_1 (r - r_0) + c_2 (r - r_0)^2 + ...
+        s : float, optional
+            r stretching factor (around r_0): the polynomial is defined as
+            c_1 + c_1 (r/s) + c_2 (r/s)^2 + ...
+        reduced : boolean, optional
+            internally reduce the r range to [0, 1];
+            useful to avoid floating-point overflows for high degrees
+            at large r (and might improve numeric accuracy)
+        """
+
+        # remove zero high-order terms
+        c = np.array(np.trim_zeros(c, 'b'), float)
+        # if all coefficients are zero
+        if len(c) == 0:
+            # then both func and abel are also zero everywhere
+            self.func = np.zeros_like(r)
+            self.abel = self.func
+            return
+        # polynomial degree
+        K = len(c) - 1
+
+        if reduced:
+            # rescale r to [0, 1] (to avoid FP overflow)
+            r = r / r_max
+            r_0 /= r_max
+            s /= r_max
+            abel_scale = r_max
+            r_min /= r_max
+            r_max = 1.0
+
+        if s != 1.0:
+            # apply stretch
+            S = np.cumprod([1.0] + [1.0 / s] * K)  # powers of 1/s
+            c *= S
+        if r_0 != 0.0:
+            # apply shift
+            P = pascal(1 + K, 'upper', False)  # binomial coefficients
+            rk = np.cumprod([1.0] + [-float(r_0)] * K)  # powers of -r_0
+            T = toeplitz([1.0] + [0.0] * K, rk)  # upper-diag. (-r_0)^{l - k}
+            c = (P * T).dot(c)
+
+        # whether even and odd powers are present
+        even = np.any(c[::2])
+        odd = np.any(c[1::2])
+
+        # index limits
+        n = r.shape[0]
+        i_min = np.searchsorted(r, r_min)
+        i_max = np.searchsorted(r, r_max)
+
+        # Calculate all necessary variables within [0, r_max]
+
+        # x, x^2
+        x = r[:i_max]
+        x2 = x * x
+
+        # integration limits y = sqrt(r^2 - x^2) or 0
+        def sqrt0(x): return np.sqrt(x, np.zeros_like(x), where=x > 0)
+        y_up = sqrt0(r_max * r_max - x2)
+        y_lo = sqrt0(r_min * r_min - x2)
+
+        # y r^k |_lo^up
+        # (actually only even are neded for "even", and only odd for "odd")
+        Dyr = np.outer(np.cumprod([1.0] + [r_max] * K), y_up) - \
+              np.outer(np.cumprod([1.0] + [r_min] * K), y_lo)
+
+        # ln(r + y) |_lo^up, only for odd k
+        if odd:
+            # ln x for x > 0, otherwise 0
+            def ln0(x): return np.log(x, np.zeros_like(x), where=x > 0)
+            Dlnry = ln0(r_max + y_up) - \
+                    ln0(np.maximum(r_min, x) + y_lo)
+
+        # One-sided Abel integral \int_lo^up r^k dy.
+        def a(k):
+            odd_k = k % 2
+            # max. x power
+            K = k - 1 if odd_k else k
+            # generate coefficients for all x^l r^{k - l} terms
+            C = [0] * (K + 1)  # only even indices are actually used
+            if odd_k:
+                c = 1 / (k + 1)
+                C[0] = c
+                for l in range(K - 2, -1, -2):
+                    c *= (l + 3) / (l + 2)
+                    C[K - l] = c
+                # C[K] is also used for x^{k+1} ln(r + y)
+            else:  # even k
+                c = 1 / abs(binom(-3/2, k / 2))
+                C[K] = c
+                for l in range(0, K + 1, 2):
+                    C[K - l] = c
+                    c *= (l + 1) / (l + 2)
+            # sum all terms using Horner's method in x
+            a = C[K] * Dyr[k - K]
+            if odd_k:
+                a += C[K] * x2 * Dlnry
+            for l in range(K - 2, -1, -2):
+                a = a * x2 + C[l] * Dyr[k - l]
+            return a
+
+        # Generate the polynomial function
+        func = np.zeros(n)
+        span = slice(i_min, i_max)
+        # (using Horner's method)
+        func[span] = c[K]
+        for k in range(K - 1, -1, -1):
+            func[span] = func[span] * x[span] + c[k]
+        self.func = func
+
+        # Generate its Abel transform
+        abel = np.zeros(n)
+        span = slice(0, i_max)
+        if reduced:
+            c *= abel_scale
+        for k in range(K + 1):
+            if c[k]:
+                abel[span] += c[k] * 2 * a(k)
+        self.abel = abel
+
+    def __imul__(self, m):
+        """
+        In-place multiplication: Polynomial *= num.
+        """
+        self.func *= m
+        self.abel *= m
+        return self
+
+    def __mul__(self, m):
+        """
+        Multiplication: Polynomial * num.
+        """
+        res = self.__new__(type(self))  # create empty object (same type)
+        res.func = self.func * m
+        res.abel = self.abel * m
+        return res
+
+    __rmul__ = __mul__
+    __rmul__.__doc__ = \
+        """
+        Multiplication: num * Polynomial.
+        """
+
+    def __itruediv__(self, m):
+        """
+        In-place division: Polynomial /= num.
+        """
+        return self.__imul__(1 / m)
+
+    def __truediv__(self, m):
+        """
+        Division: Polynomial / num.
+        """
+        return self.__mul__(1 / m)
+
+    # (Addition and subtraction are not implemented because they are
+    #  meaningful only for polynomials generated over the same r array.
+    #  Use PiecewisePolynomial for sums of polynomials.)
+
+
+class PiecewisePolynomial(Polynomial):
+    def __init__(self, r, ranges):
+        """
+        Piecewise polynomial function (sum of ``Polynomial``s)
+        and its Abel transform.
+
+        Parameters
+        ----------
+        r : numpy array
+            r values at which the function is generated
+            (and x values for its Abel transform)
+        ranges : iterable of unpackable
+            (list of tuples of) polynomial parameters for each piece:
+            [(r_min_1st, r_max_1st, c_1st),
+             (r_min_2nd, r_max_2nd, c_2nd),
+             ...
+             (r_min_nth, r_max_nth, c_nth)]
+            according to ``Polynomial`` conventions.
+            All ranges are independent (may overlap and have gaps, may define
+            polynomials of any degrees) and may include optional ``Polynomial``
+            parameters
+        """
+
+        self.p = []
+        for rng in ranges:
+            self.p.append(Polynomial(r, *rng))
+
+        func = self.p[0].func
+        for p in self.p[1:]:
+            func += p.func
+        self.func = func
+
+        abel = self.p[0].abel
+        for p in self.p[1:]:
+            abel += p.abel
+        self.abel = abel
+
+    # (Multiplication and division methods are inherited from Polynomial.)

--- a/abel/tools/polynomial.py
+++ b/abel/tools/polynomial.py
@@ -7,37 +7,38 @@ from scipy.special import binom
 
 
 class Polynomial(object):
+    """
+    Polynomial function and its Abel transform.
+
+    Supports multiplication and division by numbers.
+
+    Parameters
+    ----------
+    r : numpy array
+        *r* values at which the function is generated
+        (and *x* values for its Abel transform);
+        must be non-negative and in ascending order
+    r_min, r_max : float
+        *r* domain:
+        the function is defined as the polynomial on [**r_min**, **r_max**]
+        and zero outside it;
+        0 ≤ **r_min** < **r_max** ≲ **max r**
+        (**r_max** might exceed maximal **r**, but usually by < 1 pixel)
+    c: numpy array
+        polynomial coefficients in order of increasing degree:
+        [c₀, c₁, c₂] means c₀ + c₁ *r* + c₂ *r*\ ²
+    r_0 : float, optional
+        origin shift: the polynomial is defined as
+        c₀ + c₁ (*r* − **r_0**) + c₂ (*r* − **r_0**)² + ...
+    s : float, optional
+        *r* stretching factor (around **r_0**): the polynomial is defined as
+        c₀ + c₁ (*r*/**s**) + c₂ (*r*/**s**)² + ...
+    reduced : boolean, optional
+        internally rescale the *r* range to [0, 1];
+        useful to avoid floating-point overflows for high degrees
+        at large r (and might improve numeric accuracy)
+    """
     def __init__(self, r, r_min, r_max, c, r_0=0.0, s=1.0, reduced=False):
-        """
-        Polynomial function and its Abel transform.
-
-        Parameters
-        ----------
-        r : numpy array
-            r values at which the function is generated
-            (and x values for its Abel transform);
-            must be non-negative and in ascending order
-        r_min, r_max : float
-            r domain:
-            the function is defined as the polynomial on [r_min, r_max]
-            and zero outside it;
-            0 <= ``r_min`` < ``r_max`` <~ max r
-            (``r_max`` might exceed maximal ``r``, but usually by < 1 pixel)
-        c: numpy array
-            polynomial coefficients in order of increasing degree:
-            [c_0, c_1, c_2] means c_1 + c_1 r + c_2 r^2
-        r_0 : float, optional
-            origin shift: the polynomial is defined as
-            c_1 + c_1 (r - r_0) + c_2 (r - r_0)^2 + ...
-        s : float, optional
-            r stretching factor (around r_0): the polynomial is defined as
-            c_1 + c_1 (r/s) + c_2 (r/s)^2 + ...
-        reduced : boolean, optional
-            internally reduce the r range to [0, 1];
-            useful to avoid floating-point overflows for high degrees
-            at large r (and might improve numeric accuracy)
-        """
-
         # remove zero high-order terms
         c = np.array(np.trim_zeros(c, 'b'), float)
         # if all coefficients are zero
@@ -189,28 +190,31 @@ class Polynomial(object):
 
 
 class PiecewisePolynomial(Polynomial):
+    """
+    Piecewise polynomial function (sum of ``Polynomial``\ s)
+    and its Abel transform.
+
+    Supports multiplication and division by numbers.
+
+    Parameters
+    ----------
+    r : numpy array
+        *r* values at which the function is generated
+        (and *x* values for its Abel transform)
+    ranges : iterable of unpackable
+        (list of tuples of) polynomial parameters for each piece::
+
+           [(r_min_1st, r_max_1st, c_1st),
+            (r_min_2nd, r_max_2nd, c_2nd),
+            ...
+            (r_min_nth, r_max_nth, c_nth)]
+
+        according to ``Polynomial`` conventions.
+        All ranges are independent (may overlap and have gaps, may define
+        polynomials of any degrees) and may include optional ``Polynomial``
+        parameters
+    """
     def __init__(self, r, ranges):
-        """
-        Piecewise polynomial function (sum of ``Polynomial``s)
-        and its Abel transform.
-
-        Parameters
-        ----------
-        r : numpy array
-            r values at which the function is generated
-            (and x values for its Abel transform)
-        ranges : iterable of unpackable
-            (list of tuples of) polynomial parameters for each piece:
-            [(r_min_1st, r_max_1st, c_1st),
-             (r_min_2nd, r_max_2nd, c_2nd),
-             ...
-             (r_min_nth, r_max_nth, c_nth)]
-            according to ``Polynomial`` conventions.
-            All ranges are independent (may overlap and have gaps, may define
-            polynomials of any degrees) and may include optional ``Polynomial``
-            parameters
-        """
-
         self.p = []
         for rng in ranges:
             self.p.append(Polynomial(r, *rng))

--- a/abel/tools/polynomial.py
+++ b/abel/tools/polynomial.py
@@ -3,7 +3,6 @@ from __future__ import division
 
 import numpy as np
 from scipy.linalg import pascal, toeplitz
-from scipy.special import binom
 
 
 class Polynomial(object):
@@ -106,28 +105,20 @@ class Polynomial(object):
         def a(k):
             odd_k = k % 2
             # max. x power
-            K = k - 1 if odd_k else k
-            # generate coefficients for all x^l r^{k - l} terms
-            C = [0] * (K + 1)  # only even indices are actually used
-            if odd_k:
-                c = 1 / (k + 1)
-                C[0] = c
-                for l in range(K - 2, -1, -2):
-                    c *= (l + 3) / (l + 2)
-                    C[K - l] = c
-                # C[K] is also used for x^{k+1} ln(r + y)
-            else:  # even k
-                c = 1 / abs(binom(-3/2, k / 2))
-                C[K] = c
-                for l in range(0, K + 1, 2):
-                    C[K - l] = c
-                    c *= (l + 1) / (l + 2)
+            K = k - odd_k  # (k - 1 for odd k)
+            # generate coefficients for all x^m r^{k - m} terms
+            # (only even indices are actually used;
+            #  for odd k, C[K] is also used for x^{k+1} ln(r + y))
+            C = [0] * (K + 1)
+            C[0] = 1 / (k + 1)
+            for m in range(k, 1, -2):
+                C[k - m + 2] = C[k - m] * m / (m - 1)
             # sum all terms using Horner's method in x
             a = C[K] * Dyr[k - K]
             if odd_k:
                 a += C[K] * x2 * Dlnry
-            for l in range(K - 2, -1, -2):
-                a = a * x2 + C[l] * Dyr[k - l]
+            for m in range(K - 2, -1, -2):
+                a = a * x2 + C[m] * Dyr[k - m]
             return a
 
         # Generate the polynomial function

--- a/doc/abel.rst
+++ b/doc/abel.rst
@@ -103,6 +103,14 @@ abel.tools.polar module
     :undoc-members:
     :show-inheritance:
 
+abel.tools.polynomial module
+-----------------------
+
+.. automodule:: abel.tools.polynomial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 abel.tools.transform_pairs module
 ----------------------------------
 

--- a/doc/abel.rst
+++ b/doc/abel.rst
@@ -169,3 +169,13 @@ abel.benchmark module
     :members:
     :undoc-members:
     :show-inheritance:
+
+abel.tests module
+-----------------
+
+.. automodule:: abel.tests.run
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/doc/abel.rst
+++ b/doc/abel.rst
@@ -177,13 +177,3 @@ abel.benchmark module
     :members:
     :undoc-members:
     :show-inheritance:
-
-abel.tests module
------------------
-
-.. automodule:: abel.tests.run
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,6 +136,9 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Properly format combined parameters with common type/description.
+napoleon_use_param = False
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ setup(name='PyAbel',
       packages=find_packages(),
       install_requires=install_requires,
       package_data={'abel': ['tests/data/*' ]},
-      test_suite="abel.tests.run_cli",
       classifiers=[
       # How mature is this project? Common values are
       #   3 - Alpha


### PR DESCRIPTION
This addresses all issues in #230 and finalizes #226.

## Main changes

The basis-generation code (`_bs_basex()`) is rewritten almost completely.
- Now it works with arbitrary width parameters _σ_ and accepts `n, sigma` instead of `n, nbf`. `sigma` is actually used everywhere, since it is more fundamental than `nbf` (which is `n` / `sigma`).
- The computations became is >10 times faster:
   - All the needed Γ-function values are precomputed, which takes _O_(_n_<sup>2</sup>) extra space (~the same as for the basis matrices), but avoids recomputing them _O_(_n_<sup>3</sup>) times.
   - The summation cutoff is tightened very close to the limit for "numerically exact" results (floating-point precision).
- It can take previously computed smaller basis matrices for the same _σ_ and extend them by computing only the missing (outer) elements.

The `get_bs_cached()` code (renamed from `get_bs_basex_cached()` for consistency) is changed accordingly.
- The file-naming scheme is changed to `basex_basis_{n}_{sigma}.npy`.
- Attempts to get the basis (if not already in memory) are tried in the following order:
   1. If the file for given `n`, `sigma` exists, then it is used.
   2. If files for larger `n` and the same `sigma` exist, then the smallest of them is loaded and cropped.
   3. If files for smaller `n` and the same `sigma` exist, then the largest of them is loaded and extended by `_bs_basex()`.
   4. If nothing helps, then a completely new basis is generated.

The `MAGIC_NUMBER` intensity correction is replaced by `get_basex_correction()`, activated by passing `correction=True` to `basex_transform()` (or `get_bs_cached()`). See #230 for details.

A new module `abel.tools.polynomial` is added (primarily for `get_basex_correction()`), which implements the analytical Abel transform for arbitrary polynomials. `Polynomial` and `PiecewisePolynomial` are added to `abel.tools.analytical`.

Test are added/updated for `abel.basex` and `abel.tools.polynomial`.

## Additional changes

Declared `_source` as `global` in `dash.cache_cleanup()` (amending #232).

Minor corrections to documentation.
In particular, `abel.tools.analytical` docstrings are moved from `__init__()` to class levels, since they were not visible in the generated documentation.

## Questions

What is `mask_valid` in `BaseAnalytical` and how to set it meaningfully for polynomials?

What happened to the `GaussianAnalytical` docstring (the [`ratio_valid_sigma` description](https://github.com/PyAbel/PyAbel/blob/be2d1adb1b20a664ac6f757d1c40fb737222ba63/abel/tools/analytical.py#L187-L190))?

The are some problems with multiple parameters in docstrings, for example, see [`abel.tools.polar.cart2polar`](https://pyabel.readthedocs.io/en/latest/abel.html#abel.tools.polar.cart2polar) — `x, y : floats or arrays` is rendered as "**y** (_x,_)".
This is probably related to https://github.com/sphinx-doc/sphinx/issues/2227?

Perhaps, `linbasex.basis_cache_cleanup()` should be renamed to `linbasex.cache_cleanup()` for consistency with and `dasch.cache_cleanup()` `basex.cache_cleanup()`?