### PR TITLE
Trying to fix zenodo releases

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,13 +5,16 @@
       "name": "Gibson, Stephen"
     },
     {
-      "name": "Hickstein, Daniel"
+      "name": "Hickstein, Daniel D."
     },
     {
       "name": "Yurchak, Roman"
     },
     {
       "name": "Ryazanov, Mikhail"
+    },
+    {
+      "name": "Das, Dhrubajyoti"
     },
     {
       "name": "Shih, Gilbert"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,19 +2,19 @@
   "creators": [
     {
       "affiliation": "Australian National University",
-      "name": "Gibson, Stephen",
+      "name": "Gibson, Stephen"
     },
     {
-      "name": "Hickstein, Daniel",
+      "name": "Hickstein, Daniel"
     },
     {
-      "name": "Yurchak, Roman",
+      "name": "Yurchak, Roman"
     },
     {
-      "name": "Ryazanov, Mikhail",
+      "name": "Ryazanov, Mikhail"
     },
     {
-      "name": "Shih, Gilbert",
+      "name": "Shih, Gilbert"
     } 
   ],
   "license": "MIT",

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,6 +57,7 @@ which should launch a browser window displaying the docs. When you save a change
 
 Alternatively, `restview <https://pypi.python.org/pypi/restview>`_ is a nice way to preview the ``.rst`` files.
 
+
 Before merging
 --------------
 
@@ -123,12 +124,20 @@ Dependencies
 
 The current list of dependencies can be found in `setup.py <https://github.com/PyAbel/PyAbel/blob/master/setup.py>`_. Please refrain from adding new dependencies, unless it cannot be avoided.
 
+
 Change Log
 ----------
 
 If the change is significant (more than just a typo-fix), please leave a short note about the change in `CHANGELOG.rst <https://github.com/PyAbel/PyAbel/blob/master/CHANGELOG.rst>`_
 
+
 Releasing on PyPi
 -----------------
 
 PyAbel should be automatically released on PyPi (see PR `#161 <https://github.com/PyAbel/PyAbel/pull/161>`_) whenever a new release is drafted on GitHub via the "Draft New Release" button on the `Releases page <https://github.com/PyAbel/PyAbel/releases>`_. Just remember to increment the version number in abel/_version.py first.
+
+
+Citations
+---------
+
+Each version of PyAbel that is released triggers a new DOI on Zenodo, so that people can cite the project. If you would like you name added to the author list on Zenodo, please include it in ``.zenodo.json``. 


### PR DESCRIPTION
I'm still trying to get the automatic publishing of new releases to Zenodo to work.

For v0.8.0, we got the following response from Zenodo:
```
{
    "errors": "Unknown error occured."
}
```
which is super helpful. This was the "payload" delivered to Zenodo from GitHub [[gist link](https://gist.github.com/DanHickstein/e6a840e1e2d2adccda8811cf467a77d0)]

I then realized that many of the author names on Zenodo for v0.7.6 were just the github user names, and not our real names. I figured out that we can make a `.zenodo.json` file in out repository that contains our corrected names.

Then, I released v0.8.1, and got the following error:
```
{
    "errors": "Metadata file \".zenodo.json\" is not valid JSON."
}
```
Which is legit, because I had some extra commas in the .json file. I removed these, and used https://jsonlint.com/ to ensure that the .json file was valid.

So, I guess we get to try again when we release version 0.8.2, whenever we do that.

EDIT: I also includes some information in CONTRIBUTING.rst saying that people can include their names in that file to be listed as authors on Zenodo.

