### PR TITLE
New benchmark code

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -346,7 +346,6 @@ class AbelTiming(object):
     # Do not take or return anything, but use instance variables:
     # parameters:
     #   self.ni, self.h, self.w -- image size, height, half-width,
-    #   self.n_max_bs, self.n_max_slow -- image-size limits
     #   self.whole_image, self.half_image -- image (part) to transform
     # results:
     #   self.res[kind][method] = [timings] -- appended for each image size,

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -272,7 +272,7 @@ class AbelTiming(object):
         if self.ni > self.n_max_bs:
             self._append('bs', 'basex_bs', np.nan)
             for direction in ['inverse', 'forward']:
-                for method in ['basex', 'basex(var)']:
+                for method in ['basex', 'basex(var.reg.)']:
                     self._append(direction, method, np.nan)
 
         # benchmark the basis generation (default parameters)

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -274,6 +274,7 @@ class AbelTiming(object):
             for direction in ['inverse', 'forward']:
                 for method in ['basex', 'basex(var.reg.)']:
                     self._append(direction, method, np.nan)
+            return
 
         # benchmark the basis generation (default parameters)
         def gen_basis():
@@ -333,6 +334,7 @@ class AbelTiming(object):
         if self.ni > self.n_max_bs:
             self._append('bs', 'linbasex_bs', np.nan)
             self._append('inverse', 'linbasex', np.nan)
+            return
 
         # benchmark the basis generation (default parameters)
         def gen_basis():
@@ -362,6 +364,7 @@ class AbelTiming(object):
         if self.ni > self.n_max_bs:
             self._append('bs', method + '_bs', np.nan)
             self._append('inverse', method, np.nan)
+            return
 
         # benchmark the basis generation (default parameters)
         def gen_basis():

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -440,8 +440,10 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
     a binary array with the symmetry condition for the corresponding quadrants.
     The globa
 
-    Note: if both i_sym=True and i_sym=True, the input array is checked
-    for polar symmetry.
+    Notes
+    -----
+    If both **i_sym** = ``True`` and **j_sym** = ``True``, the input array is
+    checked for polar symmetry.
 
     See https://github.com/PyAbel/PyAbel/issues/34#issuecomment-160344809
     for the defintion of a center of the image.
@@ -469,7 +471,7 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
 def absolute_ratio_benchmark(analytical, recon, kind='inverse'):
     """
     Check the absolute ratio between an analytical function and the result
-    of a inv. Abel reconstruction.
+    of a inverse Abel reconstruction.
 
     Parameters
     ----------

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -477,33 +477,41 @@ class AbelTiming(object):
 
     def __repr__(self):
         import platform
-        from itertools import chain
 
-        out = []
-        out += ['PyAbel benchmark run on {}\n'.format(platform.processor())]
-        out += ['time in milliseconds']
+        out = ['PyAbel benchmark run on {}\n'.format(platform.processor()),
+               'time in milliseconds']
 
-        LABEL_FORMAT = 'Implementation  ' +\
-                       ''.join(['    n = {:<9} '.format(ni) for ni in self.n])
-        ROW_FORMAT = '{:>16} ' + ' {:8.1f}         '*len(self.n)
-        SEP_ROW = '' + '-'*(22 + (17+1)*len(self.n))
-
-        HEADER_ROW = '\n========= {:>8} Abel implementations ==========\n'
+        # field widths are chosen to accommodate up to:
+        #   method = 15 characters
+        #   ni = 99999 (would require at least 75 GB RAM)
+        #   time = 9999999.9 ms (almost 3 hours)
+        # data columns are 9 characters wide and separated by 3 spaces
+        TITLE_FORMAT = '=== {} ==='
+        HEADER_ROW = 'Method         ' + \
+                     ''.join(['   {:>9}'.
+                              format('n = {}'.format(ni)) for ni in self.n])
+        SEP_ROW = '-' * len(HEADER_ROW)
+        ROW_FORMAT = '{:15}' + '   {:9.1f}' * len(self.n)
 
         def print_benchmark(name, res):
-            out = [HEADER_ROW.format(name)]
-            if res:
-                out += [LABEL_FORMAT]
-                out += [SEP_ROW]
-                for name, row in sorted(res.items()):
-                    out += [ROW_FORMAT.format(name, *row)]
+            title = '{:=<{w}}'.format(TITLE_FORMAT.format(name),
+                                      w=len(SEP_ROW))
+            out = ['\n' + title + '\n']
+            out += [HEADER_ROW]
+            out += [SEP_ROW]
+            for name, row in sorted(res.items()):
+                out += [ROW_FORMAT.format(name, *row)]
             return out
 
-        out += print_benchmark('Basis', self.bs)
-        out += ['']
-        out += print_benchmark('Forward', self.fabel)
-        out += ['']
-        out += print_benchmark('Inverse', self.iabel)
+        if self.bs:
+            out += print_benchmark('Basis generation', self.bs)
+            out += ['']
+        if self.fabel:
+            out += print_benchmark('Forward Abel transform', self.fabel)
+            out += ['']
+        if self.iabel:
+            out += print_benchmark('Inverse Abel transform', self.iabel)
+
         return '\n'.join(out)
 
 

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -309,7 +309,6 @@ class AbelTiming(object):
         res_keys = []
         for p in param:
             res_keys += itertools.product(*map(ensure_list, p))
-        res_keys = [(k, m + '_bs' if k == 'bs' else m) for k, m in res_keys]
 
         def decorator(f):
             method = f.__name__[6:]  # (remove initial "_time_")
@@ -360,7 +359,7 @@ class AbelTiming(object):
         def gen_basis():
             basex.cache_cleanup()
             basex.get_bs_cached(self.w, basis_dir=None)
-        self._benchmark('bs', 'basex_bs',
+        self._benchmark('bs', 'basex',
                         gen_basis)
 
         # benchmark all transforms
@@ -415,7 +414,7 @@ class AbelTiming(object):
         def gen_basis():
             linbasex.cache_cleanup()
             linbasex.get_bs_cached(self.h, basis_dir=None)
-        self._benchmark('bs', 'linbasex_bs',
+        self._benchmark('bs', 'linbasex',
                         gen_basis)
 
         # get the basis (is already cached)
@@ -440,7 +439,7 @@ class AbelTiming(object):
         def gen_basis():
             dasch.cache_cleanup()
             dasch.get_bs_cached(method, self.w, basis_dir=None)
-        self._benchmark('bs', method + '_bs',
+        self._benchmark('bs', method,
                         gen_basis)
 
         # get the transform matrix (is already cached)


### PR DESCRIPTION
This is the reworked `abel.benchmark.AbelTiming`.

The main changes are related to the basis caching now used by all the basis-set methods, plus that `basex` also got the forward transform (and variable regularization, as previously addressed in the experimental [bench-var](https://github.com/MikhailRyazanov/PyAbel/tree/bench-var)). It also implements the “run for at least _n_ seconds” idea, which help to get more stable results for fast stuff without running the slow stuff too many times.

Since it turned out that different methods require somewhat different benchmarking procedures, I have created here an individual function for each method, which benchmarks everything related to that method (basis-set generation, forward and inverse transforms — as applicable). This makes the code more localized and easier to modify and to accommodate future methods. It should also consume less memory, since instead of first generating basis sets for all the methods and keeping them all in RAM before testing the transforms, the procedure is now
```
for each method:
  generate method's basis
  test method's transforms
  clean-up
```
so only at most one basis set is kept in RAM.

There is a technical decision to benchmark `get_bs_cached()` for each method instead of the specific low-level basis-generating functions. The reason is that this makes the code simpler and uniform, while these functions have a relatively small overhead (even for `basex`) compared to the basis generation itself.

From the interface point of view, the `transform_repeat` is renamed to `repeat` because it also applies to basis-generation benchmarks (I think that it should, since they take about the same time as some transform methods). Also the `duration` parameter is added.

Let's discuss whether all this makes sense and what needs to be changed (naming, comments/docs, default parameters)...

(I also propose to add a `verbose` parameter for printing some progress information (to `stderr`) instead of being completely silent for seconds–minutes–hours and only at the end showing the summary.)