### PR TITLE
hansenlaw with gradient calculated as a first-order finite difference

### DIFF
--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -161,8 +161,13 @@ def hansenlaw_transform(image, dr=1, direction='inverse', hold_order=0,
         drive = -2*dr*np.pi*np.copy(image)
         a = 1  # integration increases lambda + 1
     else:  # inverse Abel transform
-        drive = np.zeros_like(image)
-        drive[:, :-1] = (image[:, 1:] - image[:, :-1])/dr
+        if hold_order == 0:
+            # better suits sharp structure - see issue #249
+            drive = np.zeros_like(image)
+            drive[:, :-1] = (image[:, 1:] - image[:, :-1])/dr
+        else:
+            # hold_order=1 prefers gradient
+            drive = np.gradient(image, dr, axis=-1)
         a = 0  # due to 1/piR factor
 
     n = np.arange(cols-1, 1, -1)

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-from scipy.ndimage import interpolation
 
 #############################################################################
 # hansenlaw - a recursive method forward/inverse Abel transform algorithm

--- a/abel/onion_bordas.py
+++ b/abel/onion_bordas.py
@@ -109,7 +109,7 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=False,
     # onion-peeling uses grid rather than pixel values, 
     # odd shaped whole images require shift image (-1/2, -1/2)
     if shift_grid:
-        IM = shift(IM, -1/2)
+        IM = shift(IM, (0, -1/2))
 
     # make sure that the data is the right shape (1D must be converted to 2D):
     IM = np.atleast_2d(IM.copy())
@@ -164,6 +164,6 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=False,
 
     # shift back to pixel grid
     if shift_grid:
-        abel_arr = shift(abel_arr, 1/2)
+        abel_arr = shift(abel_arr, (0, 1/2))
 
     return abel_arr/(2*dr)  # x1/2 for 'correct' normalization   

--- a/abel/onion_bordas.py
+++ b/abel/onion_bordas.py
@@ -109,7 +109,7 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=False,
     # onion-peeling uses grid rather than pixel values, 
     # odd shaped whole images require shift image (-1/2, -1/2)
     if shift_grid:
-        IM = shift(IM, (0, -1/2))
+        IM = shift(IM, -1/2)
 
     # make sure that the data is the right shape (1D must be converted to 2D):
     IM = np.atleast_2d(IM.copy())
@@ -164,6 +164,6 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=False,
 
     # shift back to pixel grid
     if shift_grid:
-        abel_arr = shift(abel_arr, (0, 1/2))
+        abel_arr = shift(abel_arr, 1/2)
 
     return abel_arr/(2*dr)  # x1/2 for 'correct' normalization   


### PR DESCRIPTION
For `hansenlaw` evaluate the image row gradient as a first-order finite difference, as per @MikhailRyazanov suggestion:
> Well, in one dimension, “gradient” is the derivative. But I see that PyAbel actually calculates it using numpy.gradient, which assumes “that f ... has at least 3 continuous derivatives” — I think, this is way too much to expect from any experimental data.

> Basically, the problem is that NumPy uses the two-sided formula to estimate the derivative at the grid points, whereas our integral (2) actually needs the derivatives within the integration intervals. I suspect that using the standard first-order finite differences and choosing the integration points half-way between the image sample points will work better. For the “direct” method at least, I don't know how the Hansel–Law method works.

Bonus, the `sub_pixel_shift=-0.35` grid-alignment (for `hold_order=0`) is no longer required, and has been dropped.