### PR TITLE
Updates to convert from travis-ci.org to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 PyAbel README
 =============
 
-.. image:: https://travis-ci.org/PyAbel/PyAbel.svg?branch=master
-    :target: https://travis-ci.org/PyAbel/PyAbel
+.. image:: https://travis-ci.com/PyAbel/PyAbel.svg?branch=master
+    :target: https://travis-ci.com/PyAbel/PyAbel
 .. image:: https://ci.appveyor.com/api/projects/status/g1rj5f0g7nohcuuo
     :target: https://ci.appveyor.com/project/PyAbel/PyAbel
 


### PR DESCRIPTION
This is in response to https://github.com/PyAbel/PyAbel/issues/242. 

So far, I think that the only update is that we need to change the link to the badge in README.rst from .org to .com. Part of this PR is a test to see if we can successfully trigger builds on travis-ci.com. 