### PR TITLE
abel.tools.vmi.angular_integration() Jacobian should be R^2 not R

### DIFF
--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -62,8 +62,8 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
 
     dt = T[0, 1] - T[0, 0]
 
-    if Jacobian:  # x r sinθ
-        polarIM = polarIM * R * np.abs(np.sin(T))
+    if Jacobian:  # x r^2 sinθ
+        polarIM *= R**2 * np.abs(np.sin(T))
 
     speeds = np.trapz(polarIM, axis=1, dx=dt)
 


### PR DESCRIPTION
Trivial bug, the Jacobian, line 66, in `abel.tools.vmi.angular_integration()` should be <math>R<sup>2</sup>sin&theta;</math> not <math>Rsin&theta;</math>.

Tracked down from some recent velocity-map imaging data that has intensity near the image centre. The `xR` resultant photoelectron spectrum is way too strong.

<math>R</math>   vs <math>R<sup>2</sup></math>:

![image](https://user-images.githubusercontent.com/10932229/57005798-35dceb00-6c1e-11e9-96e6-60296565b054.png)![image](https://user-images.githubusercontent.com/10932229/57005802-3d03f900-6c1e-11e9-8a34-7d18eca9e073.png)

