### PR TITLE
Various radial distributions

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -535,7 +535,10 @@ class DistributionsTiming(object):
         ``'full'``:
             full image (*n*, *n*), centered
     rmax : str or sequence of str
-        symbolic **rmax** for :class:`abel.tools.vmi.Distributions`
+        ``'MIN'`` (default) and/or ``'all'``, see **rmax** in
+        :class:`abel.tools.vmi.Distributions`
+    order : int
+        highest order in the angular distributions. Even number ≥ 0.
     weight : str or sequence of str
         weighting to test. Use ``'all'`` (default) for all available or
         choose any combination of individual types::
@@ -573,8 +576,8 @@ class DistributionsTiming(object):
     The results can be output in a nice format by simply
     ``print(DistributionsTiming(...))``.
     """
-    def __init__(self, n=[301, 501], shape='half', rmax='MIN', weight='all',
-                 method='all', repeat=1, t_min=0.1):
+    def __init__(self, n=[301, 501], shape='half', rmax='MIN', order=2,
+                 weight='all', method='all', repeat=1, t_min=0.1):
         self.n = _ensure_list(n)
 
         if shape == 'Q':
@@ -590,6 +593,8 @@ class DistributionsTiming(object):
             raise ValueError('Incorrect shape "{}"'.format(shape))
 
         self.rmaxs = rmaxs = _ensure_list(rmax)
+
+        self.order = order
 
         weights = _ensure_list(weight)
         if 'all' in weights:
@@ -634,9 +639,10 @@ class DistributionsTiming(object):
                             w = weight
                         # single-image
                         t1 = time(Ibeta,
-                                  IM, origin, rmax, weight=w, method=method)
+                                  IM, origin, rmax, order, weight=w,
+                                  method=method)
                         # cached
-                        distr = Distributions(origin, rmax, weight=w,
+                        distr = Distributions(origin, rmax, order, weight=w,
                                               method=method)
                         distr(IM)  # trigger precalculations
 
@@ -652,7 +658,7 @@ class DistributionsTiming(object):
         import platform
 
         out = ['PyAbel benchmark run on {}\n'.format(platform.processor()),
-               'time in milliseconds']
+               'order = {}, time in milliseconds'.format(self.order)]
 
         # field widths are chosen to accommodate up to:
         #   rmax + weight = 3 leading spaces + 10 characters

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -664,8 +664,7 @@ class DistributionsTiming(object):
                      ''.join(['   {:>9}'.
                               format('n = {}'.format(ni)) for ni in self.n])
         SEP_ROW = '-' * len(HEADER_ROW)
-        ROW1_FORMAT = '   {}, {:5}' + '   {:9.1f}' * len(self.n)
-        ROWn_FORMAT = '             ' + '   {:9.1f}' * len(self.n)
+        ROW_FORMAT = '   {}, {:5}' + '   {:9.1f}' * len(self.n)
 
         def print_benchmark(mode):
             title = '{:=<{w}}'.format(TITLE_FORMAT.format(mode),
@@ -680,8 +679,8 @@ class DistributionsTiming(object):
                     resr = resm[rmax]
                     for weight in self.weights:
                         res = resr[weight]
-                        t = zip(*res)[0 if mode == 'single' else 1]
-                        out += [ROW1_FORMAT.format(rmax, weight, *t)]
+                        t = list(zip(*res))[0 if mode == 'single' else 1]
+                        out += [ROW_FORMAT.format(rmax, str(weight), *t)]
             return out
 
         out += print_benchmark('single')

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -89,7 +89,8 @@ def hansenlaw_transform(image, dr=1, direction='inverse', hold_order=0,
         full image.
 
 
-    For the full image transform, use the :class:``abel.Transform``.
+    For the full image transform, use the
+    :class:`abel.Transform<abel.transform.Transform>`.
 
     Inverse Abel transform: ::
 

--- a/abel/tests/test_tools_distributions.py
+++ b/abel/tests/test_tools_distributions.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
+import itertools
 
 from abel.tools.vmi import Distributions, harmonics
 
@@ -50,29 +51,29 @@ def run_order(method, tol):
         for i in range(1, n + 1):
             Q += peak(i)
 
-        for wname in [None, 'sin', 'array']:
-            weight = np.full_like(Q, 0.5) if wname == 'array' else wname
-            for rmax in ['MIN', 'all']:
-                param = '-> rmax = {}, order={}, weight = {}, method = {}'.\
-                        format(rmax, 2 * n, wname, method)
-                cossin = Distributions('ul', rmax, 2 * n, weight=weight,
-                                       method=method).image(Q).cossin()
-                cs = np.array([cossin[int((i + 1) * step)]
-                               for i in range(n + 1)])
-                assert_allclose(cs, np.identity(n + 1), atol=tol[n],
-                                err_msg=param)
+        for rmax in ['MIN', 'all']:
+            param = '-> rmax = {}, order={}, method = {}'.\
+                    format(rmax, 2 * n, method)
+            res = Distributions('ul', rmax, 2 * n, method=method).image(Q)
+            cossin = res.cossin()
+            cs = np.array([cossin[int((i + 1) * step)]
+                           for i in range(n + 1)])
+            assert_allclose(cs, np.identity(n + 1), atol=tol[n],
+                            err_msg=param)
+            # test that Ibeta, and thus harmonics, work in principle
+            res.Ibeta()
 
 
 def test_order_nearest():
-    run_order('nearest', [0.0018, 0.0020, 0.0019, 0.0049, 0.014])
+    run_order('nearest', [0.0018, 0.0020, 0.0019, 0.0022, 0.0055])
 
 
 def test_order_linear():
-    run_order('linear', [0.0031, 0.0033, 0.0034, 0.0052, 0.020])
+    run_order('linear', [0.0031, 0.0033, 0.0034, 0.0034, 0.011])
 
 
 def test_order_remap():
-    run_order('remap', [5e-6, 6e-6, 7e-6, 8e-6, 5e-5])
+    run_order('remap', [5e-6, 6e-6, 7e-6, 8e-6, 2e-5])
 
 
 def run_method(method, rmax, tolP0, tolP2, tolI, tolbeta, weq=True):
@@ -122,79 +123,83 @@ def run_method(method, rmax, tolP0, tolP2, tolI, tolbeta, weq=True):
         beta = P2 / P0
         return r, P0, P2, I, beta
 
-    for y0 in yc:
-        for x0 in xc:
-            param = ' @ y0 = {}, x0 = {}, rmax = {}, method = {}'.\
-                    format(y0, x0, rmax, method)
+    for y0, x0 in itertools.product(yc, xc):
+        param = ' @ y0 = {}, x0 = {}, rmax = {}, method = {}'.\
+                format(y0, x0, rmax, method)
 
-            if rmax == 'MIN':
-                R = min(max(x0, n - 1 - x0), max(y0, m - 1 - y0))
-            elif rmax == 'all':
-                R = max([int(np.sqrt((x - x0)**2 + (y - y0)**2))
-                         for x in (0, n - 1) for y in (0, m - 1)])
-            step = (R - 5 * sigma) / 3
-            refr, refP0, refP2, refI, refbeta = ref_distr()
-            f = 1 / (4 * np.pi * (1 + refr**2))  # rescaling factor for I
+        if rmax == 'MIN':
+            R = min(max(x0, n - 1 - x0), max(y0, m - 1 - y0))
+        elif rmax == 'all':
+            R = max([int(np.sqrt((x - x0)**2 + (y - y0)**2))
+                     for x in (0, n - 1) for y in (0, m - 1)])
+        step = (R - 5 * sigma) / 3
+        refr, refP0, refP2, refI, refbeta = ref_distr()
+        f = 1 / (4 * np.pi * (1 + refr**2))  # rescaling factor for I
 
-            IM, ws = image()
-            w1 = np.ones_like(IM)
+        IM, ws = image()
+        w1 = np.ones_like(IM)
 
-            IMcopy = IM.copy()
-            w1copy = w1.copy()
-            wscopy = ws.copy()
+        IMcopy = IM.copy()
+        w1copy = w1.copy()
+        wscopy = ws.copy()
 
-            weights = [('None', None),
-                       ('sin', 'sin'),
-                       ('1', w1),
-                       ('s', ws)]
-            P0, P2, r, I, beta = {}, {}, {}, {}, {}
-            for wname, weight in weights:
-                weight_param = param + ', weight = ' + wname
+        weights = [(False, None, None),
+                   (True, None, None),
+                   (False, '1', w1),
+                   (False, 'sin', ws),
+                   (True, '1', w1)]
+        P0, P2, r, I, beta = {}, {}, {}, {}, {}
+        for use_sin, wname, warray in weights:
+            weight_param = param + \
+                           ', sin = {}, weights = {}'.format(use_sin, wname)
+            key = (use_sin, wname)
 
-                distr = Distributions((y0, x0), rmax, weight=weight,
-                                      method=method)
-                res = distr(IM)
-                P0[wname], P2[wname] = res.harmonics().T
-                r[wname], I[wname], beta[wname] = res.rIbeta().T
+            distr = Distributions((y0, x0), rmax, use_sin=use_sin,
+                                  weights=warray, method=method)
+            res = distr(IM)
+            P0[key], P2[key] = res.harmonics().T
+            r[key], I[key], beta[key] = res.rIbeta().T
 
-                def assert_cmp(msg, a, ref, tol):
-                    atol, rmstol = tol
-                    assert_allclose(a, ref, atol=atol,
-                                    err_msg=msg + weight_param)
-                    rms = np.sqrt(np.mean((a - ref)**2))
-                    assert rms < rmstol, \
-                           '\n' + msg + weight_param + \
-                           '\nRMS error = {} > {}'.format(rms, rmstol)
+            def assert_cmp(msg, a, ref, tol):
+                atol, rmstol = tol
+                assert_allclose(a, ref, atol=atol,
+                                err_msg=msg + weight_param)
+                rms = np.sqrt(np.mean((a - ref)**2))
+                assert rms < rmstol, \
+                       '\n' + msg + weight_param + \
+                       '\nRMS error = {} > {}'.format(rms, rmstol)
 
-                assert_cmp('-> P0', P0[wname], refP0, tolP0)
-                assert_cmp('-> P2', P2[wname], refP2, tolP2)
+            assert_cmp('-> P0', P0[key], refP0, tolP0)
+            assert_cmp('-> P2', P2[key], refP2, tolP2)
 
-                assert_equal(r[wname], refr, err_msg='-> r' + weight_param)
-                assert_cmp('-> I', f * I[wname], f * refI, tolI)
-                # beta values at peak centers
-                b = [round(beta[wname][int(i * step)], 5) for i in (1, 2, 3)]
-                assert_allclose(b, [-1, 0, 2], atol=tolbeta,
-                                err_msg='-> beta' + weight_param)
+            assert_equal(r[key], refr, err_msg='-> r' + weight_param)
+            assert_cmp('-> I', f * I[key], f * refI, tolI)
+            # beta values at peak centers
+            b = [round(beta[key][int(i * step)], 5) for i in (1, 2, 3)]
+            assert_allclose(b, [-1, 0, 2], atol=tolbeta,
+                            err_msg='-> beta' + weight_param)
 
-                assert_equal(IM, IMcopy,
-                             err_msg='-> IM corrupted' + weight_param)
-                assert_equal(w1, w1copy,
-                             err_msg='-> weight corrupted' + weight_param)
-                assert_equal(ws, wscopy,
-                             err_msg='-> weight corrupted' + weight_param)
+            assert_equal(IM, IMcopy,
+                         err_msg='-> IM corrupted' + weight_param)
+            assert_equal(w1, w1copy,
+                         err_msg='-> weights corrupted' + weight_param)
+            assert_equal(ws, wscopy,
+                         err_msg='-> weights corrupted' + weight_param)
 
-            if not weq:
-                continue
-            for w, wa in [('None', '1'), ('sin', 's')]:
-                pair_param = param + ', weight {} != {}'.format(w, wa)
-                assert_allclose(P0[w], P0[wa],
-                                err_msg='-> P0' + pair_param)
-                assert_allclose(P2[w], P2[wa],
-                                err_msg='-> P2' + pair_param)
-                assert_allclose(I[w], I[wa],
-                                err_msg='-> I' + pair_param)
-                assert_allclose(beta[w], beta[wa],
-                                err_msg='-> beta' + pair_param)
+        if not weq:
+            continue
+        for key1, key2 in [((False, '1'), (False, None)),
+                           ((False, 'sin'), (True, None)),
+                           ((True, '1'), (False, 'sin'))]:
+            pair_param = param + ', sin + weights {} != {}'.format(key1, key2)
+            assert_allclose(P0[key1], P0[key2],
+                            err_msg='-> P0' + pair_param)
+            assert_allclose(P2[key1], P2[key2],
+                            err_msg='-> P2' + pair_param)
+            assert_allclose(I[key1], I[key2],
+                            err_msg='-> I' + pair_param)
+            assert_allclose(beta[key1], beta[key2],
+                            err_msg='-> beta' + pair_param)
 
 
 def test_nearest():
@@ -218,13 +223,13 @@ def test_remap():
     run_method('remap', 'all',
                (0.027, 0.0046), (0.041, 0.0071), (0.027, 0.0046), 0.073,
                weq=False)
-    # (resampling of weight array in 'remap' makes "weq" differ)
+    # (resampling of weights array in 'remap' makes "weq" differ)
 
 
-def run_random(method, parts=True):
+def run_random(method, use_sin, parts=True):
     """
     method = method name
-    parts = test that masking by weight array equals image cropping
+    parts = test that masking by weights array equals image cropping
     """
     # image size
     n = 51  # width
@@ -232,70 +237,76 @@ def run_random(method, parts=True):
 
     np.random.seed(0)
     IM = np.random.random((m, n)) + 1
-    weight = np.random.random((m, n)) + 1
+    weights = np.random.random((m, n)) + 1
 
     # quadrant flips
     for y in [0, m - 1]:
         ydir = -1 if y > 0 else 1
         for x in [0, n - 1]:
             xdir = -1 if x > 0 else 1
-            ho = harmonics(IM, (y, x), 'all', weight=weight, method=method)
-            hf = harmonics(IM[::ydir, ::xdir], (0, 0), 'all',
-                           weight=weight[::ydir, ::xdir], method=method)
-            assert_equal(ho, hf, err_msg='-> flip({}, {}) @ method = {}'.
-                                         format(ydir, xdir, method))
+            ho = harmonics(IM, (y, x), 'all', use_sin=use_sin,
+                           weights=weights, method=method)
+            hf = harmonics(IM[::ydir, ::xdir], (0, 0), 'all', use_sin=use_sin,
+                           weights=weights[::ydir, ::xdir], method=method)
+            assert_equal(ho, hf,
+                         err_msg='-> flip({}, {}) @ method = {}, sin = {}'.
+                                 format(ydir, xdir, method, use_sin))
 
     # parts
     if not parts:
         return
-    for y0 in [15, m // 2, 25]:
-        for x0 in [10, n // 2, 40]:
-            param = ' @ y0 = {}, x0 = {}, method = {}'.format(y0, x0, method)
+    for y0, x0 in itertools.product([15, m // 2, 25], [10, n // 2, 40]):
+        param = ' @ y0 = {}, x0 = {}, method = {}'.format(y0, x0, method)
 
-            # trim border
-            trim = (slice(1, -1), slice(1, -1))
-            IMtrim = IM[trim]
-            wtrim = weight[trim]
-            ht = harmonics(IMtrim, (y0 - 1, x0 - 1), 'all', weight=wtrim,
-                           method=method)
+        # trim border
+        trim = (slice(1, -1), slice(1, -1))
+        IMtrim = IM[trim]
+        wtrim = weights[trim]
+        ht = harmonics(IMtrim, (y0 - 1, x0 - 1), 'all', use_sin=use_sin,
+                       weights=wtrim, method=method)
+
+        wmask = np.zeros_like(IM)
+        wmask[trim] = weights[trim]
+        hm = harmonics(IM, (y0, x0), 'all', use_sin=use_sin,
+                       weights=wmask, method=method)
+
+        assert_allclose(ht, hm[:ht.shape[0]], err_msg='-> trim' + param)
+
+        # cut quadrants
+        regions = [
+            ((slice(0, y0 + 1), slice(0, x0 + 1)), 'lr'),
+            ((slice(0, y0 + 1), slice(x0, None)),  'll'),
+            ((slice(y0, None),  slice(0, x0 + 1)), 'ur'),
+            ((slice(y0, None),  slice(x0, None)),  'ul'),
+        ]
+        for region, origin in regions:
+            Q = IM[region]
+            Qw = weights[region]
+            hc = harmonics(Q, origin, 'all', use_sin=use_sin,
+                           weights=Qw, method=method)
 
             wmask = np.zeros_like(IM)
-            wmask[trim] = weight[trim]
-            hm = harmonics(IM, (y0, x0), 'all', weight=wmask, method=method)
+            wmask[region] = weights[region]
+            hm = harmonics(IM, (y0, x0), 'all', use_sin=use_sin,
+                           weights=wmask, method=method)
 
-            assert_allclose(ht, hm[:ht.shape[0]], err_msg='-> trim' + param)
-
-            # cut quadrants
-            regions = [
-                ((slice(0, y0 + 1), slice(0, x0 + 1)), 'lr'),
-                ((slice(0, y0 + 1), slice(x0, None)),  'll'),
-                ((slice(y0, None),  slice(0, x0 + 1)), 'ur'),
-                ((slice(y0, None),  slice(x0, None)),  'ul'),
-            ]
-            for region, origin in regions:
-                Q = IM[region]
-                Qw = weight[region]
-                hc = harmonics(Q, origin, 'all', weight=Qw, method=method)
-
-                wmask = np.zeros_like(IM)
-                wmask[region] = weight[region]
-                hm = harmonics(IM, (y0, x0), 'all', weight=wmask,
-                               method=method)
-
-                assert_allclose(hc, hm[:hc.shape[0]],
-                                err_msg='-> Q (origin = ' + origin + ')' + param)
+            assert_allclose(hc, hm[:hc.shape[0]],
+                            err_msg='-> Q (origin = ' + origin + ')' + param)
 
 
 def test_nearest_random():
-    run_random('nearest')
+    run_random('nearest', False)
+    run_random('nearest', True)
 
 
 def test_linear_random():
-    run_random('linear')
+    run_random('linear', False)
+    run_random('linear', True)
 
 
 def test_remap_random():
-    run_random('remap', parts=False)
+    run_random('remap', False, parts=False)
+    run_random('remap', True, parts=False)
     # (interpolation and different sampling in 'remap' makes "parts" differ)
 
 

--- a/abel/tests/test_tools_distributions.py
+++ b/abel/tests/test_tools_distributions.py
@@ -148,6 +148,10 @@ def test_nearest():
     run_method('nearest')
 
 
+def test_linear():
+    run_method('linear')
+
+
 def run_random(method):
     # image size
     n = 51  # width
@@ -211,8 +215,15 @@ def test_nearest_random():
     run_random('nearest')
 
 
+def test_linear_random():
+    run_random('linear')
+
+
 if __name__ == '__main__':
     test_origin()
 
     test_nearest()
     test_nearest_random()
+
+    test_linear()
+    test_linear_random()

--- a/abel/tests/test_tools_distributions.py
+++ b/abel/tests/test_tools_distributions.py
@@ -56,7 +56,7 @@ def run_order(method, tol):
                     format(rmax, 2 * n, method)
             res = Distributions('ul', rmax, 2 * n, method=method).image(Q)
             cossin = res.cossin()
-            cs = np.array([cossin[int((i + 1) * step)]
+            cs = np.array([cossin[:, int((i + 1) * step)]
                            for i in range(n + 1)])
             assert_allclose(cs, np.identity(n + 1), atol=tol[n],
                             err_msg=param)
@@ -157,8 +157,8 @@ def run_method(method, rmax, tolP0, tolP2, tolI, tolbeta, weq=True):
             distr = Distributions((y0, x0), rmax, use_sin=use_sin,
                                   weights=warray, method=method)
             res = distr(IM)
-            P0[key], P2[key] = res.harmonics().T
-            r[key], I[key], beta[key] = res.rIbeta().T
+            P0[key], P2[key] = res.harmonics()
+            r[key], I[key], beta[key] = res.rIbeta()
 
             def assert_cmp(msg, a, ref, tol):
                 atol, rmstol = tol
@@ -270,7 +270,7 @@ def run_random(method, use_sin, parts=True):
         hm = harmonics(IM, (y0, x0), 'all', use_sin=use_sin,
                        weights=wmask, method=method)
 
-        assert_allclose(ht, hm[:ht.shape[0]], err_msg='-> trim' + param)
+        assert_allclose(ht, hm[:, :ht.shape[1]], err_msg='-> trim' + param)
 
         # cut quadrants
         regions = [
@@ -290,7 +290,7 @@ def run_random(method, use_sin, parts=True):
             hm = harmonics(IM, (y0, x0), 'all', use_sin=use_sin,
                            weights=wmask, method=method)
 
-            assert_allclose(hc, hm[:hc.shape[0]],
+            assert_allclose(hc, hm[:, :hc.shape[1]],
                             err_msg='-> Q (origin = ' + origin + ')' + param)
 
 

--- a/abel/tests/test_tools_distributions.py
+++ b/abel/tests/test_tools_distributions.py
@@ -1,0 +1,218 @@
+from __future__ import division
+
+import numpy as np
+from numpy.testing import assert_equal, assert_allclose
+
+from abel.tools.vmi import Distributions, harmonics
+
+
+def test_origin():
+    # image size
+    n = 11  # width
+    m = 20  # height
+    # origin (symbolic)
+    row = 'utclb'
+    col = 'lcr'
+    # origin (numeric)
+    xc = [0, n // 2, n - 1]
+    yc = [0, 0, m // 2, m - 1, m - 1]
+
+    np.random.seed(0)
+    IM = np.random.random((m, n))
+
+    for r, y in zip(row, yc):
+        for c, x in zip(col, xc):
+            assert_equal(harmonics(IM, r + c), harmonics(IM, (y, x)),
+                         err_msg='-> origin "{}" != {}'.format(r + c, (y, x)))
+
+
+def run_method(method):
+    # image size
+    n = 51  # width
+    m = 41  # height
+    # origin coordinates
+    xc = [0, 10, n // 2, 40, n - 1]
+    yc = [0, 15, m // 2, 25, m - 1]
+    # peak SD
+    sigma = 2.0
+
+    def peak(i, r):
+        return np.exp(-(r - i * step)**2 / (2 * sigma**2))
+
+    def image():
+        # squared coordinates:
+        x2 = (np.arange(float(n)) - x0)**2
+        y2 = (np.arange(float(m))[:, None] - y0)**2
+        r2 = x2 + y2
+        # radius:
+        r = np.sqrt(r2)
+        # cos^2, sin^2:
+        c2 = np.divide(y2, r2, out=np.zeros_like(r2), where=r2 != 0)
+        s2 = 1 - c2
+        # image: 3 peaks with different anisotropies
+        IM = s2 * peak(1, r) + \
+                  peak(2, r) + \
+             c2 * peak(3, r)
+        return IM, np.sqrt(s2)  # image, sin theta
+
+    def ref_distr():
+        r = np.arange(rmax + 1)
+        P0 = 2/3 * peak(1, r) + \
+                   peak(2, r) + \
+             1/3 * peak(3, r)
+        P2 = -2/3 * peak(1, r) + \
+              2/3 * peak(3, r)
+        I = 4 * np.pi * r**2 * P0
+        beta = P2 / P0
+        return r, P0, P2, I, beta
+
+    for y0 in yc:
+        for x0 in xc:
+            param = ' @ y0 = {}, x0 = {}, method = {}'.format(y0, x0, method)
+
+            rmin = min(max(x0, n - 1 - x0), max(y0, m - 1 - y0))
+            rmax = max([int(np.sqrt((x - x0)**2 + (y - y0)**2))
+                        for x in (0, n - 1) for y in (0, m - 1)])
+            step = (rmax - 5 * sigma) / 3
+            refr, refP0, refP2, refI, refbeta = ref_distr()
+            f = 1 / (4 * np.pi * (1 + refr**2))  # rescaling factor for I
+
+            IM, ws = image()
+            w1 = np.ones_like(IM)
+
+            IMcopy = IM.copy()
+            w1copy = w1.copy()
+            wscopy = ws.copy()
+
+            weights = [('None', None),
+                       ('sin', 'sin'),
+                       ('1', w1),
+                       ('s', ws)]
+            P0, P2, r, I, beta = {}, {}, {}, {}, {}
+            for wname, weight in weights:
+                weight_param = param + ', weight = ' + wname
+
+                distr = Distributions((y0, x0), 'all', method=method,
+                                      weight=weight)
+                res = distr(IM)
+                P0[wname], P2[wname] = res.harmonics().T
+                r[wname], I[wname], beta[wname] = res.rIbeta().T
+
+                def assert_cmp(msg, a, ref, atol, rmstol):
+                    assert_allclose(a, ref, atol=atol,
+                                    err_msg=msg + weight_param)
+                    rms = np.sqrt(np.mean((a - ref)**2))
+                    assert rms < rmstol, \
+                           '\n' + msg + weight_param + \
+                           '\nRMS error = {} > {}'.format(rms, rmstol)
+
+                assert_cmp('-> P0', P0[wname], refP0,
+                           0.038, 0.011)
+                assert_cmp('-> P2', P2[wname], refP2,
+                           0.071, 0.015)
+                assert_cmp('-> P0(min)', P0[wname][:rmin], refP0[:rmin],
+                           0.029, 0.013)
+                assert_cmp('-> P2(min)', P2[wname][:rmin], refP2[:rmin],
+                           0.036, 0.016)
+
+                assert_equal(r[wname], refr, err_msg='-> r' + weight_param)
+                assert_cmp('-> I', f * I[wname], f * refI,
+                           0.038, 0.011)
+                assert_cmp('-> I(min)', (f * I[wname])[:rmin], (f * refI)[:rmin],
+                           0.029, 0.012)
+                # beta values at peak centers
+                b = [round(beta[wname][int(i * step)], 5) for i in (1, 2, 3)]
+                assert_allclose(b, [-1, 0, 2], atol=0.053,
+                                err_msg='-> beta' + weight_param)
+
+                assert_equal(IM, IMcopy,
+                             err_msg='-> IM corrupted' + weight_param)
+                assert_equal(w1, w1copy,
+                             err_msg='-> weight corrupted' + weight_param)
+                assert_equal(ws, wscopy,
+                             err_msg='-> weight corrupted' + weight_param)
+
+            for w, wa in [('None', '1'), ('sin', 's')]:
+                pair_param = param + ', weight {} != {}'.format(w, wa)
+                assert_allclose(P0[w], P0[wa],
+                                err_msg='-> P0' + pair_param)
+                assert_allclose(P2[w], P2[wa],
+                                err_msg='-> P2' + pair_param)
+                assert_allclose(I[w], I[wa],
+                                err_msg='-> I' + pair_param)
+                assert_allclose(beta[w], beta[wa],
+                                err_msg='-> beta' + pair_param)
+
+
+def test_nearest():
+    run_method('nearest')
+
+
+def run_random(method):
+    # image size
+    n = 51  # width
+    m = 41  # height
+
+    np.random.seed(0)
+    IM = np.random.random((m, n)) + 1
+    weight = np.random.random((m, n)) + 1
+
+    # quadrant flips
+    for y in [0, m - 1]:
+        ydir = -1 if y > 0 else 1
+        for x in [0, n - 1]:
+            xdir = -1 if x > 0 else 1
+            ho = harmonics(IM, (y, x), 'all', weight=weight, method=method)
+            hf = harmonics(IM[::ydir, ::xdir], (0, 0), 'all',
+                           weight=weight[::ydir, ::xdir], method=method)
+            assert_equal(ho, hf, err_msg='-> flip({}, {}) @ method = {}'.
+                                         format(ydir, xdir, method))
+
+    # parts
+    for y0 in [15, m // 2, 25]:
+        for x0 in [10, n // 2, 40]:
+            param = ' @ y0 = {}, x0 = {}, method = {}'.format(y0, x0, method)
+
+            # trim border
+            trim = (slice(1, -1), slice(1, -1))
+            IMtrim = IM[trim]
+            wtrim = weight[trim]
+            ht = harmonics(IMtrim, (y0 - 1, x0 - 1), 'all', weight=wtrim,
+                           method=method)
+
+            wmask = np.zeros_like(IM)
+            wmask[trim] = weight[trim]
+            hm = harmonics(IM, (y0, x0), 'all', weight=wmask, method=method)
+
+            assert_allclose(ht, hm[:ht.shape[0]], err_msg='-> trim' + param)
+
+            # cut quadrants
+            regions = [
+                ((slice(0, y0 + 1), slice(0, x0 + 1)), 'lr'),
+                ((slice(0, y0 + 1), slice(x0, None)),  'll'),
+                ((slice(y0, None),  slice(0, x0 + 1)), 'ur'),
+                ((slice(y0, None),  slice(x0, None)),  'ul'),
+            ]
+            for region, origin in regions:
+                Q = IM[region]
+                Qw = weight[region]
+                hc = harmonics(Q, origin, 'all', weight=Qw, method=method)
+
+                wmask = np.zeros_like(IM)
+                wmask[region] = weight[region]
+                hm = harmonics(IM, (y0, x0), 'all', weight=wmask,
+                               method=method)
+
+                assert_allclose(hc, hm[:hc.shape[0]],
+                                err_msg='-> Q (origin = ' + origin + ')' + param)
+
+
+def test_nearest_random():
+    run_random('nearest')
+
+
+if __name__ == '__main__':
+    test_origin()
+
+    test_nearest()
+    test_nearest_random()

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -460,16 +460,16 @@ class Distributions(object):
         ``'VER'``:
             touching vertically
         ``'min'``:
-            minimum of ``'h'`` and ``'v'``, the largest area with 4 full
+            minimum of ``'hor'`` and ``'ver'``, the largest area with 4 full
             quadrants
         ``'max'``:
-            maximum of ``'h'`` and ``'v'``, the largest area with 2 full
+            maximum of ``'hor'`` and ``'ver'``, the largest area with 2 full
             quadrants
         ``'MIN'`` (default):
-            minimum of ``'H'`` and ``'V'``, the largest area with 1 full
+            minimum of ``'HOR'`` and ``'VER'``, the largest area with 1 full
             quadrant (thus the largest with the full 90° angular range)
         ``'MAX'``:
-            maximum of ``'H'`` and  ``'V'``
+            maximum of ``'HOR'`` and  ``'VER'``
         ``'all'``:
             covering all pixels (might have huge errors at large *r*, since the
             angular dependences must be inferred from very small available
@@ -835,35 +835,6 @@ class Distributions(object):
                     Qw = self.Qsin
                 else:
                     Qw *= self.Qsin  # (here Qw is not aliased)
-
-            '''
-            if self.weight in [None, 'sin']:
-                Qw = None
-                if self.fold:
-                    # count overlapping pixels
-                    Qw = np.zeros((Qheight, Qwidth))
-                    for src, dst in self.regions:
-                        Qw[dst] += 1
-                elif rmax > min(HOR, VER):
-                    Qw = np.ones((Qheight, Qwidth))
-                if Qw is not None:
-                    Qw = map_coordinates(Qw, self.grid)
-                if self.weight == 'sin':
-                    self.warray = np.sin(theta)
-                    if Qw is None:
-                        Qw = self.warray
-                    else:
-                        Qw *= self.warray
-            elif self.weight == 'array':
-                if self.fold:
-                    # sum all source regions into one quadrant
-                    Qw = np.zeros((Qheight, Qwidth))
-                    for src, dst in self.regions:
-                        Qw[dst] += self.warray[src]
-                else:
-                    Qw = self.warray[self.flip_row, self.flip_col]
-                Qw = map_coordinates(Qw, self.grid)
-            '''
 
             # Integrals.
             pc = [self._int_remap(None, Qw)]

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -443,13 +443,13 @@ class Distributions(object):
 
         ``int``:
             explicit value
-        ``'h'``:
+        ``'hor'``:
             fitting inside horizontally
-        ``'v'``:
+        ``'ver'``:
             fitting inside vertically
-        ``'H'``:
+        ``'HOR'``:
             touching horizontally
-        ``'V'``:
+        ``'VER'``:
             touching vertically
         ``'min'``:
             minimum of ``'h'`` and ``'v'``, the largest area with 4 full

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -13,7 +13,7 @@ from scipy.optimize import curve_fit
 
 
 def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
-    """Angular integration of the image.
+    r"""Angular integration of the image.
 
     Returns the one-dimensional intensity profile as a function of the
     radial coordinate.
@@ -31,11 +31,11 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
         defaults to ``rows//2, cols//2``.
 
     Jacobian : boolean
-        Include :math:`r\sin\\theta` in the angular sum (integration).
+        Include :math:`r\sin\theta` in the angular sum (integration).
         Also, ``Jacobian=True`` is passed to
         :func:`abel.tools.polar.reproject_image_into_polar`,
         which includes another value of ``r``, thus providing the appropriate
-        total Jacobian of :math:`r^2\sin\\theta`.
+        total Jacobian of :math:`r^2\sin\theta`.
 
     dr : float
         Radial coordinate grid spacing, in pixels (default 1). `dr=0.5` may
@@ -105,9 +105,9 @@ def average_radial_intensity(IM, **kwargs):
 
 
 def radial_integration(IM, radial_ranges=None):
-    """ Intensity variation in the angular coordinate.
+    r""" Intensity variation in the angular coordinate.
 
-    This function is the :math:`\\theta`-coordinate complement to
+    This function is the :math:`\theta`-coordinate complement to
     :func:`abel.tools.vmi.angular_integration`
 
     Evaluates intensity vs angle for defined radial ranges.
@@ -184,15 +184,15 @@ def radial_integration(IM, radial_ranges=None):
 
 
 def anisotropy_parameter(theta, intensity, theta_ranges=None):
-    """
-    Evaluate anisotropy parameter :math:`\\beta`, for :math:`I` vs
-    :math:`\\theta` data.
+    r"""
+    Evaluate anisotropy parameter :math:`\beta`, for :math:`I` vs
+    :math:`\theta` data.
 
     .. math::
 
-        I = \\frac{\sigma_\\text{total}}{4\pi} [ 1 + \\beta P_2(\cos\\theta) ]
+        I = \frac{\sigma_\text{total}}{4\pi} [ 1 + \beta P_2(\cos\theta) ]
 
-    where :math:`P_2(x)=\\frac{3x^2-1}{2}` is a 2nd order Legendre polynomial.
+    where :math:`P_2(x)=\frac{3x^2-1}{2}` is a 2nd order Legendre polynomial.
 
     `Cooper and Zare "Angular distribution of photoelectrons"
     J Chem Phys 48, 942-943 (1968) <http://dx.doi.org/10.1063/1.1668742>`_
@@ -252,7 +252,7 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
 
 def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
           photon_energy=None, Vrep=None, zoom=1):
-    """
+    r"""
     Convert speed radial coordinate into electron kinetic or electron binding
     energy.  Return the photoelectron spectrum (PES).
 
@@ -266,9 +266,9 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
     remain approximately constant.
 
     The ``energy_cal_factor`` is readily determined by comparing the
-    generated energy scale with published spectra. e.g. for O\ :sup:`-`
+    generated energy scale with published spectra. e.g. for O\ :sup:`−`
     photodetachment, the strongest fine-structure transition occurs at the
-    electron affinity :math:`EA = 11,784.676(7)` cm :math:`^{-1}`. Values for
+    electron affinity :math:`EA = 11\,784.676(7)` cm\ :math:`^{-1}`. Values for
     the ANU experiment are given below, see also
     `examples/example_hansenlaw.py`.
 
@@ -287,7 +287,7 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
         energy calibration factor that will convert radius squared into energy.
         The units affect the units of the output. e.g. inputs in
         eV/pixel\ :sup:`2`, will give output energy units in eV.  A value of
-        :math:`1.148427\\times 10^{-5}` cm\ :math:`^{-1}/`\ pixel\ :sup:`2`
+        :math:`1.148427\times 10^{-5}` cm\ :math:`^{-1}/`\ pixel\ :sup:`2`
         applies for "examples/data/O-ANU1024.txt" (with Vrep = -98 volts).
 
     per_energy_scaling : bool
@@ -303,7 +303,7 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
 
         measurement photon energy. The output energy scale is then set to
         electron-binding-energy in units of `energy_cal_factor`. The
-        conversion from wavelength (nm) to `photon_energy` in (cm\ :`sup:-1`\ )
+        conversion from wavelength (nm) to `photon_energy` (cm\ :sup:`−1`)
         is :math:`10^{7}/\lambda` (nm) e.g. `1.0e7/812.51` for
         "examples/data/O-ANU1024.txt".
 
@@ -362,7 +362,7 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
 
 
 class Distributions(object):
-    """
+    r"""
     Class for calculating various radial distributions.
 
     Objects of this class hold the analysis parameters and cache some
@@ -448,12 +448,14 @@ class Distributions(object):
         ``'V'``:
             touching vertically
         ``'min'``:
-            minimum of ``'h'`` and ``'v'``, the largest area with 4 full quadrants
+            minimum of ``'h'`` and ``'v'``, the largest area with 4 full
+            quadrants
         ``'max'``:
-            maximum of ``'h'`` and ``'v'``, the largest area with 2 full quadrants
+            maximum of ``'h'`` and ``'v'``, the largest area with 2 full
+            quadrants
         ``'MIN'`` (default):
-            minimum of ``'H'`` and ``'V'``, the largest area with 1 full quadrant
-            (thus the largest with the full 90° angular range)
+            minimum of ``'H'`` and ``'V'``, the largest area with 1 full
+            quadrant (thus the largest with the full 90° angular range)
         ``'MAX'``:
             maximum of ``'H'`` and  ``'V'``
         ``'all'``:
@@ -469,7 +471,7 @@ class Distributions(object):
         ``None``:
             use equal weights for all pixels
         ``'sin'`` (default):
-            use :math:`|\\sin \\theta|` weighting. This is the weight implied
+            use :math:`|\sin \theta|` weighting. This is the weight implied
             in spherical integration (for the total intensity, for example) and
             with respect to which the Legendre polynomial are orthogonal, so
             using it in the fitting procedure gives the most reasonable results
@@ -747,8 +749,8 @@ class Distributions(object):
             self.cn = cn
 
         def cos(self):
-            """
-            Radial distributions of :math:`\\cos^n \\theta` terms
+            r"""
+            Radial distributions of :math:`\cos^n \theta` terms
             (0 ≤ *n* ≤ ``order``).
 
             (You probably do not need them.)
@@ -756,7 +758,7 @@ class Distributions(object):
             Returns
             -------
             cosn : (rmax + 1) × (# terms) numpy array
-                :math:`\\cos^n \\theta` terms for each radius, ordered from the
+                :math:`\cos^n \theta` terms for each radius, ordered from the
                 lowest to the highest power
             """
             return self.cn
@@ -768,53 +770,53 @@ class Distributions(object):
             return np.hstack((self.r, self.cn))
 
         def cossin(self):
-            """
+            r"""
             Radial distributions of
-            :math:`\\cos^n \\theta \\cdot \\sin^m \\theta` terms
+            :math:`\cos^n \theta \cdot \sin^m \theta` terms
             (*n* + *m* = ``order``).
 
             For ``order`` = 0:
 
-                :math:`\\cos^0 \\theta` is the total intensity.
+                :math:`\cos^0 \theta` is the total intensity.
 
             For ``order`` = 2
 
-                :math:`\\cos^2 \\theta` corresponds to “parallel” (∥)
+                :math:`\cos^2 \theta` corresponds to “parallel” (∥)
                 transitions,
 
-                :math:`\\sin^2 \\theta` corresponds to “perpendicular” (⟂)
+                :math:`\sin^2 \theta` corresponds to “perpendicular” (⟂)
                 transitions.
 
             For ``order = 4``
 
-                :math:`\\cos^4 \\theta` corresponds to ∥,∥,
+                :math:`\cos^4 \theta` corresponds to ∥,∥,
 
-                :math:`\\cos^2 \\theta \\cdot \\sin^2 \\theta` corresponds
+                :math:`\cos^2 \theta \cdot \sin^2 \theta` corresponds
                 to ∥,⟂ and ⟂,∥.
 
-                :math:`\\sin^4 \\theta` corresponds to ⟂,⟂.
+                :math:`\sin^4 \theta` corresponds to ⟂,⟂.
 
                 And so on.
 
             Notice that higher orders can represent lower orders as well:
 
-               :math:`\\cos^2 \\theta + \\sin^2 \\theta = \\cos^0 \\theta
-               \\quad` (∥ + ⟂ = 1),
+               :math:`\cos^2 \theta + \sin^2 \theta = \cos^0 \theta
+               \quad` (∥ + ⟂ = 1),
 
-               :math:`\\cos^4 \\theta + \\cos^2 \\theta \\cdot \\sin^2 \\theta
-               = \\cos^2 \\theta \\quad` (∥,∥ + ∥,⟂ = ∥,∥ + ⟂,∥ = ∥),
+               :math:`\cos^4 \theta + \cos^2 \theta \cdot \sin^2 \theta
+               = \cos^2 \theta \quad` (∥,∥ + ∥,⟂ = ∥,∥ + ⟂,∥ = ∥),
 
-               :math:`\\cos^2 \\theta \\cdot \\sin^2 \\theta + \\sin^4
-               \\theta = \\sin^2 \\theta \\quad` (∥,⟂ + ⟂,⟂ = ⟂,∥ + ⟂,⟂ = ⟂),
+               :math:`\cos^2 \theta \cdot \sin^2 \theta + \sin^4
+               \theta = \sin^2 \theta \quad` (∥,⟂ + ⟂,⟂ = ⟂,∥ + ⟂,⟂ = ⟂),
 
                and so forth.
 
             Returns
             -------
             cosnsinm : (rmax + 1) × (# terms) numpy array
-                :math:`\\cos^n \\theta \\cdot \\sin^m \\theta` terms for each
-                radius, ordered from the highest :math:`\\cos \\theta` power to
-                the highest :math:`\\sin \\theta` power
+                :math:`\cos^n \theta \cdot \sin^m \theta` terms for each
+                radius, ordered from the highest :math:`\cos \theta` power to
+                the highest :math:`\sin \theta` power
             """
             C = np.array([[1.0, 1.0],
                           [1.0, 0.0]])
@@ -828,26 +830,26 @@ class Distributions(object):
             return np.hstack((self.r, self.cossin()))
 
         def harmonics(self):
-            """
+            r"""
             Radial distributions of spherical harmonics
-            (Legendre polynomials :math:`P_n(\\cos \\theta)`).
+            (Legendre polynomials :math:`P_n(\cos \theta)`).
 
             Spherical harmonics are orthogonal with respect to integration over
             the full sphere:
 
             .. math::
-                \\iint P_n P_m \\,d\\Omega =
-                \\int_0^{2\\pi} \\int_0^\\pi
-                    P_n(\\cos \\theta) P_m(\\cos \\theta)
-                \\,\\sin\\theta d\\theta \\,d\\varphi = 0
+                \iint P_n P_m \,d\Omega =
+                \int_0^{2\pi} \int_0^\pi
+                    P_n(\cos \theta) P_m(\cos \theta)
+                \,\sin\theta d\theta \,d\varphi = 0
 
-            for *n* ≠ *m*; and :math:`P_0(\\cos \\theta)` is the spherically
+            for *n* ≠ *m*; and :math:`P_0(\cos \theta)` is the spherically
             averaged intensity.
 
             Returns
             -------
             Pn : (rmax + 1) × (# terms) numpy array
-                :math:`P_n(\\cos \\theta)` terms for each radius
+                :math:`P_n(\cos \theta)` terms for each radius
             """
             C = np.array([[1.0, 0.0],
                           [1/3, 2/3]])
@@ -861,36 +863,36 @@ class Distributions(object):
             return np.hstack((self.r, self.harmonics()))
 
         def Ibeta(self):
-            """
+            r"""
             Radial intensity and anisotropy distributions.
 
             A cylindrically symmetric 3D intensity distribution can be expanded
             over spherical harmonics (Legendre polynomials
-            :math:`P_n(\\cos \\theta)`) as
+            :math:`P_n(\cos \theta)`) as
 
             .. math::
-                I(r, \\theta, \\varphi) =
-                \\frac{1}{4\\pi} I(r) [1 + \\beta_2(r) P_2(\\cos \\theta) +
-                                       \\beta_4(r) P_4(\\cos \\theta) +
-                                       \\dots],
+                I(r, \theta, \varphi) =
+                \frac{1}{4\pi} I(r) [1 + \beta_2(r) P_2(\cos \theta) +
+                                       \beta_4(r) P_4(\cos \theta) +
+                                       \dots],
 
             where :math:`I(r)` is the “radial intensity distribution”
             integrated over the full sphere:
 
             .. math::
-                I(r) = \\int_0^{2\\pi} \\int_0^\\pi I(r, \\theta, \\varphi)
-                       \\,r^2 \\sin\\theta d\\theta \\,d\\varphi,
+                I(r) = \int_0^{2\pi} \int_0^\pi I(r, \theta, \varphi)
+                       \,r^2 \sin\theta d\theta \,d\varphi,
 
-            and :math:`\\beta_n(r)` are the dimensionless “anisotropy
+            and :math:`\beta_n(r)` are the dimensionless “anisotropy
             parameters” describing relative contributions of each harmonic
-            order (:math:`\\beta_0(r) = 1` by definition). In particular:
+            order (:math:`\beta_0(r) = 1` by definition). In particular:
 
-                :math:`\\beta_2 = 2` for the :math:`\\cos^2 \\theta` (∥)
+                :math:`\beta_2 = 2` for the :math:`\cos^2 \theta` (∥)
                 angular distribution,
 
-                :math:`\\beta_2 = 0` for the isotropic distribution,
+                :math:`\beta_2 = 0` for the isotropic distribution,
 
-                :math:`\\beta_2 = -1` for the :math:`\\sin^2 \\theta` (⟂)
+                :math:`\beta_2 = -1` for the :math:`\sin^2 \theta` (⟂)
                 angular distribution.
 
             Returns

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -380,7 +380,7 @@ class Distributions(object):
         distr0 = Distributions('ll', ...)
         distr1 = Distributions('lr', ...)
         distr2 = Distributions('ur', ...)
-        distr3 = Distributions('rl', ...)
+        distr3 = Distributions('ul', ...)
 
         for image in images:
             Q0, Q1, Q2, Q3 = ...
@@ -494,13 +494,17 @@ class Distributions(object):
         numerical integration method used in the fitting procedure
 
         ``'nearest'``:
-            each pixel of the image is assigned to the nearest radial bin
+            each pixel of the image is assigned to the nearest radial bin. The
+            fastest, but noisier.
         ``'linear'`` (default):
             each pixel of the image is linearly distributed over the two
-            adjacent radial bins
+            adjacent radial bins. About twice slower than ``'nearest'``, but
+            smoother.
         ``'remap'``:
             the image is resampled to a uniform polar grid, then polar pixels
-            are summed over all angles for each radius
+            are summed over all angles for each radius. The smoothest, but
+            significantly slower and might have problems with
+            **rmax** > ``'MIN'`` and discontinuous weights.
     """
     def __init__(self, origin='cc', rmax='MIN', order=2, weight='sin',
                  method='linear'):

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -100,7 +100,7 @@ def average_radial_intensity(IM, **kwargs):
 
     """
     R, intensity = angular_integration(IM, Jacobian=False, **kwargs)
-    intensity /= 2*np.pi
+    intensity /= 2 * np.pi
     return R, intensity
 
 
@@ -185,7 +185,8 @@ def radial_integration(IM, radial_ranges=None):
 
 def anisotropy_parameter(theta, intensity, theta_ranges=None):
     """
-    Evaluate anisotropy parameter :math:`\\beta`, for :math:`I` vs :math:`\\theta` data.
+    Evaluate anisotropy parameter :math:`\\beta`, for :math:`I` vs
+    :math:`\\theta` data.
 
     .. math::
 
@@ -206,7 +207,8 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
        Intensity variation with angle
 
     theta_ranges: list of tuples
-       Angular ranges over which to fit ``[(theta1, theta2), (theta3, theta4)]``.
+       Angular ranges over which to fit
+       ``[(theta1, theta2), (theta3, theta4)]``.
        Allows data to be excluded from fit, default include all data
 
     Returns
@@ -219,10 +221,10 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
 
     """
     def P2(x):   # 2nd order Legendre polynomial
-        return (3*x*x-1)/2
+        return (3 * x * x - 1) / 2
 
     def PAD(theta, beta, amplitude):
-        return amplitude*(1 + beta*P2(np.cos(theta)))   # Eq. (1) as above
+        return amplitude * (1 + beta * P2(np.cos(theta)))   # Eq. (1) as above
 
     # angular range of data to be included in the fit
     if theta_ranges is not None:
@@ -288,8 +290,8 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
         :math:`1.148427\\times 10^{-5}` cm\ :math:`^{-1}/`\ pixel\ :sup:`2`
         applies for "examples/data/O-ANU1024.txt" (with Vrep = -98 volts).
 
-    per_energy_scaling : bool 
-        
+    per_energy_scaling : bool
+
         sets the intensity Jacobian.
         If `True`, the returned intensities correspond to an "intensity per eV"
         or "intensity per cm\ :sup:`-1` ". If `False`, the returned intensities
@@ -307,10 +309,10 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
 
     Vrep : None or float
 
-        repeller voltage. Convenience parameter to allow the `energy_cal_factor`
-        to remain constant, for different VMI lens repeller voltages. Defaults
-        to `None`, in which case no extra scaling is applied.
-        e.g. `-98 volts`, for "examples/data/O-ANU1024.txt".
+        repeller voltage. Convenience parameter to allow the
+        `energy_cal_factor` to remain constant, for different VMI lens repeller
+        voltages. Defaults to `None`, in which case no extra scaling is
+        applied. e.g. `-98 volts`, for "examples/data/O-ANU1024.txt".
 
     zoom : float
 
@@ -327,15 +329,15 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
 
     PES : numpy 1d-array of floats
 
-        the photoelectron spectrum, scaled according to the `per_energy_scaling`
-        input parameter.
+        the photoelectron spectrum, scaled according to the
+        `per_energy_scaling` input parameter.
 
     """
 
     if Vrep is not None:
-        energy_cal_factor *= np.abs(Vrep)/zoom**2
+        energy_cal_factor *= np.abs(Vrep) / zoom**2
 
-    eKE = radial**2*energy_cal_factor
+    eKE = radial**2 * energy_cal_factor
 
     if photon_energy is not None:
         # electron binding energy
@@ -348,7 +350,7 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
     # Jacobian, we find dE/dr = 2c2r. Since the coordinates are getting
     # stretched at high E and "squished" at low E, we know that we need to
     # divide by this factor.
-    intensity[1:] /= (2*radial[1:])  # 1: to exclude R = 0
+    intensity[1:] /= (2 * radial[1:])  # 1: to exclude R = 0
     if per_energy_scaling:
         # intensity per unit energy
         intensity /= energy_cal_factor

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -13,6 +13,7 @@ from scipy.optimize import curve_fit
 from scipy.linalg import hankel, inv, pascal
 from scipy.special import legendre
 
+
 def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     r"""Angular integration of the image.
 
@@ -769,7 +770,7 @@ class Distributions(object):
 
             # Integrals.
             if self.method == 'nearest':
-                pc = [self._int_nearest(None, Qw)]
+                pc = [self._int_nearest(None, Qw).astype(float)]
                 for c in self.c[1:]:
                     pc.append(self._int_nearest(c, Qw))
             else:  # 'linear'

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -638,7 +638,8 @@ class Distributions(object):
             self.regions = []
             for r in (False, True):
                 for c in (False, True):
-                    self.regions.append(zip(slices_row(r), slices_col(c)))
+                    self.regions.append(list(zip(slices_row(r),
+                                                 slices_col(c))))
             self.fold = True
 
         if self.order != 2:

--- a/doc/anisotropy_parameter.rst
+++ b/doc/anisotropy_parameter.rst
@@ -1,46 +1,49 @@
 Anisotropy Parameter
 ====================
 
-For linearly polarized light the angular distribution of photodetached electrons from negative-ions is given by:
+For linearly polarized light the angular distribution of photodetached electrons from negative ions is given by
 
 .. math::
 
-  I(\epsilon, \theta) = \frac{\sigma_{\rm total}(\epsilon)}{4\pi} [ 1 + \beta(\epsilon) P_2(\cos\theta)]
+  I(\epsilon, \theta) = \frac{\sigma_\text{total}(\epsilon)}{4\pi} [ 1 + \beta(\epsilon) P_2(\cos\theta)],
 
-
-where :math:`\beta(\epsilon)` is the electron kinetic energy (:math:`\epsilon`) dependent anisotropy parameter, that varies between -1 and +2, and :math:`P_2(\cos\theta)` is the 2nd order Legendre polynomial in :math:`\cos\theta`. :math:`\sigma_{\rm total}` is the total photodetachment cross section. The anisotropy parameter provides phase information about the dynamics of the photon process [1].
+where :math:`\beta(\epsilon)` is the electron kinetic energy (:math:`\epsilon`) dependent anisotropy parameter, which varies between −1 and +2, and :math:`P_2(\cos\theta)` is the 2nd-order Legendre polynomial in :math:`\cos\theta`. :math:`\sigma_\text{total}` is the total photodetachment cross section. The anisotropy parameter provides phase information about the dynamics of the photon process [1].
 
 
 Methods
 -------
 
-``PyAbel`` provides two methods to determine the anisotropy parameter :math:`\beta`:
+``PyAbel`` provides several methods to determine the anisotropy parameter :math:`\beta`:
 
-   Method 1: :doc:`linbasex <transform_methods/linbasex>` evaluates :math:`\beta` directly, available as the class attribute `Beta[1]`
+   Method 1: :doc:`linbasex <transform_methods/linbasex>` evaluates :math:`\beta` directly, available as the class attribute `Beta[1]`.
 
-       This method fits spherical harmonic functions to the velocity-image to directly determine the anisotropy parameter as a function of the radial coordinate. This parameter has greater uncertainty in radial regions of low intensity, and so it is commonly plotted as the product :math:`I \times \beta`.  See ``examples/example_linbasex.py``
+       This method fits spherical harmonic functions to the velocity-map image to directly determine the anisotropy parameter as a function of the radial coordinate. This parameter has greater uncertainty in radial regions of low intensity, and so it is commonly plotted as the product :math:`I \times \beta`.  See ``examples/example_linbasex.py``.
 
    .. image:: https://cloud.githubusercontent.com/assets/10932229/17164544/94adacdc-540c-11e6-955a-c5c9092943cc.png
       :width: 600px
       :alt: example_linbasex output image
 
-
    |
 
-   Method 2: using :func:`abel.tools.vmi.radial_integration`
+   Method 2: using :func:`abel.tools.vmi.radial_integration`.
 
-       This method determines the anisotropy parameter from the inverse Abel transformed image, by extracting intensity vs angle for each specified radial range (tuples) and then fitting the intensity formula given above. This method is best applied to the radial ranges the correspond to strong spectral (intensity) in the image. It has the advantage of providing the least-squares fit error estimate for the parameter(s).
+       This method determines the anisotropy parameter from the inverse Abel-transformed image, by extracting intensity vs angle for each specified radial range and then fitting the intensity formula given above. This method is best applied to the radial ranges corresponding to strong spectral intensity in the image. It has the advantage of providing the least-squares fit error estimate for the parameter(s).
+
+   Method 3: using :class:`abel.tools.vmi.Distributions`.
+
+       This method, like the previous one, works on the inverse Abel-transformed image, but fits the angular intensity dependence at each radius, providing radially dependent anisotropy parameters, like in the first method. If the anisotropy parameters are known to be smooth radial functions, a moving-window averaging can be employed for noise reduction.
 
 
-
-Example of both methods
------------------------
+Example
+-------
 
 See :doc:`example_anisotropy_parameter`. In this case the anisotropy parameter is determined using each method. Note:
  
-   1. Method 1 the filter parameter ``threshold=0.2`` is set to a larger value so as to exclude evaluation in regions of weak intensity.
+   * In method 1, the filter parameter ``threshold=0.2`` is set to a larger value so as to exclude evaluation in regions of weak intensity.
 
-   2. Method 2 evaluates the anisotropy parameter for particular radial regions, of strong intensity.
+   * Method 2 evaluates the anisotropy parameter for particular radial regions of strong intensity.
+
+   * In method 3, the anisotropy parameter is calculated with 9-pixel radial averaging and plotted only in the regions with > 1 % of the maximal intensity.
 
 .. plot:: ../examples/example_anisotropy_parameter.py 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyAbel'
-copyright = '2016, PyAbel team'
+copyright = u'2016–2019, PyAbel team'
 author = 'PyAbel team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/examples/example_anisotropy_parameter.py
+++ b/examples/example_anisotropy_parameter.py
@@ -64,6 +64,13 @@ Beta, Amp, Rmid, Ivstheta, theta =\
 # Beta_whole_grid, Amp_whole_grid, Radial_midpoints =\
 #                         abel.tools.vmi.anisotropy(AIM.transform, 20)
 
+# Radial intensity and anisotropy distributions
+I, beta2 = abel.tools.vmi.Ibeta(HIM.transform, window=9)
+# normalize to max intensity peak
+I /= I.max()
+# remove (noisy) anisotropy values for low-intensity parts
+beta2[I < 0.01] = np.nan
+
 # plots of the analysis
 fig = plt.figure(figsize=(8, 4))
 ax1 = plt.subplot(121)
@@ -82,23 +89,32 @@ im1 = ax1.imshow(JIM, origin='lower', aspect='auto', vmin=0, vmax=vmax)
 fig.colorbar(im1, ax=ax1, fraction=.1, shrink=0.9, pad=0.03)
 ax1.set_xlabel('x (pixels)')
 ax1.set_ylabel('y (pixels)')
-ax1.set_title('VMI, inverse Abel: {:d}x{:d}'.format(rows, cols))
+ax1.set_title('VMI, inverse Abel: {:d}×{:d}'.format(rows, cols))
 
 # Plot the 1D speed distribution
-ax2.plot(LIM.Beta[0], 'r-', label='linbasex-Beta[0]')
-ax2.plot(speed, 'b-', label='speed')
+line01, = ax2.plot(LIM.Beta[0], 'r-', label='linbasex-Beta[0]')
+line02, = ax2.plot(speed, 'b-', label='speed')
+line03, = ax2.plot(I, 'c--', label='$I(r)$')
+legend0 = ax2.legend(handles=[line01, line02, line03],
+                     frameon=False, labelspacing=0.1, numpoints=1, loc=2,
+                     fontsize='small')
+plt.gca().add_artist(legend0)
+
 # Plot anisotropy parameter, attribute Beta[1], x speed
-ax2.plot(LIM.Beta[1], 'r-', label='linbasex-Beta[2]')
+line11, = ax2.plot(LIM.Beta[1], 'r-', label='linbasex-Beta[2]')
 BetaT = np.transpose(Beta)
-ax2.errorbar(Rmid, BetaT[0], BetaT[1], fmt='o', color='g',
-             label='specific radii')
+line12 = ax2.errorbar(Rmid, BetaT[0], BetaT[1], fmt='.', color='g',
+                      label='specific radii')
 # ax2.plot(Radial_midpoints, Beta_whole_grid[0], '-g', label='stepped')
+line13, = ax2.plot(beta2, 'c', label=r'$\beta_2(r)$')
+legend1 = ax2.legend(handles=[line11, line12, line13],
+                     frameon=False, labelspacing=0.1, numpoints=1, loc=3,
+                     fontsize='small')
+
 ax2.axis(xmin=100, xmax=450, ymin=-1.2, ymax=1.2)
 ax2.set_xlabel('radial pixel')
 ax2.set_ylabel('speed/anisotropy')
 ax2.set_title('speed/anisotropy distribution')
-ax2.legend(frameon=False, labelspacing=0.1, numpoints=1, loc=3,
-           fontsize='small')
 
 plt.subplots_adjust(left=0.06, bottom=0.17, right=0.95, top=0.89,
                     wspace=0.35, hspace=0.37)


### PR DESCRIPTION
This is the implementation of various radial distributions (intensity, anisotropy), discussed in #254.
(Plus some minor changes to code and docstrings formatting and the updated copyright years.)

Works for any image parts (any quadrant, any half, full image with the origin anywhere) and any even angular orders. Also is fast:
```
order = 2, time in milliseconds

=== Half image, single ==========================================

Method                n = 257     n = 513    n = 1025    n = 2049
-----------------------------------------------------------------
nearest
   MIN, none              2.0         5.4        18.1        52.5
   MIN, sin               2.0         6.2        20.2        55.7
   MIN, sin+array         2.1         6.5        21.5        62.3
linear
   MIN, none              2.3         6.9        24.9        82.0
   MIN, sin               2.4         8.2        30.6        92.6
   MIN, sin+array         2.5         8.9        32.6        98.9
remap
   MIN, none              8.5        29.6       118.3       461.7
   MIN, sin               8.5        31.5       121.9       473.4
   MIN, sin+array         8.7        31.8       123.6       487.4


=== Half image, cached ==========================================

Method                n = 257     n = 513    n = 1025    n = 2049
-----------------------------------------------------------------
nearest
   MIN, none              0.7         1.3         3.6        12.1
   MIN, sin               0.7         1.4         4.1        14.1
   MIN, sin+array         0.8         1.7         5.1        18.3
linear
   MIN, none              0.9         2.0         6.6        24.1
   MIN, sin               0.9         2.1         7.2        26.6
   MIN, sin+array         1.0         2.3         8.1        30.5
remap
   MIN, none              4.0        14.2        59.4       222.8
   MIN, sin               4.1        14.3        58.2       225.8
   MIN, sin+array         4.2        14.6        58.0       231.5
```
One quadrant is somewhat faster, full image is somewhat slower. Timings for the radial intensity distribution only (`order = 0`) are also somewhat smaller. For comparison, here are the timings for `abel.tools.vmi.angular_integration`:
```
Shape                 n = 257     n = 513    n = 1025    n = 2049
-----------------------------------------------------------------
one quadrant              3.1        14.7        57.4       208.1
half                     15.1        57.5       213.9       839.6
full                     13.8        54.8       203.4       800.0
```

Besides asking everybody to test this, I have two design questions:
1. It seems that different tools use different conventions for the image center:
   * (row, col), as for arrays,
   * (x, y) with y from the bottom, as usual coordinates (but contrary to “PyAbel adopts the “television” convention”).

   Here I use (row, col), but maybe it should be changed?
2. The results are arranged as arrays with the first index corresponding to the radius, and the second to the angular terms. This means that, for example, instead of
   `I, beta = results.Ibeta()`
   one needs to write
   `I, beta = results.Ibeta().T`
   which is less neat. On the other hand, this allows to write
   `plt.plot(results.harmonics())`
   to plot all radial distributions together. And might be considered more convenient is some situations, since `Ibeta[r]` gives all the information (_I_(_r_), _β_<sub>2</sub>(_r_), _β_<sub>4</sub>(_r_), ...) about radius _r_.
   Or it should be the opposite?