### PR TITLE
New benchmark code (update)

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -21,9 +21,9 @@ import sys
 
 def _ensure_list(x):
     """
-    Wrap the argument in a list, if it is not a list already.
+    Convert the argument to a list (a scalar becomes a single-element list).
     """
-    return x if isinstance(x, list) else [x]
+    return [x] if np.ndim(x) == 0 else list(x)
 
 
 def _roundsf(x, n):
@@ -128,9 +128,9 @@ class AbelTiming(object):
 
     Parameters
     ----------
-    n : int or list of int
+    n : int or sequence of int
         array size(s) for the benchmark (assuming 2D square arrays (*n*, *n*))
-    select : str or list of str
+    select : str or sequence of str
         methods to benchmark. Use ``'all'`` (default) for all available or
         choose any combination of individual methods::
 

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -259,7 +259,9 @@ class AbelTiming(object):
                         self.half_image = np.random.randn(self.h, self.w)
                     if methods & need_whole:
                         self.whole_image = np.random.randn(self.h, self.h)
-                except KeyboardInterrupt:
+                except (KeyboardInterrupt, MemoryError) as e:
+                    self._vprint(repr(e) + ' during image creation!'
+                                 ' Skipping the rest...')
                     self.t_max = -1.0
                     # (the images will not be used, so leaving them as is)
 
@@ -268,9 +270,8 @@ class AbelTiming(object):
                 self._vprint(' ', method)
                 try:
                     getattr(self, '_time_' + method)()
-                except KeyboardInterrupt:
-                    self._vprint('\nInterrupted by the user! '
-                                 'Skipping the rest...')
+                except (KeyboardInterrupt, MemoryError) as e:
+                    self._vprint('\n' + repr(e) + '! Skipping the rest...')
                     self.t_max = -1.0
                     # rerun this interrupted benchmark to nan-fill its results
                     getattr(self, '_time_' + method)()


### PR DESCRIPTION
1. For convenience, multiple image sizes (`n=...`) can now be passed as `numpy.ndarray` (or any other object convertible to Python's `list`). The previous implementation required multiple sizes to be passed as a list and was producing not very helpful error messages otherwise.
2. Some people try to use `abel.benchmark.AbelTiming` for very large image sizes, and if it runs out of memory, the program crashes, losing all the previous results. To avoid that, the `MemoryError` exception is now handled in the same way as `SIGINT` (Ctrl+C), skipping the rest of the benchmarks, but preserving the existing results.

I have only tested that this memory handling works in Linux when the requested size is too large.
If anybody is willing to test it in Windows and macOS, and also how it works (in all systems) in cases when the requested memory is close to the limit (for example, less than the RAM size but more than the free RAM, and more than the physical RAM but less than the RAM + swap), please report here.