### PR TITLE
Odd orders for abel.tools.vmi.Distributions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,40 @@
 Changelog
 =========
 
+Unreleased
+----------
+* Added odd angular orders to tools.vmi.Distributions (PR #266).
+
+v0.8.3 (2019-08-16)
+-------------------
+* New tools.vmi.Distributions class for extracting radial intensity and
+  anisotropy distributions (PR #257).
+* Dropped PyAbel version from basex cache files (PR #260).
+
+v0.8.2 (2019-07-11)
+-------------------
+* Added forward transform to basex method (PR #240).
+* Corrected tools.transform_pairs.profile4 (PR #241).
+* Removed tools.transform_pairs.profile8, which was the same as profile6
+  (PR #241).
+* Major changes in benchmark.AbelTiming class (PR #244, #252).
+* Corrected image shift in onion_bordas method (PR #248).
+* Changed gradient calculations in hansenlaw method to first-order finite
+  difference (PR #249).
+* Corrected background width for Dribinski sample image in
+  tools.analytical.SampleImage (PR #255).
+
+v0.8.1 (2018-11-29)
+-------------------
+* Implemented Tikhonov regularization in basex method (PR #227).
+* Improvements and changes in basis caching for methods using basis sets
+  (PR #227, #232, #235).
+* Improvements in basis generation for basex method, allow any sigma (PR #235).
+* Added intensity correction to basex method (PR #235).
+* New tools.polynomial module for analytical Abel transform of piecewise
+  polynomials (PR #235).
+
+
 2016-04-20 - Lin-BASEX method of Thomas Gerber and co-workers available (see #167)
 
 2016-04-15 - Made changes to .travis.yml to have Travis CI automatically release new version of PyAbel to PyPi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,12 +35,17 @@ v0.8.1 (2018-11-29)
   polynomials (PR #235).
 
 
-2016-04-20 - Lin-BASEX method of Thomas Gerber and co-workers available (see #167)
+(2016-04-20)
+------------
+* Lin-BASEX method of Thomas Gerber and co-workers available (PR #177)
 
-2016-04-15 - Made changes to .travis.yml to have Travis CI automatically release new version of PyAbel to PyPi
-
-2016-03-20 - Dasch two-point, three-point (updated), and onion-peeling available (see PR #155)
+(2016-03-20)
+------------
+* Dasch two-point, three-point (updated), and onion-peeling available
+  (PR #155).
  
-2016-03-19 - onion-peeling algorithm now available (see #53)
-
-2016-03-15 - Changed abel.transform to be a class rather than a function. The previous syntax of ``abel.transform(IM)['transform']`` has been replaced with ``abel.Transform(IM).transform``.
+(2016-03-15)
+------------
+* Changed abel.transform to be a class rather than a function. The previous
+  syntax of abel.transform(IM)['transform'] has been replaced with
+  abel.Transform(IM).transform.

--- a/abel/tests/test_tools_distributions.py
+++ b/abel/tests/test_tools_distributions.py
@@ -32,7 +32,7 @@ def run_order(method, tol):
     step = 6 * sigma
 
     for n in range(len(tol)):  # order = 2n
-        size = (n + 2) * step
+        size = int((n + 2) * step)
         # squared coordinates:
         x2 = np.arange(float(size))**2
         y2 = x2[:, None]
@@ -81,16 +81,17 @@ def run_order_odd(method, tol):
     step = 6 * sigma
 
     for n in range(0, len(tol)):  # order = n
-        size = (n + 2) * step
+        size = int((n + 2) * step)
         # coordinates:
         x = np.arange(float(size))
         y = size - np.arange(2 * float(size) + 1)[:, None]
         # radius
         r = np.sqrt(x**2 + y**2)
-        r[int(size), 0] = np.inf
+        # cos, sin
+        r[size, 0] = np.inf
         c = y / r
         s = x / r
-        r[0, 0] = 0
+        r[size, 0] = 0
 
         def peak(i):
             m = n - i
@@ -278,6 +279,179 @@ def test_remap():
     # (resampling of weights array in 'remap' makes "weq" differ)
 
 
+def run_method_odd(method, rmax, tolP0, tolP1, tolP2,
+                   tolI, tolbeta1, tolbeta2, weq=True):
+    """
+    method = method name
+    rmax = 'MIN' or 'all'
+    tol... = (atol, rmstol) for ...
+    tolbeta = atol for beta
+    weq = compare symbolic and array weights
+    """
+    # image size
+    n = 81  # width
+    m = 91  # height
+    # origin coordinates
+    xc = [0, 30, n // 2, 50, n - 1]
+    yc = [0, 25, m // 2, 65, m - 1]
+    # peak SD
+    sigma = 2.0
+
+    def peak(i, r):
+        return np.exp(-(r - i * step)**2 / (2 * sigma**2))
+
+    def image():
+        # coordinates:
+        x = np.arange(float(n)) - x0
+        y = y0 - np.arange(float(m))[:, None]
+        # radius:
+        r = np.sqrt(x**2 + y**2)
+        # cos, |sin|
+        r[y0, x0] = np.inf
+        c = y / r
+        s = np.abs(x) / r
+        s[y0, x0] = 1
+        r[y0, x0] = 0
+        # image: 3 peaks with different anisotropies
+        IM = s**2      * peak(1, r) + \
+             c**2      * peak(2, r) + \
+             (1/2 + c) * peak(3, r) + \
+                         peak(4, r)
+        return IM, s  # image, sin theta
+
+    def ref_distr():
+        r = np.arange(R + 1)
+        P0 = 2/3 * peak(1, r) + \
+             1/3 * peak(2, r) + \
+             1/2 * peak(3, r) + \
+                   peak(4, r)
+        P1 = peak(3, r)
+        P2 = -2/3 * peak(1, r) + \
+              2/3 * peak(2, r)
+        I = 4 * np.pi * r**2 * P0
+        beta1 = P1 / P0
+        beta2 = P2 / P0
+        return r, P0, P1, P2, I, beta1, beta2
+
+    for y0, x0 in itertools.product(yc, xc):
+        param = ' @ y0 = {}, x0 = {}, rmax = {}, method = {}'.\
+                format(y0, x0, rmax, method)
+
+        if rmax == 'MIN':
+            R = min(max(x0, n - 1 - x0), max(y0, m - 1 - y0))
+        elif rmax == 'MAX':
+            # exclude situations when the outer ring has insufficient vertical
+            # span for reliable even/odd separation
+            if y0 in [0, m - 1] and x0 not in [0, n - 1] or \
+               x0 == n // 2 and abs(y0 - m // 2) not in [0, m // 2]:
+                continue
+            R = max(max(x0, n - 1 - x0), max(y0, m - 1 - y0))
+        step = (R - 5 * sigma) / 4
+        refr, refP0, refP1, refP2, refI, refbeta1, refbeta2 = ref_distr()
+        f = 1 / (4 * np.pi * (1 + refr**2))  # rescaling factor for I
+
+        IM, ws = image()
+        w1 = np.ones_like(IM)
+
+        IMcopy = IM.copy()
+        w1copy = w1.copy()
+        wscopy = ws.copy()
+
+        weights = [(False, None, None),
+                   (True, None, None),
+                   (False, '1', w1),
+                   (False, 'sin', ws),
+                   (True, '1', w1)]
+        P0, P1, P2, r, I, beta1, beta2 = {}, {}, {}, {}, {}, {}, {}
+        for use_sin, wname, warray in weights:
+            weight_param = param + \
+                           ', sin = {}, weights = {}'.format(use_sin, wname)
+            key = (use_sin, wname)
+
+            distr = Distributions((y0, x0), rmax, odd=True, use_sin=use_sin,
+                                  weights=warray, method=method)
+            res = distr(IM)
+            P0[key], P1[key], P2[key] = res.harmonics()
+            r[key], I[key], beta1[key], beta2[key] = res.rIbeta()
+
+            def assert_cmp(msg, a, ref, tol):
+                atol, rmstol = tol
+                assert_allclose(a, ref, atol=atol,
+                                err_msg=msg + weight_param)
+                rms = np.sqrt(np.mean((a - ref)**2))
+                assert rms < rmstol, \
+                       '\n' + msg + weight_param + \
+                       '\nRMS error = {} > {}'.format(rms, rmstol)
+
+            assert_cmp('-> P0', P0[key], refP0, tolP0)
+            assert_cmp('-> P1', P1[key], refP1, tolP1)
+            assert_cmp('-> P2', P2[key], refP2, tolP2)
+
+            assert_equal(r[key], refr, err_msg='-> r' + weight_param)
+            assert_cmp('-> I', f * I[key], f * refI, tolI)
+            # beta values at peak centers
+            b1 = [round(beta1[key][int(i * step)], 5) for i in (1, 2, 3, 4)]
+            assert_allclose(b1, [0, 0, 2, 0], atol=tolbeta1,
+                            err_msg='-> beta1' + weight_param)
+            b2 = [round(beta2[key][int(i * step)], 5) for i in (1, 2, 3, 4)]
+            assert_allclose(b2, [-1, 2, 0, 0], atol=tolbeta2,
+                            err_msg='-> beta2' + weight_param)
+
+            assert_equal(IM, IMcopy,
+                         err_msg='-> IM corrupted' + weight_param)
+            assert_equal(w1, w1copy,
+                         err_msg='-> weights corrupted' + weight_param)
+            assert_equal(ws, wscopy,
+                         err_msg='-> weights corrupted' + weight_param)
+
+        if not weq:
+            continue
+        for key1, key2 in [((False, '1'), (False, None)),
+                           ((False, 'sin'), (True, None)),
+                           ((True, '1'), (False, 'sin'))]:
+            pair_param = param + ', sin + weights {} != {}'.format(key1, key2)
+            assert_allclose(P0[key1], P0[key2],
+                            err_msg='-> P0' + pair_param)
+            assert_allclose(P1[key1], P1[key2],
+                            err_msg='-> P1' + pair_param)
+            assert_allclose(P2[key1], P2[key2],
+                            err_msg='-> P2' + pair_param)
+            assert_allclose(I[key1], I[key2],
+                            err_msg='-> I' + pair_param)
+            assert_allclose(beta1[key1], beta1[key2],
+                            err_msg='-> beta1' + pair_param)
+            assert_allclose(beta2[key1], beta2[key2],
+                            err_msg='-> beta2' + pair_param)
+
+
+def test_nearest_odd():
+    run_method_odd('nearest', 'MIN',
+                   (0.093, 0.030), (0.21, 0.063), (0.17, 0.042),
+                   (0.093, 0.030), 0.18, 0.075)
+    run_method_odd('nearest', 'MAX',
+                   (0.16, 0.029), (0.27, 0.049), (0.12, 0.022),
+                   (0.16, 0.029), 0.080, 0.030)
+
+
+def test_linear_odd():
+    run_method_odd('linear', 'MIN',
+                   (0.025, 0.0078), (0.072, 0.028), (0.054, 0.019),
+                   (0.025, 0.0078), 0.17, 0.11)
+    run_method_odd('linear', 'MAX',
+                   (0.20, 0.040), (0.33, 0.064), (0.14, 0.027),
+                   (0.20, 0.040), 0.11, 0.086)
+
+
+def test_remap_odd():
+    run_method_odd('remap', 'MIN',
+                   (0.016, 0.0033), (0.029, 0.0060), (0.015, 0.0030),
+                   (0.016, 0.0033), 0.050, 0.012, weq=False)
+    run_method_odd('remap', 'MAX',
+                   (0.13, 0.025), (0.21, 0.041), (0.087, 0.017),
+                   (0.13, 0.025), 0.021, 0.011, weq=False)
+    # (resampling of weights array in 'remap' makes "weq" differ)
+
+
 def run_random(method, odd, use_sin, parts=True):
     """
     method = method name
@@ -382,14 +556,17 @@ if __name__ == '__main__':
     test_order_nearest()
     test_order_odd_nearest()
     test_nearest()
+    test_nearest_odd()
     test_nearest_random()
 
     test_order_linear()
     test_order_odd_linear()
     test_linear()
+    test_linear_odd()
     test_linear_random()
 
     test_order_remap()
     test_order_odd_remap()
     test_remap()
+    test_remap_odd()
     test_remap_random()

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -475,18 +475,19 @@ class Distributions(object):
             angular dependences must be inferred from very small available
             angular ranges)
     order : int
-        highest order in the angular distributions, ≥ 0
+        highest order in the angular distributions, ≥ 0 (by default, 2)
     odd : bool
-        include odd angular orders (is enabled automatically if **order** is
-        odd). Notice that although odd orders can be extracted from the upper
-        or lower image part alone, analyzing the whole image is more reliable.
+        include odd angular orders. By default is ``False``, but is enabled
+        automatically if **order** is odd. Notice that although odd orders can
+        be extracted from the upper or lower image part alone, analyzing the
+        whole image is more reliable.
     use_sin: bool
-        use :math:`|\sin \theta|` weighting. This is the weight implied in
-        spherical integration (for the total intensity, for example) and with
-        respect to which the Legendre polynomials are orthogonal, so using it
-        in the fitting procedure gives the most reasonable results even if the
-        data deviates form the assumed angular behavior. It also reduces
-        contributions from the centerline noise.
+        use :math:`|\sin \theta|` weighting (enabled by default). This is the
+        weight implied in spherical integration (for the total intensity, for
+        example) and with respect to which the Legendre polynomials are
+        orthogonal, so using it in the fitting procedure gives the most
+        reasonable results even if the data deviates form the assumed angular
+        behavior. It also reduces contributions from the centerline noise.
     weights : m × n numpy array, optional
         in addition to the optional :math:`|\sin \theta|` weighting (see
         **use_sin** above), use given weights for each pixel. The array shape

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -939,8 +939,12 @@ class Distributions(object):
             C = np.zeros((self.N, self.N))
             for m in range(self.N, 0, -1):
                 try:
-                    C[:m, :m] = inv(P[:m, :m])
-                    # (this is faster than np.pad)
+                    Pi = inv(P[:m, :m])
+                    # due to numerical errors, inv() might "succeed" even for
+                    # some degenerate matrices, so try to reject them manually
+                    if np.max(Pi) > 1e14:  # (FP precision is only ~15 digits)
+                        raise np.linalg.LinAlgError
+                    C[:m, :m] = Pi  # (this is faster than np.pad)
                     return C
                 except np.linalg.LinAlgError:
                     pass  # try lower rank

--- a/doc/changelog_link.rst
+++ b/doc/changelog_link.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyAbel'
-copyright = u'2016–2019, PyAbel team'
+copyright = u'2016–2020, PyAbel team'
 author = 'PyAbel team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ Contents:
    circularize_image
    examples
    contributing_link
-   
+   changelog_link
 
 
 Indices and tables


### PR DESCRIPTION
This is (finally!) an implementation of odd angular orders for the anisotropy distributions, to finish with #254 and address #265.

The behavior and performance for even orders (still the default mode) should not be affected, but odd terms can now be included by specifying `odd=True` after `order` or supplying an odd `order`.

An example with pure Legendre polynomials:
```python
from __future__ import division
import numpy as np
import matplotlib.pyplot as plt
from abel.tools.vmi import Distributions

fig = plt.figure(figsize=(16, 8))

R = 150
n = 2 * R + 1  # width
m = 2 * R + 1  # height
x0 = R; y0 = R  # center
# coordinates:
x = np.arange(float(n)) - x0
y = y0 - np.arange(float(m))[:, None]
r = np.sqrt(x**2 + y**2)
# cos, sin:
r[y0, x0] = np.inf
s = x / r
c = y / r
r[y0, x0] = 0

sigma = 5.0  # peak SD
step = 5 * sigma  # distance between centers

def peak(i):
  return np.exp(-(r - (i + 1) * step)**2 / (2 * sigma**2))
  
IM = peak(0) + \
     peak(1) * c + \
     peak(2) * (3 * c**2 - 1) / 2 + \
     peak(3) * (5 * c**3 - 3 * c) / 2 + \
     peak(4) * (35 * c**4 - 30 * c**2 + 3) / 8

fig.add_subplot(1, 2, 1)
plt.imshow(IM, cmap='bwr')

distr = Distributions((y0, x0), order=4, odd=True)
res = distr(IM)

fig.add_subplot(2, 2, 2)
for n, c in enumerate(res.cos()):
  plt.plot(c, label='$\\cos^{}\\theta$'.format(n))
plt.legend()

fig.add_subplot(2, 2, 4)
for n, h in enumerate(res.harmonics()):
  plt.plot(h, label='$P_{}(\\cos\\theta)$'.format(n))
plt.legend()
plt.xlabel('$r$')

plt.tight_layout()
plt.show()
```
![harmonics](https://user-images.githubusercontent.com/12854133/67919539-65859500-fb66-11e9-954e-269e8d346268.png)

And the same, but with radial intensity and anisotropy distributions for a non-negative image:
```python
...
IM = peak(0) + \
     peak(1) * (1 + c) + \
     peak(2) * (1 + (3 * c**2 - 1) / 2) + \
     peak(3) * (1 + (5 * c**3 - 3 * c) / 2) + \
     peak(4) * (1 + (35 * c**4 - 30 * c**2 + 3) / 8)
...
plt.imshow(IM, cmap='binary')
...
(I,), beta = np.vsplit(res.Ibeta(), (1,))
...
plt.plot(I, label='$I$')
...
for n, b in enumerate(beta):
  plt.plot(b, label='$\\beta_{}$'.format(1 + n))
...
```
![Ibeta](https://user-images.githubusercontent.com/12854133/67919653-d3ca5780-fb66-11e9-9f98-e626b53a1805.png)

If @haribo3127 (the initiator of #265) or anybody else can provide an experimental image for testing, it would be great. Other testing, feedback and suggestions are also very welcome.