### PR TITLE
Drop PyAbel version from BASEX cache files

### DIFF
--- a/abel/basex.py
+++ b/abel/basex.py
@@ -344,7 +344,7 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
                     print('Loading basis sets...')
                     # saved as a .npy file
                 try:
-                    M, Mc, M_version = np.load(full_path(best_file))
+                    M, Mc = np.load(full_path(best_file))
                     # crop if loaded larger
                     if M.shape != (n, nbf):
                         M = M[:n, :nbf]
@@ -365,7 +365,7 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
 
             # Try to extend the largest available
             try:
-                oldM, oldMc, M_version = np.load(full_path(largest_file))
+                oldM, oldMc = np.load(full_path(largest_file))
                 if verbose:
                     print('(extending {})'.format(largest_file))
             except:
@@ -374,8 +374,7 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True,
             M, Mc = _bs_basex(n, sigma, oldM, verbose=verbose)
 
             if basis_dir is not None:
-                np.save(full_path(basis_file),
-                        (M, Mc, np.array(__version__)))
+                np.save(full_path(basis_file), (M, Mc))
                 if verbose:
                     print('Basis set saved for later use to')
                     print('  {}'.format(basis_file))


### PR DESCRIPTION
As noticed in #259, recent versions of NumPy switched the default parameters of `numpy.load()` to `allow_pickle=False`, which makes any attempts to load `basex` cache files always fail and thus triggers basis-set generation every time. The problem is that the PyAbel version (`__version__`) is saved in the cache files, and NumPy need to “pickle”/“unpickle” this _string_, so `allow_pickle=True` is required in the `load()` functions. This was actually the default behavior, but now is disabled by default (allegedly, due to security reasons).

However, this version string, although saved and loaded, is in fact not used for any purposes. And other Abel methods do not even write it to their cache files. So, I think, the best solution is just to drop it from `basex` cache files, which is done in this PR. This also solves the problem that PyAbel executed under Python 3 could not read cache files generated by PyAbel executed under Python 2 (probably due to different assumed string encodings).
