### PR TITLE
BASEX forward transform

### DIFF
--- a/abel/basex.py
+++ b/abel/basex.py
@@ -243,10 +243,10 @@ def _nbf(n, sigma):
 _bs_prm = None   # [n, sigma]
 _bs = None       # [M, Mc]
 # forward transform
-_trf_prm = None  # [reg, correction]
+_trf_prm = None  # [reg, correction, dr]
 _trf = None      # Af
 # inverse transform
-_tri_prm = None  # [reg, correction]
+_tri_prm = None  # [reg, correction, dr]
 _tri = None      # Ai
 
 def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
@@ -387,9 +387,9 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
 
     # Check whether transform matrices for these parameters
     # are already created
-    if direction == 'forward' and _trf_prm == [reg, correction]:
+    if direction == 'forward' and _trf_prm == [reg, correction, dr]:
         A = _trf
-    elif direction == 'inverse' and _tri_prm == [reg, correction]:
+    elif direction == 'inverse' and _tri_prm == [reg, correction, dr]:
         A = _tri
     else:  # recalculate
         if verbose:
@@ -401,18 +401,17 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
             cor = get_basex_correction(A, sigma, direction)
             A = np.multiply(A, cor)
         if direction == 'forward':
-            _trf_prm = [reg, correction]
+            _trf_prm = [reg, correction, dr]
             _trf = A
         else:  # 'inverse'
-            _tri_prm = [reg, correction]
+            _tri_prm = [reg, correction, dr]
             _tri = A
-
-    # Apply intensity scaling, if needed
-    if dr != 1.0:
-        if direction == 'forward':
-            A *= dr
-        else:  # 'inverse'
-            A /= dr
+        # apply intensity scaling, if needed
+        if dr != 1.0:
+            if direction == 'forward':
+                A *= dr
+            else:  # 'inverse'
+                A /= dr
 
     return A
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -31,6 +31,8 @@ from ._version import __version__
 # https://doi.org/10.1063/1.1482156
 #
 #
+# 2018-10-29
+#   MR added forward transform.
 # 2018-10-27
 #   MR exposed BASIS_SET_CUTOFF for speed/accuracy control.
 # 2018-10-07
@@ -86,16 +88,12 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=True,
     Abel transform. It works on a "right side" image. I.e.,
     it works on just half of a cylindrically symmetric
     object, and ``data[0,0]`` should correspond to a central pixel.
-    To perform a BASEX transorm on
-    a whole image, use ::
+    To perform a BASEX transform on a whole image, use ::
 
         abel.Transform(image, method='basex', direction='inverse').transform
 
     This BASEX implementation only works with images that have an
     odd-integer full width.
-
-    Note: only the `direction="inverse"` transform is currently implemented.
-
 
     Parameters
     ----------
@@ -111,6 +109,8 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=True,
         regularization parameter, square of the Tikhonov factor.
         ``reg=0`` means no regularization,
         ``reg=100`` is a reasonable value for megapixel images.
+        Forward transform requires regularization only if **sigma** < 1,
+        and **reg** should be ≪ 1.
     correction : boolean
         apply intensity correction in order to reduce method artifacts
         (intensity normalization and oscillations)
@@ -122,20 +122,14 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=True,
         This only affects the absolute scaling of the transformed image.
     verbose : boolean
         determines whether statements should be printed
-    direction : str
-        the type of Abel transform to be performed.
-        Currently only accepts value ``'inverse'``.
-
+    direction : str ('forward' or 'inverse')
+        type of Abel transform to be performed
 
     Returns
     -------
     recon : m × n numpy array
         the transformed (half) image
-
     """
-
-    if direction != 'inverse':
-        raise ValueError('Forward BASEX transform not implemented')
 
     # make sure that the data is the right shape (1D must be converted to 2D):
     data = np.atleast_2d(data)
@@ -152,12 +146,13 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=True,
 
     n = data.shape[1]
 
-    # load the basis sets:
-    Ai = get_bs_cached(n, sigma=sigma, reg=reg, correction=correction,
-                       basis_dir=basis_dir, verbose=verbose)
+    # load the basis sets and compute the transform matrix
+    A = get_bs_cached(n, sigma=sigma, reg=reg, correction=correction,
+                      basis_dir=basis_dir, verbose=verbose,
+                      direction=direction)
 
-    # Do the actual transform:
-    recon = basex_core_transform(data, Ai, dr)
+    # do the actual transform
+    recon = basex_core_transform(data, A, dr)
 
     if data_ndim == 1:  # taking the middle row, since the rest are zeroes
         recon = recon[recon.shape[0] - recon.shape[0]//2 - 1]  # ??
@@ -167,26 +162,24 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=True,
         return recon
 
 
-def basex_core_transform(rawdata, Ai, dr=1.0):
+def basex_core_transform(rawdata, A, dr=1.0):
     """
-    This is the internal function that does the actual BASEX transform.
+    Internal function that does the actual BASEX transform.
     It requires that the transform matrix be passed.
-
 
     Parameters
     ----------
     rawdata : m × n numpy array
-        the raw image. This is the right half (with the axis) of the image.
+        right half (with the axis) of the input image.
     Ai : n × n numpy array
         2D array given by the transform-calculation function
     dr : float
         pixel size. This only affects the absolute scaling of the output.
 
-
     Returns
     -------
     IM : m × n numpy array
-        the Abel-transformed image, a slice of the 3D distribution
+        the Abel-transformed image
     """
 
     # Note that our images are stored with matrix rows corresponding to
@@ -197,39 +190,48 @@ def basex_core_transform(rawdata, Ai, dr=1.0):
     # The vertical transform is not applied, since without regularization
     # its overall effect is an identity transform.
 
-    # Reconstructing image  - This is where the magic happens
-    IM = rawdata.dot(Ai) / dr
-    # P = dot(dot(Mc,Ci),M.T) # This calculates the projection, !! not
-    # which should recreate the original image                  !! really
-    return IM
+    # transform the image
+    IM = rawdata.dot(A)
+
+    # apply intensity scaling, if needed
+    if dr == 1.0:
+        return IM
+    else:
+        return IM / dr
 
 
-def _get_Ai(M, Mc, reg):
-    """ An internal helper function for no-up/down-asymmetry BASEX:
-        given basis sets M, Mc,
-        return matrix of inverse Abel transform
+def _get_A(M, Mc, reg, direction):
+    """ Internal helper function.
+        Calculates the forward/inverse Abel-transform matrix
+        from basis matrices for given regularization parameter.
     """
-    # Ai  is the overall (horizontal) transform matrix,
+    # A   is the overall (horizontal) transform matrix,
     #     corresponds to A^T Z in the article.
     # reg corresponds to q_1^2 in the article.
 
+    # basis matrices for input and output spaces
+    if direction == 'forward':
+        Bi, Bo = Mc, M  # image -> projection
+    else:  # 'inverse'
+        Bi, Bo = M, Mc  # projection -> image
+
     n, nbf = M.shape
     if reg == 0.0 and nbf == n:
-        Ai = inv(M.T).dot(Mc.T)
+        A = inv(Bi.T).dot(Bo.T)
     else:
         # square of Tikhonov matrix
         E = np.diag([reg] * nbf)
-        # regularized inverse of basis projection
-        R = M.dot(inv((M.T).dot(M) + E))
-        # {expansion coefficients} = projection . R
-        # image = {expansion coefficients} . {image basis}
-        # so: image = projection . (R . {image basis})
-        #     image = projection . Ai
-        #     Ai = R . {image basis}
-        # Ai is the matrix of the inverse Abel transform
-        Ai = R.dot(Mc.T)
+        # regularized inverse of input basis
+        R = Bi.dot(inv((Bi.T).dot(Bi) + E))
+        # {expansion coefficients} = input . R
+        # output = {expansion coefficients} . {output basis}
+        # so: output = input . (R . {output basis})
+        #     output = input . A
+        #     A = R . {output basis}
+        # A is the matrix of the Abel transform
+        A = R.dot(Bo.T)
 
-    return Ai
+    return A
 
 
 def _nbf(n, sigma):
@@ -242,13 +244,18 @@ def _nbf(n, sigma):
 
 
 # Cached matrices and their parameters
-_bs_prm = None  # [n, sigma]
-_bs = None      # [M, Mc]
-_tr_prm = None  # [reg, correction]
-_tr = None      # Ai
+# basis set
+_bs_prm = None   # [n, sigma]
+_bs = None       # [M, Mc]
+# forward transform
+_trf_prm = None  # [reg, correction]
+_trf = None      # Af
+# inverse transform
+_tri_prm = None  # [reg, correction]
+_tri = None      # Ai
 
 def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
-                  basis_dir='.', verbose=False):
+                  basis_dir='.', verbose=False, direction='inverse'):
     """
     Internal function.
 
@@ -276,14 +283,18 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
     basis_dir : str
         path to the directory for saving / loading the basis sets.
         If ``None``, the basis sets will not be saved to disk.
+    verbose : boolean
+        determines whether statements should be printed
+    direction : str ('forward' or 'inverse')
+        type of Abel transform to be performed
 
     Returns
     -------
     Ai : n × n numpy array
-        the matrix of the inverse Abel transform
+        matrix of the Abel transform (forward or inverse)
     """
 
-    global _bs_prm, _bs, _tr_prm, _tr
+    global _bs_prm, _bs, _trf_prm, _trf, _tri_prm, _tri
 
     sigma = float(sigma)  # (ensure FP format)
     nbf = _nbf(n, sigma)
@@ -374,28 +385,35 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
 
         _bs_prm = [n, sigma]
         _bs = [M, Mc]
-        _tr_prm = None
+        _trf_prm = None
+        _tri_prm = None
 
-    # Check whether transform matrices for this regularization
-    # are already loaded
-    if _tr_prm == [reg, correction]:
-        Ai = _tr
+    # Check whether transform matrices for these parameters
+    # are already created
+    if direction == 'forward' and _trf_prm == [reg, correction]:
+        A = _trf
+    elif direction == 'inverse' and _tri_prm == [reg, correction]:
+        A = _tri
     else:  # recalculate
         if verbose:
             print('Updating regularization...')
-        Ai = _get_Ai(*_bs, reg=reg)
+        A = _get_A(*_bs, reg=reg, direction=direction)
         if correction:
             if verbose:
                 print('Calculating correction...')
-            cor = get_basex_correction(Ai, sigma)
-            Ai = np.multiply(Ai, cor)
-        _tr_prm = [reg, correction]
-        _tr = Ai
+            cor = get_basex_correction(A, sigma, direction)
+            A = np.multiply(A, cor)
+        if direction == 'forward':
+            _trf_prm = [reg, correction]
+            _trf = A
+        else:  # 'inverse'
+            _tri_prm = [reg, correction]
+            _tri = A
 
-    return Ai
+    return A
 
 
-def cache_cleanup():
+def cache_cleanup(select='all'):
     """
     Utility function.
 
@@ -405,21 +423,30 @@ def cache_cleanup():
 
     Parameters
     ----------
-    None
+    select : str
+        selects which caches to clean:
+        ``'all'`` (default) everything, including basis;
+        ``'forward'`` forward transform;
+        ``'inverse'`` inverse transform.
 
     Returns
     -------
     None
     """
-    global _bs_prm, _bs, _tr_prm, _tr
+    global _bs_prm, _bs, _trf_prm, _trf, _tri_prm, _tri
 
-    _bs_prm = None
-    _bs = None
-    _tr_prm = None
-    _tr = None
+    if select == 'all':
+        _bs_prm = None
+        _bs = None
+    if select in ('all', 'forward'):
+        _trf_prm = None
+        _trf = None
+    if select in ('all', 'inverse'):
+        _tri_prm = None
+        _tri = None
 
 
-def get_basex_correction(Ai, sigma):
+def get_basex_correction(A, sigma, direction):
     """
     Internal function.
 
@@ -434,17 +461,19 @@ def get_basex_correction(Ai, sigma):
 
     Parameters
     ----------
-    Ai : n × n numpy array
-        matrix of the inverse Abel transform
+    A : n × n numpy array
+        matrix of the Abel transform
     sigma : float
         basis width parameter
+    direction : str ('forward' or 'inverse')
+        type of the Abel transform
 
     Returns
     -------
     cor : 1 × **n** numpy array
         intensity correction profile
     """
-    n = Ai.shape[0]
+    n = A.shape[0]
     nbf = _nbf(n, sigma)
 
     # Generate soft step function and its projection
@@ -459,11 +488,14 @@ def get_basex_correction(Ai, sigma):
                                    (c, c + w, [0, 0, 1/2], c + w, w)])
     # (this is more numerically stable at large r than cubic smoothstep)
 
-    # get BASEX inverse Abel transform of the projection
-    tran = basex_core_transform(step.abel, Ai)
-
-    # correction profile = expected / BASEX result
-    cor = step.func / tran
+    # get BASEX Abel transform of the projection
+    # and set correction profile = expected / BASEX result
+    if direction == 'forward':
+        tran = basex_core_transform(step.func, A)
+        cor = step.abel / tran
+    else:  # 'inverse'
+        tran = basex_core_transform(step.abel, A)
+        cor = step.func / tran
 
     return cor
 
@@ -492,23 +524,23 @@ def _bs_basex(n=251, sigma=1.0, oldM=None, verbose=True):
 
     Parameters:
     -----------
-    n : integer
+    n : int
         horizontal dimensions of the half-width image in pixels.
         Must include the axial pixel.
         See https://github.com/PyAbel/PyAbel/issues/34
     sigma : float
         width parameter for basis functions
     oldM : numpy array
-        projected basis matrix for the same ``sigma`` but a smaller image size.
+        projected basis matrix for the same **sigma** but a smaller image size.
         Can be supplied to avoid recalculating matrix elements
         that are already available.
 
     Returns:
     --------
-    M, Mc : n x nbf numpy arrays
-        ``Mc`` is the reconstructed-image basis rho_k(r_i) (~Gaussians),
+    M, Mc : **n** × **nbf** numpy array
+        **Mc** is the reconstructed-image basis rho_k(r_i) (~Gaussians),
                corresponds to Z^T in the article.
-        ``M``  is the projected basis chi_k(x_i),
+        **M**  is the projected basis chi_k(x_i),
                corresponds to X^T in the article.
     """
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -411,7 +411,7 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
     if dr != 1.0:
         if direction == 'forward':
             A *= dr
-        else:
+        else:  # 'inverse'
             A /= dr
 
     return A

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -107,22 +107,25 @@ def basex_transform(data, sigma=1.0, reg=0.0, correction=True,
         is not very meaningful and requires regularization.
     reg : float
         regularization parameter, square of the Tikhonov factor.
-        ``reg=0`` means no regularization,
-        ``reg=100`` is a reasonable value for megapixel images.
+
+            ``reg=0`` means no regularization,
+
+            ``reg=100`` is a reasonable value for megapixel images.
+
         Forward transform requires regularization only if **sigma** < 1,
         and **reg** should be ≪ 1.
     correction : boolean
         apply intensity correction in order to reduce method artifacts
         (intensity normalization and oscillations)
     basis_dir : str
-        path to the directory for saving / loading the basis-set coefficients.
+        path to the directory for saving / loading the basis sets.
         If ``None``, the basis set will not be saved to disk.
     dr : float
         size of one pixel in the radial direction.
         This only affects the absolute scaling of the transformed image.
     verbose : boolean
         determines whether statements should be printed
-    direction : str ('forward' or 'inverse')
+    direction : str: ``'forward'`` or ``'inverse'``
         type of Abel transform to be performed
 
     Returns
@@ -261,8 +264,8 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
     Parameters
     ----------
     n : int
-        Abel inverse transform will be performed on an
-        **n** pixels wide area of the (half) image
+        Abel transform will be performed on an **n** pixels wide area
+        of the (half) image
     sigma : float
         width parameter for basis functions
     reg : float
@@ -279,7 +282,7 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
         pixel size. This only affects the absolute scaling of the output.
     verbose : boolean
         determines whether statements should be printed
-    direction : str ('forward' or 'inverse')
+    direction : str: ``'forward'`` or ``'inverse'``
         type of Abel transform to be performed
 
     Returns
@@ -426,9 +429,13 @@ def cache_cleanup(select='all'):
     ----------
     select : str
         selects which caches to clean:
-        ``'all'`` (default) everything, including basis;
-        ``'forward'`` forward transform;
-        ``'inverse'`` inverse transform.
+
+        ``all`` (default)
+            everything, including basis;
+        ``forward``
+            forward transform;
+        ``inverse``
+            inverse transform.
 
     Returns
     -------
@@ -466,12 +473,12 @@ def get_basex_correction(A, sigma, direction):
         matrix of the Abel transform
     sigma : float
         basis width parameter
-    direction : str ('forward' or 'inverse')
+    direction : str: ``'forward'`` or ``'inverse'``
         type of the Abel transform
 
     Returns
     -------
-    cor : 1 × **n** numpy array
+    cor : 1 × n numpy array
         intensity correction profile
     """
     n = A.shape[0]
@@ -489,7 +496,7 @@ def get_basex_correction(A, sigma, direction):
                                    (c, c + w, [0, 0, 1/2], c + w, w)])
     # (this is more numerically stable at large r than cubic smoothstep)
 
-    # get BASEX Abel transform of the projection
+    # get BASEX Abel transform of the step
     # and set correction profile = expected / BASEX result
     if direction == 'forward':
         tran = basex_core_transform(step.func, A)
@@ -523,8 +530,8 @@ def _bs_basex(n=251, sigma=1.0, oldM=None, verbose=True):
     """
     Generates horizontal basis sets for the BASEX method.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     n : int
         horizontal dimensions of the half-width image in pixels.
         Must include the axial pixel.
@@ -536,13 +543,15 @@ def _bs_basex(n=251, sigma=1.0, oldM=None, verbose=True):
         Can be supplied to avoid recalculating matrix elements
         that are already available.
 
-    Returns:
-    --------
-    M, Mc : **n** × **nbf** numpy array
-        **Mc** is the reconstructed-image basis rho_k(r_i) (~Gaussians),
-               corresponds to Z^T in the article.
-        **M**  is the projected basis chi_k(x_i),
-               corresponds to X^T in the article.
+    Returns
+    -------
+    M, Mc : n × nbf numpy array
+        Mc
+            is the reconstructed-image basis rho_k(r_i) (~Gaussians),
+            corresponds to Z^T in the article.
+        M
+            is the projected basis chi_k(x_i),
+            corresponds to X^T in the article.
     """
 
     sigma = float(sigma)  # (ensure FP type)

--- a/abel/tests/test_basex.py
+++ b/abel/tests/test_basex.py
@@ -170,6 +170,44 @@ def test_basex_gaussian_sigma_07_reg_10_corrected():
     basex_gaussian(sigma=0.7, reg=10, cor=True, tol=6e-3)
 
 
+def basex_forward_gaussian(sigma, reg, atol, rtol):
+    """Check a gaussian solution for BASEX"""
+    n = 100
+    r_max = n - 1
+
+    ref = GaussianAnalytical(n, r_max, symmetric=False, sigma=30)
+    tr = np.tile(ref.func[None, :], (n, 1))  # make a 2D array from 1D
+
+    Ai = abel.basex.get_bs_cached(n, sigma=sigma, reg=reg,
+                                  basis_dir=None, verbose=False,
+                                  direction='forward')
+
+    proj = abel.basex.basex_core_transform(tr, Ai)
+    proj = proj[n // 2 + n % 2]
+
+    ref = ref.abel
+
+    assert_allclose(proj, ref, atol=atol, rtol=rtol)
+
+
+def test_basex_forward_gaussian():
+    """Check a gaussian solution for BASEX forward transform:
+       default parameters"""
+    basex_forward_gaussian(sigma=1, reg=0, atol=1e-3, rtol=2e-3)
+
+
+def test_basex_forward_gaussian_3():
+    """Check a gaussian solution for BASEX forward transform:
+       large sigma"""
+    basex_forward_gaussian(sigma=3, reg=0, atol=1e-3, rtol=4e-3)
+
+
+def test_basex_forward_gaussian_07():
+    """Check a gaussian solution for BASEX forward transform:
+       small sigma, regularized"""
+    basex_forward_gaussian(sigma=0.7, reg=1e-6, atol=1e-3, rtol=1e-2)
+
+
 if __name__ == '__main__':
     test_basex_basis_sets_cache()
     test_basex_basis_sets_resize_1()
@@ -181,3 +219,6 @@ if __name__ == '__main__':
     test_basex_gaussian_sigma_3()
     test_basex_gaussian_sigma_3_corrected()
     test_basex_gaussian_sigma_07_reg_10_corrected()
+    test_basex_forward_gaussian()
+    test_basex_forward_gaussian_3()
+    test_basex_forward_gaussian_07()


### PR DESCRIPTION
This adds the forward Abel transform to the BASEX method.

The basic idea is that since the projected image and its reconstruction are described by the same coefficients, but in different basis sets (related to each other through the forward/inverse Abel transform), swapping these basis sets and applying the same method reverses the transform direction.

Then there are some technical details related to the _dr_ scaling and what to use for the intensity correction.

`cache_cleanup()` now accepts an optional parameter for selective cache purging. For example, it is possible to do a forward transform, discard its matrix, keeping the basis set cached, and do an inverse transform. By default, it still purges everything.

I've added new tests for the forward transform, but no benchmarks, since they should be the same. Do we need them for completeness?