### PR TITLE
Center/origin consistency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,11 @@ Unreleased
   (row, column) format for consistency within PyAbel and with NumPy/SciPy; this
   can break some code, so please check carefully and update it if necessary.
   See PR #267.
+* Fixed the GUI examples (example_GUI.py and example_simple_GUI.py)
+  so that they work with the lastest versions of tk (PR #269).
 
 v0.8.3 (2019-08-16)
 -------------------
-* Fixed the GUI examples (example_GUI.py and example_simple_GUI.py)
-  so that they work with the lastest versions of tk (#269).
 * New tools.vmi.Distributions class for extracting radial intensity and
   anisotropy distributions (PR #257).
 * Dropped PyAbel version from basex cache files (PR #260).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 * Added odd angular orders to tools.vmi.Distributions (PR #266).
+* Important! Some "center" functions/parameters are renamed to "origin" or
+  "method"; using old names still works but will print deprecation warnings,
+  please update your code accordingly. Image origin is now always in the
+  (row, column) format for consistency within PyAbel and with NumPy/SciPy; this
+  can break some code, so please check carefully and update it if necessary.
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
   please update your code accordingly. Image origin is now always in the
   (row, column) format for consistency within PyAbel and with NumPy/SciPy; this
   can break some code, so please check carefully and update it if necessary.
+  See PR #267.
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -134,7 +134,7 @@ If the change is significant (more than just a typo-fix), please leave a short n
 Releasing on PyPi
 -----------------
 
-PyAbel should be automatically released on PyPi (see PR `#161 <https://github.com/PyAbel/PyAbel/pull/161>`_) whenever a new release is drafted on GitHub via the "Draft New Release" button on the `Releases page <https://github.com/PyAbel/PyAbel/releases>`_. Just remember to increment the version number in abel/_version.py first.
+PyAbel should be automatically released on PyPi (see `PR #161 <https://github.com/PyAbel/PyAbel/pull/161>`_) whenever a new release is drafted on GitHub via the "Draft New Release" button on the `Releases page <https://github.com/PyAbel/PyAbel/releases>`_. Just remember to increment the version number in abel/_version.py first.
 
 
 Citations

--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,10 @@ The results can then be plotted using Matplotlib:
 
     fig, axs = plt.subplots(1, 2, figsize=(6, 4))
 
-    axs[0].imshow(forward_abel, clim=(0, np.max(forward_abel)*0.6), origin='lower', extent=(-1,1,-1,1))
-    axs[1].imshow(inverse_abel, clim=(0, np.max(inverse_abel)*0.4), origin='lower', extent=(-1,1,-1,1))
+    axs[0].imshow(forward_abel, clim=(0, np.max(forward_abel) * 0.6),
+                  origin='lower', extent=(-1, 1, -1, 1))
+    axs[1].imshow(inverse_abel, clim=(0, np.max(inverse_abel) * 0.4),
+                  origin='lower', extent=(-1, 1, -1, 1))
 
     axs[0].set_title('Forward Abel Transform')
     axs[1].set_title('Inverse Abel Transform')
@@ -127,8 +129,8 @@ The PyAbel code adheres to the following conventions:
 
     .. code-block:: python
 
-        x = np.linspace(-2,2,5)
-        X,Y = np.meshgrid(x, -x) # notice the minus sign in front of the y-coordinate
+        x = np.linspace(-2, 2, 5)
+        X, Y = np.meshgrid(x, -x) # notice the minus sign in front of the y-coordinate
     
 - 
     **Angle:** All angles in PyAbel are measured in radians. When an absolute angle is defined, zero-angle corresponds to the upwards, vertical direction. Positive values are on the right side, and negative values on the left side. The range of angles is from -Pi to +Pi. The polar grid for a 5x5 image can be generated (following the code above) using:
@@ -138,16 +140,15 @@ The PyAbel code adheres to the following conventions:
         R = np.sqrt(X**2 + Y**2)
         THETA = np.arctan2(X, Y)
 
-
     where the usual ``(Y, X)`` convention of ``arctan2`` has been reversed in order to place zero-angle in the vertical direction. Consequently, to convert the angular grid back to the Cartesian grid, we use:
   
     .. code-block:: python
 
-        X = R*np.sin(THETA)
-        Y = R*np.cos(THETA)
+        X = R * np.sin(THETA)
+        Y = R * np.cos(THETA)
 
 - 
-    **Image center:** Fundamentally, the Abel and inverse-Abel transforms in PyAbel consider the center of the image to be located in the center of a pixel. This means that, for a symmetric image, the image will have a width that is an odd number of pixels. (The center pixel is effectively "shared" between both halves of the image.) In most situations, the center is specified using the ``center`` keyword in ``abel.Transform`` (or directly using ``abel.center.center_image`` to find the true center of your image. This processing step takes care of locating the center of the image in the middle of the central pixel. However, if the individual Abel transforms methods are used directly, care must be taken to supply a properly centered image.
+    **Image origin:** Fundamentally, the forward and inverse Abel transforms in PyAbel consider the origin of the image to be located in the center of a pixel. This means that, for a symmetric image, the image will have a width that is an odd number of pixels. (The central pixel is effectively "shared" between both halves of the image.) In most situations, the image origin is specified using the ``origin`` keyword in ``abel.Transform`` (or directly using ``abel.center.center_image`` to find the origin (the center of symmetry) of your image. This processing step takes care of shifting the origin of the image to the middle of the central pixel. However, if the individual Abel transforms methods are used directly, care must be taken to supply a properly centered image. Some methods also provide low-level functions for transforming only the right half of the image (with the origin located in the middle of a 0th-column pixel).
 
 
 Support

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,8 @@ PyAbel README
 .. image:: https://ci.appveyor.com/api/projects/status/g1rj5f0g7nohcuuo
     :target: https://ci.appveyor.com/project/PyAbel/PyAbel
 
-**Note:** This readme is best viewed as part of the `PyAbel Documentation <http://pyabel.readthedocs.io/en/latest/readme_link.html>`_.
+**Note:** This readme is best viewed as part of the `PyAbel Documentation <https://pyabel.readthedocs.io/en/latest/readme_link.html>`_.
+
 
 Introduction
 ------------
@@ -23,11 +24,10 @@ Inverse Abel transforms play an important role in analyzing the projections of a
 PyAbel provides efficient implementations of several Abel transform algorithms, as well as related tools for centering images, symmetrizing images, and calculating properties such as the radial intensity distribution and the anisotropy parameters.
 
 
-
 Transform Methods
 -----------------
 
-The outcome of the numerical Abel transform depends on the exact method used. So far, PyAbel includes the following `transform methods <http://pyabel.readthedocs.io/en/latest/transform_methods.html>`_:
+The outcome of the numerical Abel transform depends on the exact method used. So far, PyAbel includes the following `transform methods <https://pyabel.readthedocs.io/en/latest/transform_methods.html>`_:
 
     1. ``basex`` - Gaussian basis set expansion of Dribinski and co-workers.
 
@@ -49,7 +49,7 @@ The outcome of the numerical Abel transform depends on the exact method used. So
 Installation
 ------------
 
-PyAbel requires Python 2.7 or 3.5-3.7. `NumPy <http://www.numpy.org/>`_ and `SciPy <https://www.scipy.org/>`_ are also required, and `Matplotlib <https://matplotlib.org/>`_ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`_, which is available for free.
+PyAbel requires Python 2.7 or 3.5-3.7. `NumPy <https://www.numpy.org/>`_ and `SciPy <https://www.scipy.org/>`_ are also required, and `Matplotlib <https://matplotlib.org/>`_ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`_, which is available for free.
 
 With pip
 ~~~~~~~~
@@ -108,11 +108,12 @@ Output:
    :width: 400px
    :alt: example abel transform
 
-.. note:: Additional examples can be viewed on the `PyAbel examples <http://pyabel.readthedocs.io/en/latest/examples.html>`_ page and even more are found in the `PyAbel/examples <https://github.com/PyAbel/PyAbel/tree/master/examples>`_ directory.
+.. note:: Additional examples can be viewed on the `PyAbel examples <https://pyabel.readthedocs.io/en/latest/examples.html>`_ page and even more are found in the `PyAbel/examples <https://github.com/PyAbel/PyAbel/tree/master/examples>`_ directory.
 
 
 Documentation
 -------------
+
 General information about the various Abel transforms available in PyAbel is available at the links above. The complete documentation for all of the methods in PyAbel is hosted at https://pyabel.readthedocs.io.
 
 
@@ -144,7 +145,6 @@ The PyAbel code adheres to the following conventions:
 
         X = R*np.sin(THETA)
         Y = R*np.cos(THETA)
-    
 
 - 
     **Image center:** Fundamentally, the Abel and inverse-Abel transforms in PyAbel consider the center of the image to be located in the center of a pixel. This means that, for a symmetric image, the image will have a width that is an odd number of pixels. (The center pixel is effectively "shared" between both halves of the image.) In most situations, the center is specified using the ``center`` keyword in ``abel.Transform`` (or directly using ``abel.center.center_image`` to find the true center of your image. This processing step takes care of locating the center of the image in the middle of the central pixel. However, if the individual Abel transforms methods are used directly, care must be taken to supply a properly centered image.
@@ -152,6 +152,7 @@ The PyAbel code adheres to the following conventions:
 
 Support
 -------
+
 If you have a question or suggestion about PyAbel, the best way to contact the PyAbel Developers Team is to `open a new issue <https://github.com/PyAbel/PyAbel/issues>`_.
 
 
@@ -167,11 +168,13 @@ Either open a new `Issue <https://github.com/PyAbel/PyAbel/issues>`_ or make a `
 
 License
 -------
+
 PyAble is licensed under the `MIT license <https://github.com/PyAbel/PyAbel/blob/master/LICENSE.txt>`_, so it can be used for pretty much whatever you want! Of course, it is provided "as is" with absolutely no warranty.
 
 
 Citation
 --------
+
 First and foremost, please cite the paper(s) corresponding to the implementation of the Abel transform that you use in your work. The references can be found at the links above.
 
 If you find PyAbel useful in you work, it would bring us great joy if you would cite the project. You can find the DOI for the lastest verison `here <https://dx.doi.org/10.5281/zenodo.594858>`_

--- a/README.rst
+++ b/README.rst
@@ -125,13 +125,15 @@ Conventions
 The PyAbel code adheres to the following conventions:
 
 - 
-    **Image orientation:** PyAbel adopts the "television" convention, where ``IM[0,0]`` refers to the **upper** left corner of the image. (This means that ``plt.imshow(IM)`` should display the image in the proper orientation, without the need to use the ``origin='lower'`` keyword.) As an example, the x,y grid for a centered 5×5 image can be generated using
+    **Image orientation:** PyAbel adopts the "television" convention, where ``IM[0, 0]`` refers to the **upper** left corner of the image. (This means that ``plt.imshow(IM)`` should display the image in the proper orientation, without the need to use the ``origin='lower'`` keyword.) Image coordinates are in the (row, column) format, consistent with NumPy array indexing, and negative values are interpreted as relative to the end of the corresponding axis. For example, ``(-1, 0)`` refers to the lower left corner (last row, 0th column). Cartesian coordinates can also be generated if needed. For example, the x, y grid for a centered 5×5 image:
 
     .. code-block:: python
 
         x = np.linspace(-2, 2, 5)
         X, Y = np.meshgrid(x, -x)  # notice the minus sign in front of the y coordinate
-    
+
+    The ``abel.tools.polar.index_coords`` function does this for images of any shape with any origin.
+
 - 
     **Angle:** All angles in PyAbel are measured in radians. When an absolute angle is defined, zero angle corresponds to the upwards vertical direction. Positive values are on the right side, and negative values on the left side. The range of angles is from −π to +π. The polar grid for a centered 5×5 image can be generated (following the code above) using
 
@@ -147,8 +149,10 @@ The PyAbel code adheres to the following conventions:
         X = R * np.sin(THETA)
         Y = R * np.cos(THETA)
 
+    The ``abel.tools.polar.cart2polar`` and ``abel.tools.polar.polar2cart`` functions are available for conversion between these Cartesian and polar grids.
+
 - 
-    **Image origin:** Fundamentally, the forward and inverse Abel transforms in PyAbel consider the origin of the image to be located in the center of a pixel. This means that, for a symmetric image, the image will have a width that is an odd number of pixels. (The central pixel is effectively "shared" between both halves of the image.) In most situations, the image origin is specified using the ``origin`` keyword in ``abel.Transform`` (or directly using ``abel.center.center_image`` to find the origin (the center of symmetry) of your image. This processing step takes care of shifting the origin of the image to the middle of the central pixel. However, if the individual Abel transforms methods are used directly, care must be taken to supply a properly centered image. Some methods also provide low-level functions for transforming only the right half of the image (with the origin located in the middle of a 0th-column pixel).
+    **Image origin:** Fundamentally, the forward and inverse Abel transforms in PyAbel consider the origin of the image to be located in the center of a pixel. This means that, for a symmetric image, the image will have a width that is an odd number of pixels. (The central pixel is effectively "shared" between both halves of the image.) In most situations, the image origin is specified using the ``origin`` keyword in ``abel.Transform`` (or directly using ``abel.center.center_image`` to find the origin (the center of symmetry) of your image). This processing step takes care of shifting the origin of the image to the middle of the central pixel. However, if the individual Abel transforms methods are used directly, care must be taken to supply a properly centered image. Some methods also provide low-level functions for transforming only the right half of the image (with the origin located in the middle of a 0th-column pixel).
 
 
 Support

--- a/README.rst
+++ b/README.rst
@@ -125,22 +125,22 @@ Conventions
 The PyAbel code adheres to the following conventions:
 
 - 
-    **Image orientation:** PyAbel adopts the "television" convention, where ``IM[0,0]`` refers to the **upper** left corner of the image. (This means that ``plt.imshow(IM)`` should display the image in the proper orientation, without the need to use the ``origin='lower'`` keyword.) As an example, the x,y-grid for a 5x5 image can be generated using:
+    **Image orientation:** PyAbel adopts the "television" convention, where ``IM[0,0]`` refers to the **upper** left corner of the image. (This means that ``plt.imshow(IM)`` should display the image in the proper orientation, without the need to use the ``origin='lower'`` keyword.) As an example, the x,y grid for a centered 5×5 image can be generated using
 
     .. code-block:: python
 
         x = np.linspace(-2, 2, 5)
-        X, Y = np.meshgrid(x, -x) # notice the minus sign in front of the y-coordinate
+        X, Y = np.meshgrid(x, -x)  # notice the minus sign in front of the y coordinate
     
 - 
-    **Angle:** All angles in PyAbel are measured in radians. When an absolute angle is defined, zero-angle corresponds to the upwards, vertical direction. Positive values are on the right side, and negative values on the left side. The range of angles is from -Pi to +Pi. The polar grid for a 5x5 image can be generated (following the code above) using:
+    **Angle:** All angles in PyAbel are measured in radians. When an absolute angle is defined, zero angle corresponds to the upwards vertical direction. Positive values are on the right side, and negative values on the left side. The range of angles is from −π to +π. The polar grid for a centered 5×5 image can be generated (following the code above) using
 
     .. code-block:: python
 
         R = np.sqrt(X**2 + Y**2)
         THETA = np.arctan2(X, Y)
 
-    where the usual ``(Y, X)`` convention of ``arctan2`` has been reversed in order to place zero-angle in the vertical direction. Consequently, to convert the angular grid back to the Cartesian grid, we use:
+    where the usual ``(Y, X)`` convention of ``arctan2`` has been reversed in order to place zero angle in the vertical direction. Consequently, to convert the angular grid back to the Cartesian grid, we use
   
     .. code-block:: python
 

--- a/abel/__init__.py
+++ b/abel/__init__.py
@@ -5,13 +5,30 @@ from __future__ import unicode_literals
 
 from ._version import __version__
 
+# Temporary tools to warn about deprecated functions and parameters.
+from warnings import warn, filterwarnings
+# class for documentation format
+class __deprecated:
+    def __repr__(self):
+        return '<deprecated>'
+# marker of deprecated parameters
+_deprecated = __deprecated()
+# print deprecation warning
+def _deprecate(msg):
+    warn(msg, DeprecationWarning, stacklevel=3)
+    # 3rd level is from where the deprecated abel function is called:
+    # level 0   level 1         level 2      level 3
+    # warn() <- _deprecate() <- abel...() <- user code
+# enable deprecation warnings (ignored by default since Python 2.7) for abel
+filterwarnings('default', '^abel\.', category=DeprecationWarning)
+
 from . import basex
 from . import benchmark
+from . import dasch
 from . import direct
 from . import hansenlaw
 from . import linbasex
 from . import onion_bordas
-from . import dasch
 from . import tools
 from . import transform
 from . import tests

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -725,7 +725,8 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
     If both **i_sym** = ``True`` and **j_sym** = ``True``, the input array is
     checked for polar symmetry.
 
-    See https://github.com/PyAbel/PyAbel/issues/34#issuecomment-160344809
+    See `issue #34 comment
+    <https://github.com/PyAbel/PyAbel/issues/34#issuecomment-160344809>`_
     for the defintion of a center of the image.
     """
 

--- a/abel/dasch.py
+++ b/abel/dasch.py
@@ -26,9 +26,14 @@ from scipy.linalg import inv
 ###############################################################################
 
 _dasch_parameter_docstring = \
-    """dasch_method deconvolution
-        C. J. Dasch Applied Optics 31, 1146 (1992).
-        http://dx.doi.org/10.1364/AO.31.001146
+    """
+    The dasch_method deconvolution method.
+
+    C. J. Dasch,
+    "One-dimensional tomography: a comparison of Abel, onion-peeling, and
+    filtered backprojection methods",
+    `Appl. Opt. 31, 1146–1152 (1992)
+    <https://doi.org/10.1364/AO.31.001146>`_.
 
     Parameters
     ----------
@@ -278,7 +283,7 @@ def _bs_onion_peeling(cols):
 
 
 def get_bs_cached(method, cols, basis_dir='.', verbose=False):
-    """load Dasch method deconvolution operator array from cache, or disk.
+    """Load Dasch method deconvolution operator array from cache, or disk.
     Generate and store if not available.
 
     Checks whether ``method`` deconvolution array has been previously

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -55,24 +55,26 @@ import numpy as np
 
 def hansenlaw_transform(image, dr=1, direction='inverse', hold_order=0,
                         **kwargs):
-    r"""Forward/Inverse Abel transformation using the algorithm of:
+    r"""Forward/Inverse Abel transformation using the algorithm from
 
-    `E. W. Hansen "Fast Hankel Transform" IEEE Trans. Acoust. Speech Signal
-    Proc. 33, 666 (1985) <https://dx.doi.org/10.1109/TASSP.1985.1164579>`_
+    E. W. Hansen,
+    "Fast Hankel transform algorithm",
+    `IEEE Trans. Acoust. Speech Signal Proc. 33, 666–671 (1985)
+    <https://dx.doi.org/10.1109/TASSP.1985.1164579>`_
 
     and
 
-    `E. W. Hansen and P.-L. Law
-    "Recursive methods for computing the Abel transform and its inverse"
-    J. Opt. Soc. Am. A 2, 510-520 (1985)
-    <https://dx.doi.org/10.1364/JOSAA.2.000510>`_
+    E. W. Hansen, P.-L. Law,
+    "Recursive methods for computing the Abel transform and its inverse",
+    `J. Opt. Soc. Am. A 2, 510–520 (1985)
+    <https://dx.doi.org/10.1364/JOSAA.2.000510>`_.
 
-    This function performs the Hansen-Law transform on only one "right-side"
-    image: ::
+    This function performs the Hansen–Law transform on only one "right-side"
+    image::
 
         Abeltrans = abel.hansenlaw.hansenlaw_transform(image, direction='inverse')
 
-    .. note::  Image should be a right-side image, like this: ::
+    .. note::  Image should be a right-side image, like this::
 
         .         +--------      +--------+
         .         |      *       | *      |
@@ -92,11 +94,11 @@ def hansenlaw_transform(image, dr=1, direction='inverse', hold_order=0,
     For the full image transform, use the
     :class:`abel.Transform<abel.transform.Transform>`.
 
-    Inverse Abel transform: ::
+    Inverse Abel transform::
 
       iAbel = abel.Transform(image, method='hansenlaw').transform
 
-    Forward Abel transform: ::
+    Forward Abel transform::
 
       fAbel = abel.Transform(image, direction='forward', method='hansenlaw').transform
 

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -86,7 +86,7 @@ def hansenlaw_transform(image, dr=1, direction='inverse', hold_order=0,
         .         |     *        | *      |
         .         +--------      +--------+
 
-        In accordance with all PyAbel methods the image center ``o`` is
+        In accordance with all PyAbel methods the image origin ``o`` is
         defined to be mid-pixel i.e. an odd number of columns, for the
         full image.
 

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -33,10 +33,11 @@ from scipy import ndimage
 _linbasex_parameter_docstring = \
     r"""Inverse Abel transform using 1d projections of images.
 
-    `Gerber, Thomas, Yuzhu Liu, Gregor Knopp, Patrick Hemberger, Andras Bodi,
-    Peter Radi, and Yaroslav Sych.
-    Charged Particle Velocity Map Image Reconstruction with One-Dimensional Projections of Spherical Functions.` Review of Scientific Instruments 84, no. 3 (March 1, 2013): 033101–033101 – 10.
-    <http://dx.doi.org/10.1063/1.4793404>`_
+    Th. Gerber, Yu. Liu, G. Knopp, P. Hemberger, A. Bodi, P. Radi, Ya. Sych,
+    "Charged particle velocity map image reconstruction with one-dimensional
+    projections of spherical functions",
+    `Rev. Sci. Instrum. 84, 033101 (2013)
+    <https://doi.org/10.1063/1.4793404>`_.
 
     ``linbasex`` models the image using a sum of Legendre polynomials at each
     radial pixel, As such, it should only be applied to situations that can
@@ -136,7 +137,9 @@ def linbasex_transform(IM, basis_dir=None, proj_angles=[0, np.pi/2],
                        rcond=0.0005, threshold=0.2, return_Beta=False, clip=0,
                        norm_range=(0, -1), direction="inverse", verbose=False,
                        dr=None):
-    """wrapper function for linebasex to process supplied quadrant-image as a full-image.
+    """
+    Wrapper function for linbasex to process supplied quadrant-image as a
+    full-image.
 
     PyAbel transform functions operate on the right side of an image.
     Here we follow the `basex` technique of duplicating the right side to

--- a/abel/onion_bordas.py
+++ b/abel/onion_bordas.py
@@ -81,13 +81,13 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=True,
     `Rev. Sci. Instrum. 67, 2257–2268 (1996)
     <https://doi.org/10.1063/1.1147044>`_.
 
-    This function operates on the "right side" of an image. i.e. it works on 
-    just half of a cylindrically symmetric image.  Unlike the other transforms,
-    the left edge should be the image center, not mid-first pixel. This 
-    corresponds to an even-width full image. 
+    This function operates on the "right side" of an image. i.e. it works on
+    just half of a cylindrically symmetric image. Unlike the other transforms,
+    the image origin should be at the left edge, not mid-pixel. This
+    corresponds to an even-width full image.
                            
-    However, shift_grid=True (default) provides the typical behavior,
-    where the first pixel corresponds to the center pixel of the image.
+    However, ``shift_grid=True`` (default) provides the typical behavior,
+    where the image origin corresponds to the pixel center in the 0th column.
 
     To perform a onion-peeling transorm on a whole image, use ::
     
@@ -100,14 +100,14 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=True,
 
     dr : float
         sampling size (=1 for pixel images), used for Jacobian scaling.
-        The resulting inverse transform is simply scaled by 1/dr.
+        The resulting inverse transform is simply scaled by 1/`dr`.
 
-    direction: str
-        only the `direction="inverse"` transform is currently implemented
+    direction : str
+        only the inverse transform is currently implemented.
    
-    shift_grid: boolean
-        place width-center on grid (bottom left pixel) by shifting image 
-        center (0, -1/2) pixel 
+    shift_grid : bool
+        place the image origin on the grid (left edge) by shifting the image
+        1/2 pixel to the left.
 
     Returns
     -------

--- a/abel/onion_bordas.py
+++ b/abel/onion_bordas.py
@@ -15,11 +15,11 @@ from scipy.ndimage.interpolation import shift
 # implementation, created by Chris Rallis and Eric Wells of 
 # Augustana University, and described in this paper:
 #
-#  http://scitation.aip.org/content/aip/journal/rsi/85/11/10.1063/1.4899267
+#  https://scitation.aip.org/content/aip/journal/rsi/85/11/10.1063/1.4899267
 #
 # The algorithm actually originates from this 1996 RSI paper by Bordas et al:
 #
-#  http://scitation.aip.org/content/aip/journal/rsi/67/6/10.1063/1.1147044
+#  https://scitation.aip.org/content/aip/journal/rsi/67/6/10.1063/1.1147044
 #
 # 2016-03-19: Jacobian intensity correction, allow negative image values
 #             Steve Gibson and Dan Hickstein
@@ -63,13 +63,23 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=True,
 
     This algorithm was adapted by Dan Hickstein from the original Matlab 
     implementation, created by Chris Rallis and Eric Wells of 
-    Augustana University, and described in this paper:
+    Augustana University, and described in
 
-    http://scitation.aip.org/content/aip/journal/rsi/85/11/10.1063/1.4899267
+    C. E. Rallis, T. G. Burwitz, P. R. Andrews, M. Zohrabi, R. Averin, S. De,
+    B. Bergues, B. Jochim, A. V. Voznyuk, N. Gregerson, B. Gaire,
+    I. Znakovskaya, J. McKenna, K. D. Carnes, M. F. Kling, I. Ben-Itzhak,
+    E. Wells,
+    "Incorporating real time velocity map image reconstruction into closed-loop
+    coherent control",
+    `Rev. Sci. Instrum. 85, 113105 (2014)
+    <https://doi.org/10.1063/1.4899267>`_.
 
-    The algorithm actually originates from this 1996 RSI paper by Bordas et al:
+    The algorithm actually originates from
 
-    http://scitation.aip.org/content/aip/journal/rsi/67/6/10.1063/1.1147044
+    C. Bordas, F. Paulig,
+    "Photoelectron imaging spectrometry: Principle and inversion method",
+    `Rev. Sci. Instrum. 67, 2257–2268 (1996)
+    <https://doi.org/10.1063/1.1147044>`_.
 
     This function operates on the "right side" of an image. i.e. it works on 
     just half of a cylindrically symmetric image.  Unlike the other transforms,

--- a/abel/tests/test_tools.py
+++ b/abel/tests/test_tools.py
@@ -41,12 +41,11 @@ def test_centering_function_shape():
 
 
 def test_centering_function():
-    # ni -> original shape of the data is (ni, ni)
-    # n_c  -> the image center is (n_c, n_c)
+    # ni  -> original shape of the data is (ni, ni)
+    # n_c -> the image origin is (n_c, n_c)
 
     for (ni, n_c) in [(10, 5),
-                         (10,  5),
-                         ]:
+                      (10, 5)]:
         arr = np.zeros((ni, ni))
 
         # arr[n_c-1:n_c+2,n_c-1:n_c+2] = 1
@@ -64,8 +63,8 @@ def test_centering_function():
             'Validating the centering function for ni={}, n_c={}'.format(ni, n_c))
 
 
-def test_speeds_non_integer_center():  
-    # ensures that the rest speeds function can work with a non-integer center
+def test_speeds_non_integer_origin():
+    # ensures that the rest speeds function can work with a non-integer origin
     n  = 101
     IM = np.random.randn(n, n)
     abel.tools.vmi.angular_integration(IM, origin=(50.5, 50.5))

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -15,44 +15,44 @@ from scipy.ndimage.interpolation import shift
 def test_center_image():
 
     # BASEX sample image, Gaussians at 10, 15, 20, 70,85, 100, 145, 150, 155
-    # image width, height n = 361, center = (180, 180)
+    # image width, height n = 361, origin = (180, 180)
     IM = abel.tools.analytical.SampleImage(n=361, name="dribinski").image
 
-    # artificially displace center, now at (179, 182)
+    # artificially displace origin, now at (179, 182)
     IMx = shift(IM, (-1, 2))
-    true_center = (179, 182)
+    true_origin = (179, 182)
 
-    # find_center using 'slice' method
-    center = abel.tools.center.find_center(IMx, center="slice")
+    # find_origin using 'slice' method
+    origin = abel.tools.center.find_origin(IMx, method="slice")
 
-    assert_allclose(center, true_center, atol=1)
+    assert_allclose(origin, true_origin, atol=1)
 
-    # find_center using 'com' method
-    center = abel.tools.center.find_center(IMx, center="com")
+    # find_origin using 'com' method
+    origin = abel.tools.center.find_origin(IMx, method="com")
 
-    assert_allclose(center, true_center, atol=1)
+    assert_allclose(origin, true_origin, atol=1)
 
     # check single axis - vertical
     # center shifted image IMx in the vertical direction only
-    IMc = abel.tools.center.center_image(IMx, center="com", axes=1)
-    # determine the center
-    center = abel.tools.center.find_center(IMc, center="com")
+    IMc = abel.tools.center.center_image(IMx, method="com", axes=1)
+    # determine the origin
+    origin = abel.tools.center.find_origin(IMc, method="com")
 
-    assert_allclose(center, (179, 180), atol=1)
+    assert_allclose(origin, (179, 180), atol=1)
 
     # check single axis - horizontal
     # center shifted image IMx in the horizontal direction only
-    IMc = abel.tools.center.center_image(IMx, center="com", axes=0)
-    center = abel.tools.center.find_center(IMc, center="com")
+    IMc = abel.tools.center.center_image(IMx, method="com", axes=0)
+    origin = abel.tools.center.find_origin(IMc, method="com")
 
-    assert_allclose(center, (180, 182), atol=1)
+    assert_allclose(origin, (180, 182), atol=1)
 
     # check even image size returns odd
     # drop off one column, to make an even column image
     IM = IM[:, :-1]
     m, n = IM.shape
 
-    IMy = abel.tools.center.center_image(IM, center="slice", odd_size=True)
+    IMy = abel.tools.center.center_image(IM, method="slice", odd_size=True)
 
     assert_allclose(IMy.shape, (m, n-1))
 

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -315,8 +315,11 @@ class TransformPair(BaseAnalytical):
     """**Abel-transform pair analytical functions**.
 
     **profiles 1–7**: Table 1 of
-    `Chan and Hieftje Spectrochimica Acta B 61, 31–41 (2006)
-    <http://doi.org/10.1016/j.sab.2005.11.009>`_.
+    G. C.-Y. Chan, Gary M. Hieftje,
+    "Estimation of confidence intervals for radial emissivity and optimization
+    of data treatment techniques in Abel inversion",
+    `Spectrochimica Acta B 61, 31–41 (2006)
+    <https://doi.org/10.1016/j.sab.2005.11.009>`_.
 
     See :mod:`abel.tools.transform_pairs`.
 

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -56,7 +56,8 @@ class BaseAnalytical(object):
 class StepAnalytical(BaseAnalytical):
     """
     Define a symmetric step function and calculate its analytical
-    Abel transform. See examples/example_step.py
+    Abel transform. See :doc:`examples/example_basex_step.py
+    <example_basex_step>`.
 
     Parameters
     ----------
@@ -271,7 +272,8 @@ class PiecewisePolynomial(BaseAnalytical):
 class GaussianAnalytical(BaseAnalytical):
     """
     Define a gaussian function and calculate its analytical
-    Abel transform. See examples/example_gaussian.py
+    Abel transform. See :doc:`examples/example_basex_gaussian.py
+    <example_basex_gaussian>`.
 
     Parameters
     ----------

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -48,7 +48,7 @@ def find_origin(IM, method='image_center', square=False, verbose=False,
     Returns
     -------
     out : (float, float)
-        coordinate of the origin of the image in the (row, column) format
+        coordinates of the origin of the image in the (row, column) format
 
     """
     return func_method[method](IM, verbose=verbose, **kwargs)
@@ -71,7 +71,7 @@ def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
         centering method:
 
         ``image_center``
-            the origin of the image is used as the center. The trivial result.
+            the center of the image is used as the origin. The trivial result.
         ``com``
             the origin is found as the center of mass.
         ``convolution``

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -14,91 +14,91 @@ from scipy.optimize import minimize
 from six import string_types
 
 
-def find_center(IM, center='image_center', square=False, verbose=False,
+def find_origin(IM, method='image_center', square=False, verbose=False,
                 **kwargs):
-    """Find the coordinates of image center, using the method
-       specified by the `center` parameter.
+    """
+    Find the coordinates of image origin, using the specified method.
 
     Parameters
     ----------
-    IM: 2D np.array
-      image data
+    IM : 2D np.array
+        image data
 
-    center: str
-        this determines how the center should be found. The options are:
+    method : str
+        determines how the origin should be found. The options are:
 
         ``image_center``
-            the center of the image is used as the center. The trivial result.
+            the center of the image is used as the origin. The trivial result.
         ``com``
-            the center is found as the center of mass.
+            the origin is found as the center of mass.
         ``convolution``
-            center by convolution of two projections along each axis.
+            the origin is found as the maximum of autoconvolution of the image
+            projections along each axis.
         ``gaussian``
-            the center is extracted by a fit to a Gaussian function.
+            the origin is extracted by a fit to a Gaussian function.
             This is probably only appropriate if the data resembles a
             gaussian.
         ``slice``
             the image is broken into slices, and these slices compared
             for symmetry.
 
-    square: bool
-        if 'True' returned image will have a square shape
+    square : bool
+        if ``True``, returned image will have a square shape
 
     Returns
     -------
-    out: (float, float)
-      coordinate of the center of the image in the (y,x) format (row, column)
+    out : (float, float)
+        coordinate of the origin of the image in the (row, column) format
 
     """
-    return func_method[center](IM, verbose=verbose, **kwargs)
+    return func_method[method](IM, verbose=verbose, **kwargs)
 
 
-def center_image(IM, center='com', odd_size=True, square=False, axes=(0, 1),
+def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
                  crop='maintain_size', verbose=False, **kwargs):
-    """ Center image with the custom value or by several methods provided in
-        `find_center` function
+    """
+    Center image with the custom value or by several methods provided in
+    :func:`find_origin()` function.
 
     Parameters
     ----------
     IM : 2D np.array
-       The image data.
+        The image data.
 
-    center : tuple or str
-        center can either be (float, float), the coordinate of the center
-        of the image in the (y,x) format (row, column)
-
-        Or, it can be a string, to specify an automatic centering method.
-        The options are:
+    method : tuple or str
+        either a tuple (float, float), the coordinate of the origin of the
+        image in the (row, column) format, or a string to specify an automatic
+        centering method:
 
         ``image_center``
-            the center of the image is used as the center. The trivial result.
+            the origin of the image is used as the center. The trivial result.
         ``com``
-            the center is found as the center of mass.
+            the origin is found as the center of mass.
         ``convolution``
-            center by convolution of two projections along each axis.
+            the origin is found as the maximum of autoconvolution of the image
+            projections along each axis.
         ``gaussian``
-            the center is extracted by a fit to a Gaussian function.
+            the origin is extracted from a fit to a Gaussian function.
             This is probably only appropriate if the data resembles a
             gaussian.
         ``slice``
             the image is broken into slices, and these slices compared for
             symmetry.
 
-    odd_size: boolean
-        if True, an image will be returned containing an odd number of columns.
-        Most of the transform methods require this, so it's best to set this to
-        True if the image will subsequently be Abel transformed.
+    odd_size : boolean
+        if ``True``, the returned image will contain an odd number of columns.
+        Most of the transform methods require this, so it's best to set this
+        to ``True`` if the image will subsequently be Abel-transformed.
 
-    square: bool
-        if 'True' returned image will have a square shape
+    square : bool
+        if ``True``, the returned image will have a square shape.
 
     crop : str
-        This determines how the image should be cropped. The options are:
+        determines how the image should be cropped. The options are:
 
         ``maintain_size``
-            return image of the same size. Some of the original
-            image may be lost
-            and some regions may be filled with zeros.
+            return image of the same size. Some regions of the original image
+            may be lost, and some regions may be filled with zeros.
         ``valid_region``
             return the largest image that can be created without padding.
             All of the returned image will correspond to the original image.
@@ -116,7 +116,7 @@ def center_image(IM, center='com', odd_size=True, square=False, axes=(0, 1),
     Returns
     -------
     out : 2D np.array
-       Centered image
+        centered image
     """
 
     rows, cols = IM.shape
@@ -146,33 +146,35 @@ def center_image(IM, center='com', odd_size=True, square=False, axes=(0, 1),
 
         rows, cols = IM.shape
 
-    # center is in y,x (row column) format!
-    if isinstance(center, string_types):
-        center = find_center(IM, center=center, verbose=verbose, **kwargs)
+    # origin is in (row, column) format!
+    if isinstance(method, string_types):
+        origin = find_origin(IM, method=method, verbose=verbose, **kwargs)
+    else:
+        origin = method
 
-    centered_data = set_center(IM, center=center, crop=crop, axes=axes,
+    centered_data = set_center(IM, origin=origin, crop=crop, axes=axes,
                                verbose=verbose)
     return centered_data
 
 
-def set_center(data, center, crop='maintain_size', axes=(0, 1), verbose=False):
-    """ Move image center to mid-point of image
+def set_center(data, origin, crop='maintain_size', axes=(0, 1), verbose=False):
+    """
+    Move image origin to mid-point of image.
 
     Parameters
     ----------
     data : 2D np.array
-        The image data
+        the image data
 
-    center : tuple
-        image pixel coordinate center (row, col)
+    origin : tuple
+        (row, column) coordinates of the image origin
 
     crop : str
-        This determines how the image should be cropped. The options are:
+        determines how the image should be cropped. The options are:
 
         ``maintain_size``
-            return image of the same size. Some of the original
-            image may be lost
-            and some regions may be filled with zeros.
+            return image of the same size. Some regions of the original image
+            may be lost and some regions may be filled with zeros.
         ``valid_region``
             return the largest image that can be created without padding.
             All of the returned image will correspond to the original image.
@@ -187,19 +189,18 @@ def set_center(data, center, crop='maintain_size', axes=(0, 1), verbose=False):
         center image with respect to axis ``0`` (vertical), ``1`` (horizontal),
         or both axes ``(0, 1)`` (default).
 
-    verbose: boolean
-        True: print diagnostics
+    verbose : bool
+        ``True``: print diagnostics
     """
-    c0, c1 = center
 
     old_shape = data.shape
-    old_center = data.shape[0]//2, data.shape[1]//2
+    old_center = data.shape[0] // 2, data.shape[1] // 2
 
-    delta0 = old_center[0] - center[0]
-    delta1 = old_center[1] - center[1]
+    delta0 = old_center[0] - origin[0]
+    delta1 = old_center[1] - origin[1]
 
     if crop == 'maintain_data':
-        # pad the image so that the center can be moved without losing any of
+        # pad the image so that the origin can be moved without losing any of
         # the original data
 
         # we need to pad the image with zeros before using the shift() function
@@ -209,8 +210,8 @@ def set_center(data, center, crop='maintain_size', axes=(0, 1), verbose=False):
         if delta1 != 0:
             shift1 = 1 + int(np.abs(delta1))
 
-        container = np.zeros((data.shape[0]+shift0, data.shape[1]+shift1),
-                              dtype=data.dtype)
+        container = np.zeros((data.shape[0] + shift0, data.shape[1] + shift1),
+                             dtype=data.dtype)
 
         area = container[:, :]
         if shift0:
@@ -225,8 +226,8 @@ def set_center(data, center, crop='maintain_size', axes=(0, 1), verbose=False):
                 area = area[:, shift1:]
         area[:, :] = data[:, :]
         data = container
-        delta0 += np.sign(delta0)*shift0 / 2.0
-        delta1 += np.sign(delta1)*shift1 / 2.0
+        delta0 += np.sign(delta0) * shift0 / 2.0
+        delta1 += np.sign(delta1) * shift1 / 2.0
     if verbose:
         print("delta = ({0}, {1})".format(delta0, delta1))
 
@@ -241,7 +242,7 @@ def set_center(data, center, crop='maintain_size', axes=(0, 1), verbose=False):
         centered_data = shift(data, (delta0, delta1))
 
     if crop == 'maintain_data':
-        # pad the image so that the center can be moved
+        # pad the image so that the origin can be moved
         # without losing any of the original data
         return centered_data
     elif crop == 'maintain_size':
@@ -258,121 +259,167 @@ def set_center(data, center, crop='maintain_size', axes=(0, 1), verbose=False):
         raise ValueError("Invalid crop method!!")
 
 
-def find_center_by_center_of_mass(IM, verbose=False, round_output=False,
+def find_origin_by_center_of_mass(IM, verbose=False, round_output=False,
                                   **kwargs):
     """
-    Find image center by calculating its center of mass
+    Find image origin by calculating its center of mass.
+
+    Parameters
+    ----------
+    IM : numpy 2D array
+        image data
+
+    round_output : bool
+        if ``True``, the coordinates are rounded to integers;
+        otherwise they are floats.
+
+    Returns
+    -------
+    origin : tuple
+        (row, column)
     """
     com = center_of_mass(IM)
-    center = com[0], com[1]
+    origin = com[0], com[1]
 
     if verbose:
-        to_print = "Center of mass at ({0}, {1})".format(center[0], center[1])
+        to_print = "Center of mass at ({0}, {1})".format(origin[0], origin[1])
 
     if round_output:
-        center = (round(center[0]), round(center[1]))
+        origin = (round(origin[0]), round(origin[1]))
         if verbose:
-            to_print += " ... round to ({0}, {1})".format(center[0], center[1])
+            to_print += " ... round to ({0}, {1})".format(origin[0], origin[1])
 
     if verbose:
         print(to_print)
 
-    return center
+    return origin
 
 
-def find_center_by_convolution(IM, **kwargs):
-    """ Center the image by convolution of two projections along each axis.
-        Code from the ``linbasex`` juptyer notebook
+def find_origin_by_convolution(IM, **kwargs):
+    """
+    Find the image origin as the maximum of autoconvolution of its projections
+    along each axis.
+
+    Code from the ``linbasex`` juptyer notebook.
 
     Parameters
     ----------
-    IM: numpy 2D array
+    IM : numpy 2D array
         image data
+
+    projections : any
+        if this parameter is present, the autoconvoluted projections along
+        both axes will be returned after the origin.
 
     Returns
     -------
-    center: tuple
-        (row-center, col-center)
+    origin : tuple
+        (row, column)
 
+        `or` (row, column), conv_0, conv_1
     """
     # projection along axis=0 of image (rows)
     QL_raw0 = IM.sum(axis=1)
     # projection along axis=1 of image (cols)
     QL_raw1 = IM.sum(axis=0)
 
-    # autocorrelate projections
+    # autoconvolute projections
     conv_0 = np.convolve(QL_raw0, QL_raw0, mode='full')
     conv_1 = np.convolve(QL_raw1, QL_raw1, mode='full')
-    len_conv = len(conv_0)/2
 
     # Take the first max, should there be several equal maxima.
     # 10May16 - axes swapped - check this
-    center = (np.argmax(conv_0)/2, np.argmax(conv_1)/2)
+    origin = (np.argmax(conv_0) / 2, np.argmax(conv_1) / 2)
 
     if "projections" in kwargs.keys():
-        return center, conv_0, conv_1
+        return origin, conv_0, conv_1
     else:
-        return center
+        return origin
 
 
-def find_center_by_center_of_image(data, verbose=False, **kwargs):
+def find_origin_by_center_of_image(data, verbose=False, **kwargs):
     """
-    Find image center simply from its dimensions.
+    Find image origin simply as its center, from its dimensions.
+
+    Parameters
+    ----------
+    IM : numpy 2D array
+        image data
+
+    Returns
+    -------
+    origin : tuple
+        (row, column)
+
     """
-    return (data.shape[1] // 2, data.shape[0] // 2)
+    return (data.shape[0] // 2, data.shape[1] // 2)
 
 
-def find_center_by_gaussian_fit(IM, verbose=False, round_output=False,
+def find_origin_by_gaussian_fit(IM, verbose=False, round_output=False,
                                 **kwargs):
     """
-    Find image center by fitting the summation along x and y axis of the data
-    to two 1D Gaussian function.
+    Find image origin by fitting the summation along rows and columns of the
+    data to two 1D Gaussian functions.
+
+    Parameters
+    ----------
+    IM : numpy 2D array
+        image data
+
+    round_output : bool
+        if ``True``, the coordinates are rounded to integers;
+        otherwise they are floats.
+
+    Returns
+    -------
+    origin : tuple
+        (row, column)
     """
     x = np.sum(IM, axis=0)
     y = np.sum(IM, axis=1)
     xc = fit_gaussian(x)[1]
     yc = fit_gaussian(y)[1]
-    center = (yc, xc)
+    origin = (yc, xc)
 
     if verbose:
-        to_print = "Gaussian center at ({0}, {1})".format(center[0], center[1])
+        to_print = "Gaussian origin at ({0}, {1})".format(origin[0], origin[1])
 
     if round_output:
-        center = (round(center[0]), round(center[1]))
+        origin = (round(origin[0]), round(origin[1]))
         if verbose:
-            to_print += " ... round to ({0}, {1})".format(center[0], center[1])
+            to_print += " ... round to ({0}, {1})".format(origin[0], origin[1])
 
     if verbose:
         print(to_print)
 
-    return center
+    return origin
 
 
 def axis_slices(IM, radial_range=(0, -1), slice_width=10):
-    """returns vertical and horizontal slice profiles, summed across slice_width.
+    """
+    Returns vertical and horizontal slice profiles, summed across slice_width.
 
     Parameters
     ----------
     IM : 2D np.array
-      image data
+        image data
 
-    radial_range: tuple floats
-      (rmin, rmax) range to limit data
+    radial_range: tuple of float
+        (rmin, rmax) range to limit data
 
-    slice_width : integer
-      width of the image slice, default 10 pixels
+    slice_width : int
+        width of the image slice, default 10 pixels
 
     Returns
     -------
     top, bottom, left, right : 1D np.arrays shape (rmin:rmax, 1)
-      image slices oriented in the same direction
-
+        image slices oriented in the same direction
     """
     rows, cols = IM.shape   # image size
 
-    r2 = rows//2 + rows % 2
-    c2 = cols//2 + cols % 2
-    sw2 = slice_width//2
+    r2 = rows // 2 + rows % 2
+    c2 = cols // 2 + cols % 2
+    sw2 = slice_width // 2
 
     rmin, rmax = radial_range
 
@@ -388,32 +435,33 @@ def axis_slices(IM, radial_range=(0, -1), slice_width=10):
             left[::-1][rmin:rmax], right[rmin:rmax])
 
 
-def find_image_center_by_slice(IM, slice_width=10, radial_range=(0, -1),
+def find_image_origin_by_slice(IM, slice_width=10, radial_range=(0, -1),
                                axis=(0, 1), **kwargs):
     """
-    Center image by comparing opposite side, vertical (``axis=0``) and/or
-    horizontal slice (``axis=1``) profiles. To center along both axis, use
-    ``axis=(0,1)``.
+    Find the image origin by comparing opposite sides: vertical (``axis=0``)
+    and/or horizontal slice (``axis=1``) profiles. To find both coordinates,
+    use ``axis=(0, 1)``.
 
     Parameters
     ----------
     IM : 2D np.array
-       The image data.
+        the image data
 
     slice_width : integer
-       Sum together this number of rows (cols) to improve signal, default 10.
+        Sum together this number of rows (cols) to improve signal, default 10.
 
     radial_range: tuple
-       (rmin,rmax): radial range [rmin:rmax] for slice profile comparison.
+        (rmin, rmax): radial range ``[rmin:rmax]`` for slice profile
+        comparison.
 
-    axis : integer or tuple
-       Center with along ``axis=0`` (vertical), or ``axis=1`` (horizontal),
-       or ``axis=(0,1)`` (both vertical and horizontal).
+    axis : int or tuple
+        Find origin coordinates: ``axis=0`` (vertical), or ``axis=1``
+        (horizontal), or ``axis=(0, 1)`` (both vertical and horizontal).
 
     Returns
     -------
-    (vertical_shift, horizontal_shift) : tuple of floats
-        (axis=0 shift, axis=1 shift)
+    origin : tuple
+        (row, column)
 
     """
 
@@ -430,8 +478,8 @@ def find_image_center_by_slice(IM, slice_width=10, radial_range=(0, -1),
 
     rows, cols = IM.shape
 
-    r2 = rows//2
-    c2 = cols//2
+    r2 = rows // 2
+    c2 = cols // 2
     top, bottom, left, right = axis_slices(IM, radial_range, slice_width)
 
     xyoffset = [0.0, 0.0]
@@ -439,35 +487,36 @@ def find_image_center_by_slice(IM, slice_width=10, radial_range=(0, -1),
     # limit shift to +- 20 pixels
     initial_shift = [0.1, ]
 
-    # vertical-axis
+    # vertical axis
     if 0 in axis:
         fit = minimize(_align, initial_shift, args=(top, bottom),
                        bounds=((-50, 50), ), tol=0.1)
         if fit["success"]:
-            xyoffset[0] = -float(fit['x'])/2  # x1/2 for image center shift
+            xyoffset[0] = -float(fit['x']) / 2  # x1/2 for image shift
         else:
             if verbose:
                 print("fit failure: axis = 0, zero shift set")
                 print(fit)
 
-    # horizontal-axis
+    # horizontal axis
     if 1 in axis:
         fit = minimize(_align, initial_shift, args=(left, right),
                        bounds=((-50, 50), ), tol=0.1)
         if fit["success"]:
-            xyoffset[1] = -float(fit['x'])/2   # x1/2 for image center shift
+            xyoffset[1] = -float(fit['x']) / 2  # x1/2 for image shift
         else:
             raise RuntimeError("fit failure: axis = 1, zero shift set", fit)
 
-    # this is the (y, x) shift to align the slice profiles
+    # this is the (row, col) shift to align the slice profiles
     xyoffset = tuple(xyoffset)
 
-    return r2-xyoffset[0], c2-xyoffset[1]
+    return r2 - xyoffset[0], c2 - xyoffset[1]
+
 
 func_method = {
-    "image_center": find_center_by_center_of_image,
-    "com": find_center_by_center_of_mass,
-    "convolution": find_center_by_convolution,
-    "gaussian": find_center_by_gaussian_fit,
-    "slice": find_image_center_by_slice
+    "image_center": find_origin_by_center_of_image,
+    "com": find_origin_by_center_of_mass,
+    "convolution": find_origin_by_convolution,
+    "gaussian": find_origin_by_gaussian_fit,
+    "slice": find_image_origin_by_slice
 }

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -208,6 +208,12 @@ def set_center(data, origin, crop='maintain_size', axes=(0, 1), verbose=False,
     old_shape = data.shape
     old_center = data.shape[0] // 2, data.shape[1] // 2
 
+    origin = list(origin)
+    if origin[0] < 0:
+        origin[0] += data.shape[0]
+    if origin[1] < 0:
+        origin[1] += data.shape[1]
+
     delta0 = old_center[0] - origin[0]
     delta1 = old_center[1] - origin[1]
 
@@ -290,8 +296,7 @@ def find_origin_by_center_of_mass(IM, verbose=False, round_output=False,
     origin : tuple
         (row, column)
     """
-    com = center_of_mass(IM)
-    origin = com[0], com[1]
+    origin = center_of_mass(IM)
 
     if verbose:
         to_print = "Center of mass at ({0}, {1})".format(origin[0], origin[1])

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -13,6 +13,8 @@ from scipy.optimize import minimize
 # testing strings with Python 2 and 3 compatibility
 from six import string_types
 
+from abel import _deprecated, _deprecate
+
 
 def find_origin(IM, method='image_center', square=False, verbose=False,
                 **kwargs):
@@ -55,7 +57,8 @@ def find_origin(IM, method='image_center', square=False, verbose=False,
 
 
 def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
-                 crop='maintain_size', verbose=False, **kwargs):
+                 crop='maintain_size', verbose=False, center=_deprecated,
+                 **kwargs):
     """
     Center image with the custom value or by several methods provided in
     :func:`find_origin()` function.
@@ -118,6 +121,10 @@ def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
     out : 2D np.array
         centered image
     """
+    if center is not _deprecated:
+        _deprecate('abel.tools.center.center_image() '
+                   'argument "center" is deprecated, use "method" instead.')
+        method = center
 
     rows, cols = IM.shape
 
@@ -157,7 +164,8 @@ def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
     return centered_data
 
 
-def set_center(data, origin, crop='maintain_size', axes=(0, 1), verbose=False):
+def set_center(data, origin, crop='maintain_size', axes=(0, 1), verbose=False,
+               center=_deprecated):
     """
     Move image origin to mid-point of image.
 
@@ -192,6 +200,10 @@ def set_center(data, origin, crop='maintain_size', axes=(0, 1), verbose=False):
     verbose : bool
         ``True``: print diagnostics
     """
+    if center is not _deprecated:
+        _deprecate('abel.tools.center.set_center() '
+                   'argument "center" is deprecated, use "origin" instead.')
+        origin = center
 
     old_shape = data.shape
     old_center = data.shape[0] // 2, data.shape[1] // 2
@@ -435,8 +447,8 @@ def axis_slices(IM, radial_range=(0, -1), slice_width=10):
             left[::-1][rmin:rmax], right[rmin:rmax])
 
 
-def find_image_origin_by_slice(IM, slice_width=10, radial_range=(0, -1),
-                               axis=(0, 1), **kwargs):
+def find_origin_by_slice(IM, slice_width=10, radial_range=(0, -1),
+                         axis=(0, 1), **kwargs):
     """
     Find the image origin by comparing opposite sides: vertical (``axis=0``)
     and/or horizontal slice (``axis=1``) profiles. To find both coordinates,
@@ -518,5 +530,60 @@ func_method = {
     "com": find_origin_by_center_of_mass,
     "convolution": find_origin_by_convolution,
     "gaussian": find_origin_by_gaussian_fit,
-    "slice": find_image_origin_by_slice
+    "slice": find_origin_by_slice
 }
+
+
+# Deprecated functions
+
+def find_center(IM, center='image_center', square=False, verbose=False,
+                **kwargs):
+    """Deprecated function. Use :func:`find_origin` instead."""
+    _deprecate('abel.tools.center.find_center() '
+               'is deprecated, use abel.tools.center.find_origin() instead.')
+    return find_origin(IM, center, square, verbose, **kwargs)
+
+
+def find_center_by_center_of_mass(IM, verbose=False, round_output=False,
+                                  **kwargs):
+    """Deprecated function. Use :func:`find_origin_by_center_of_mass`
+    instead."""
+    _deprecate('abel.tools.center.find_center_by_center_of_mass() '
+               'is deprecated, use '
+               'abel.tools.center.find_origin_by_center_of_mass() instead.')
+    return find_origin_by_center_of_mass(IM, verbose, round_output, **kwargs)
+
+
+def find_center_by_convolution(IM, **kwargs):
+    """Deprecated function. Use :func:`find_origin_by_convolution` instead."""
+    _deprecate('abel.tools.center.find_center_by_convolution() '
+               'is deprecated, use '
+               'abel.tools.center.find_origin_by_convolution() instead.')
+    return find_origin_by_convolution(IM, **kwargs)
+
+
+def find_center_by_center_of_image(data, verbose=False, **kwargs):
+    """Deprecated function. Use :func:`find_origin_by_center_of_image`
+    instead."""
+    _deprecate('abel.tools.center.find_center_by_center_of_image() '
+               'is deprecated, use '
+               'abel.tools.center.find_origin_by_center_of_image() instead.')
+    return find_origin_by_center_of_image(data, verbose, **kwargs)
+
+
+def find_center_by_gaussian_fit(IM, verbose=False, round_output=False,
+                                **kwargs):
+    """Deprecated function. Use :func:`find_origin_by_gaussian_fit` instead."""
+    _deprecate('abel.tools.center.find_center_by_gaussian_fit() '
+               'is deprecated, use '
+               'abel.tools.center.find_origin_by_gaussian_fit() instead.')
+    return find_origin_by_gaussian_fit(IM, verbose, round_output, **kwargs)
+
+
+def find_image_center_by_slice(IM, slice_width=10, radial_range=(0, -1),
+                               axis=(0, 1), **kwargs):
+    """Deprecated function. Use :func:`find_origin_by_slice` instead."""
+    _deprecate('abel.tools.center.find_image_center_by_slice() '
+               'is deprecated, use '
+               'abel.tools.center.find_origin_by_slice() instead.')
+    return find_origin_by_slice(IM, slice_width, radial_range, axis, **kwargs)

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -16,8 +16,7 @@ from six import string_types
 from abel import _deprecated, _deprecate
 
 
-def find_origin(IM, method='image_center', square=False, verbose=False,
-                **kwargs):
+def find_origin(IM, method='image_center', verbose=False, **kwargs):
     """
     Find the coordinates of image origin, using the specified method.
 
@@ -43,9 +42,6 @@ def find_origin(IM, method='image_center', square=False, verbose=False,
         ``slice``
             the image is broken into slices, and these slices compared
             for symmetry.
-
-    square : bool
-        if ``True``, returned image will have a square shape
 
     Returns
     -------
@@ -546,7 +542,9 @@ def find_center(IM, center='image_center', square=False, verbose=False,
     """Deprecated function. Use :func:`find_origin` instead."""
     _deprecate('abel.tools.center.find_center() '
                'is deprecated, use abel.tools.center.find_origin() instead.')
-    return find_origin(IM, center, square, verbose, **kwargs)
+    if square:
+        _deprecate('Argument "square" has no effect and is deprecated.')
+    return find_origin(IM, center, verbose, **kwargs)
 
 
 def find_center_by_center_of_mass(IM, verbose=False, round_output=False,

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -7,6 +7,8 @@ from scipy.optimize import leastsq
 
 import abel
 
+from abel import _deprecated, _deprecate
+
 #########################################################################
 # circularize.py
 #
@@ -23,7 +25,8 @@ import abel
 
 def circularize_image(IM, method="lsq", origin=None, radial_range=None,
                       dr=0.5, dt=0.5, smooth=0, ref_angle=None,
-                      inverse=False, return_correction=False):
+                      inverse=False, return_correction=False,
+                      center=_deprecated):
     r"""
     Corrects image distortion on the basis that the structure should be
     circular.
@@ -157,6 +160,10 @@ def circularize_image(IM, method="lsq", origin=None, radial_range=None,
         angle.
 
     """
+    if center is not _deprecated:
+        _deprecate('abel.tools.circularize.circularize_image() '
+                   'argument "center" is deprecated, use "origin" instead.')
+        origin = center
 
     if origin is not None:
         # convenience function for the case image is not centered

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -21,10 +21,10 @@ import abel
 #########################################################################
 
 
-def circularize_image(IM, method="lsq", center=None, radial_range=None,
+def circularize_image(IM, method="lsq", origin=None, radial_range=None,
                       dr=0.5, dt=0.5, smooth=0, ref_angle=None,
                       inverse=False, return_correction=False):
-    """
+    r"""
     Corrects image distortion on the basis that the structure should be
     circular.
 
@@ -48,7 +48,7 @@ def circularize_image(IM, method="lsq", center=None, radial_range=None,
     connects the discrete scaling factors as a continuous function of angle.
 
     This circularization algorithm should only be applied to a well-centered
-    image, otherwise use the `center` keyword (described below) to
+    image, otherwise use the **origin** keyword (described below) to
     center it.
 
 
@@ -61,28 +61,30 @@ def circularize_image(IM, method="lsq", center=None, radial_range=None,
         Method used to determine the radial correction factor to align slice
         profiles:
 
-        ``argmax`` - compare intensity-profile.argmax() of each radial slice.
+        ``argmax``
+                compare intensity-profile.argmax() of each radial slice.
                 This method is quick and reliable, but it assumes that
                 the radial intensity profile has an obvious maximum.
                 The positioning is limited to the nearest pixel.
 
-        ``lsq`` - minimize the difference between a slice intensity-profile
+        ``lsq``
+                minimize the difference between a slice intensity-profile
                 with its adjacent slice.
                 This method is slower and may fail to converge, but it
                 may be applied to images with any (circular) structure.
                 It aligns the slices with sub-pixel precision.
 
-    center : str, float tuple, or None
+    origin : str, float tuple, or None
         Pre-center image using :func:`abel.tools.center.center_image`.
-        `center` may be: `com`, `convolution`, `gaussian`,
-        `image_center`, `slice`, or a float tuple center :math:`(y, x)`.
+        May be: ``'com'``, ``'convolution'``, ``'gaussian;``,
+        ``'image_center'``, ``'slice'``, or a float tuple (row, column).
 
-    radial_range : tuple, or None
+    radial_range : tuple or None
         Limit slice comparison to the radial range tuple (rmin, rmax), in
-        pixels, from the image center. Use to determine the distortion
+        pixels, from the image origin. Use to determine the distortion
         correction associated with particular peaks. It is recommended to
-        select a region of your image where the signal-to-noise is highest,
-        with sharp persistant (in angle) features.
+        select a region of your image where the signal-to-noise ratio is
+        highest, with sharp persistent (in angle) features.
 
     dr : float
         Radial grid size for the polar coordinate image, default = 0.5 pixel.
@@ -100,7 +102,7 @@ def circularize_image(IM, method="lsq", center=None, radial_range=None,
         correction, at the cost of greater signal to noise in the correction
         function.
 
-        Also passed to :func:`abel.tools.polar.reproject_image_into_polar`
+        Also passed to :func:`abel.tools.polar.reproject_image_into_polar`.
 
     smooth : float
         This value is passed to the :func:`scipy.interpolate.UnivariateSpline`
@@ -111,22 +113,22 @@ def circularize_image(IM, method="lsq", center=None, radial_range=None,
         It is important to examine the relative peak position (scaling factor)
         data and how well it is represented by the spline function. Use the
         option ``return_correction=True`` to examine this data. Typically,
-        `smooth` may remain zero, noisy data may require some smoothing.
+        **smooth** may remain zero, noisy data may require some smoothing.
 
-    ref_angle : `None` or float
+    ref_angle : None or float
         Reference angle for which radial coordinate is unchanged.
-        Angle varies between :math:`-\pi` to :math:`\pi`, with zero angle
+        Angle varies between :math:`-\pi` and :math:`\pi`, with zero angle
         vertical.
 
-        `None` uses :func:`numpy.mean(radial scale factors)`, which attempts
+        ``None`` uses :func:`numpy.mean(radial scale factors)`, which attempts
         to maintain the same average radial scaling. This approximation is
         likely valid, unless you know for certain that a specific angle of
         your image corresponds to an undistorted image.
 
     inverse : bool
-        Apply an inverse Abel transform the **polar** coordinate image, to
-        remove the background intensity. This may improve the signal to noise,
-        allowing the weaker intensity featured to be followed in angle.
+        Apply an inverse Abel transform to the `polar`-coordinate image, to
+        remove the background intensity. This may improve the signal-to-noise
+        ratio, allowing the weaker intensity featured to be followed in angle.
 
         Note that this step is only for the purposes of allowing the algorithm
         to better follow peaks in the image. It does not affect the final
@@ -138,10 +140,10 @@ def circularize_image(IM, method="lsq", center=None, radial_range=None,
 
     Returns
     -------
-    IMcirc : numpy 2D array, same size as input
-        Circularized version of the input image.
+    IMcirc : numpy 2D array
+        Circularized version of the input image, same size as input.
 
-     The following values are returned if ``return_correction=True``:
+    The following values are returned if ``return_correction=True``:
 
     angles : numpy 1D array
         Mid-point angle (radians) of each image slice.
@@ -149,20 +151,20 @@ def circularize_image(IM, method="lsq", center=None, radial_range=None,
     radial_correction : numpy 1D array
         Radial correction scale factor at each angular slice.
 
-    radial_correction_function : numpy function that accepts numpy.array
+    radial_correction_function : function(numpy 1D array)
         Function that may be used to evaluate the radial correction at any
         angle.
 
     """
 
-    if center is not None:
+    if origin is not None:
         # convenience function for the case image is not centered
-        IM = abel.tools.center.center_image(IM, center=center)
+        IM = abel.tools.center.center_image(IM, method=origin)
 
     # map image into polar coordinates - much easier to slice
     # cartesian (Y, X) -> polar (Radius, Theta)
-    polarIM, radial_coord, angle_coord =\
-             abel.tools.polar.reproject_image_into_polar(IM, dr=dr, dt=dt)
+    polarIM, radial_coord, angle_coord = \
+        abel.tools.polar.reproject_image_into_polar(IM, dr=dr, dt=dt)
 
     if inverse:
         # pseudo inverse Abel transform of the polar image, removes background
@@ -205,7 +207,7 @@ def circularize(IM, radial_correction_function, ref_angle=None):
     IM : numpy 2D array
         Original image
 
-    radial_correction_function : funct
+    radial_correction_function : function(numpy 1D array)
         A function returning the radial correction for a given angle. It
         should accept a numpy 1D array of angles.
 
@@ -214,7 +216,7 @@ def circularize(IM, radial_correction_function, ref_angle=None):
     Y, X = np.indices(IM.shape)
 
     row, col = IM.shape
-    origin = (col//2, row//2)  # odd image
+    origin = (col // 2, row // 2)  # odd image
 
     # coordinates relative to center
     X -= origin[0]
@@ -228,8 +230,8 @@ def circularize(IM, radial_correction_function, ref_angle=None):
         factor = radial_correction_function(ref_angle)
 
     # radial correction
-    Xactual = X*factor/radial_correction_function(theta)
-    Yactual = Y*factor/radial_correction_function(theta)
+    Xactual = X * factor / radial_correction_function(theta)
+    Yactual = Y * factor / radial_correction_function(theta)
 
     # @DanHickstein magic
     # https://github.com/PyAbel/PyAbel/issues/186#issuecomment-275471271
@@ -249,23 +251,24 @@ def _residual(param, radial, profile, previous):
 
     radial_scaling, amplitude = param[0], param[1]
 
-    newradial = radial*radial_scaling
+    newradial = radial * radial_scaling
     spline_prof = UnivariateSpline(newradial, profile, s=0, ext=3)
-    newprof = spline_prof(radial)*amplitude
+    newprof = spline_prof(radial) * amplitude
 
     # residual cf adjacent slice profile
     return newprof - previous
 
 
 def correction(polarIMTrans, angles, radial, method):
-    """Determines a radial correction factors that align an angular slice
-       radial intensity profile with its adjacent (previous) slice profile.
+    r"""
+    Determines a radial correction factors that align an angular slice
+    radial intensity profile with its adjacent (previous) slice profile.
 
 
     Parameters
     ----------
     polarIMTrans : numpy 2D array
-        Polar coordinate image, transposed :math:`(\\theta, r)` so that each
+        Polar coordinate image, transposed :math:`(\theta, r)` so that each
         row is a single angle.
 
     angles : numpy 1D array
@@ -275,12 +278,12 @@ def correction(polarIMTrans, angles, radial, method):
         Radial coordinates for one column of `polarIMTrans`.
 
     method : str
-        "argmax": radial correction factor from position of maximum intensity.
+        ``argmax``
+            radial correction factor from position of maximum intensity.
 
-        "lsq" : least-squares determine a radial correction factor that
-        will align a radial intensity profile with the previous, adjacent
-        slice.
-
+        ``lsq``
+            least-squares determine a radial correction factor that will align
+            a radial intensity profile with the previous, adjacent slice.
     """
 
     if method == "argmax":
@@ -292,7 +295,7 @@ def correction(polarIMTrans, angles, radial, method):
             pkpos.append(profile.argmax())  # store index of peak position
 
         # radial correction factor relative to peak max in first angular slice
-        radcorr = radial[pkpos[0]]/radial[pkpos]
+        radcorr = radial[pkpos[0]] / radial[pkpos]
 
     elif method == "lsq":
         # least-squares radially scale intensity profile matching previous slice

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -28,11 +28,12 @@ def circularize_image(IM, method="lsq", center=None, radial_range=None,
     Corrects image distortion on the basis that the structure should be
     circular.
 
-    This is a simplified radial scaling version of the algorithm described in 
-    `J. R. Gascooke and S. T. Gibson and W. D. Lawrance: 'A "circularisation"
-    method to repair deformations and determine the centre of velocity map 
-    images' J. Chem. Phys. 147, 013924 (2017).
-    <https://dx.doi.org/10.1063/1.4981024>`_
+    This is a simplified radial scaling version of the algorithm described in
+    J. R. Gascooke, S. T. Gibson, W. D. Lawrance,
+    "A 'circularisation' method to repair deformations and determine the centre
+    of velocity map images",
+    `J. Chem. Phys. 147, 013924 (2017)
+    <https://dx.doi.org/10.1063/1.4981024>`_.
 
     This function is especially useful for correcting the image obtained with
     a velocity-map-imaging spectrometer, in the case where there is distortion

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -37,12 +37,12 @@ def circularize_image(IM, method="lsq", origin=None, radial_range=None,
 
     This function is especially useful for correcting the image obtained with
     a velocity-map-imaging spectrometer, in the case where there is distortion
-    of the Newton Sphere (ring) structure due to an imperfect electrostatic
+    of the Newton sphere (ring) structure due to an imperfect electrostatic
     lens or stray electromagnetic fields. The correction allows the
     highest-resolution 1D photoelectron distribution to be extracted.
 
     The algorithm splits the image into "slices" at many different angles
-    (set by `dt`) and compares the radial intensity profile of adjacent slices.
+    (set by **dt**) and compares the radial intensity profile of adjacent slices.
     A scaling factor is found which aligns each slice profile with the previous
     slice. The image is then corrected using a spline function that smoothly
     connects the discrete scaling factors as a continuous function of angle.
@@ -62,22 +62,23 @@ def circularize_image(IM, method="lsq", origin=None, radial_range=None,
         profiles:
 
         ``argmax``
-                compare intensity-profile.argmax() of each radial slice.
-                This method is quick and reliable, but it assumes that
-                the radial intensity profile has an obvious maximum.
-                The positioning is limited to the nearest pixel.
+            compare intensity-profile.argmax() of each radial slice.
+            This method is quick and reliable, but it assumes that
+            the radial intensity profile has an obvious maximum.
+            The positioning is limited to the nearest pixel.
 
         ``lsq``
-                minimize the difference between a slice intensity-profile
-                with its adjacent slice.
-                This method is slower and may fail to converge, but it
-                may be applied to images with any (circular) structure.
-                It aligns the slices with sub-pixel precision.
+            minimize the difference between a slice intensity-profile
+            with its adjacent slice.
+            This method is slower and may fail to converge, but it
+            may be applied to images with any (circular) structure.
+            It aligns the slices with sub-pixel precision.
 
-    origin : str, float tuple, or None
+    origin : float tuple, str or None
         Pre-center image using :func:`abel.tools.center.center_image`.
-        May be: ``'com'``, ``'convolution'``, ``'gaussian;``,
-        ``'image_center'``, ``'slice'``, or a float tuple (row, column).
+        May be an explicit (row, column) tuple or a method name: ``'com'``,
+        ``'convolution'``, ``'gaussian;``, ``'image_center'``, ``'slice'``.
+        ``None`` (default) assumes that the image is already centered.
 
     radial_range : tuple or None
         Limit slice comparison to the radial range tuple (rmin, rmax), in

--- a/abel/tools/io.py
+++ b/abel/tools/io.py
@@ -34,7 +34,7 @@ def save16bitPNG(filename, data):
     It's not easy to save 16-bit images in Python.
     Here is a way to save a 16-bit PNG
     Again, this is thanks to stackoverflow:
-    http://stackoverflow.com/questions/25696615/\
+    https://stackoverflow.com/questions/25696615/\
     can-i-save-a-numpy-array-as-a-16-bit-image-using-normal-enthought-python
     This requires pyPNG
     """

--- a/abel/tools/math.py
+++ b/abel/tools/math.py
@@ -62,11 +62,9 @@ def gradient(f, x=None, dx=1, axis=-1):
 
 def gaussian(x, a, mu, sigma, c):
     """
-    Gaussian function
+    `Gaussian function <https://en.wikipedia.org/wiki/Gaussian_function>`_
 
     :math:`f(x)=a e^{-(x - \mu)^2 / (2 \\sigma^2)} + c`
-
-    ref: https://en.wikipedia.org/wiki/Gaussian_function
 
     Parameters
     ----------

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -56,6 +56,13 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
     ny, nx = data.shape[:2]
     if origin is None:
         origin = (ny // 2, nx // 2)
+    else:
+        origin = list(origin)
+        # wrap negative coordinates
+        if origin[0] < 0:
+            origin[0] += ny
+        if origin[1] < 0:
+            origin[1] += nx
 
     # Determine that the min and max r and theta coords will be...
     x, y = index_coords(data, origin=origin)  # (x,y) coordinates of each pixel
@@ -112,6 +119,11 @@ def index_coords(data, origin=None):
         origin_x, origin_y = nx // 2, ny // 2
     else:
         origin_y, origin_x = origin
+        # wrap negative coordinates
+        if origin_y < 0:
+            origin_y += ny
+        if origin_x < 0:
+            origin_x += nx
 
     x, y = np.meshgrid(np.arange(float(nx)) - origin_x,
                        origin_y - np.arange(float(ny)))

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -48,7 +48,7 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
     Notes
     -----
     Adapted from: 
-    http://stackoverflow.com/questions/3798333/image-information-along-a-polar-coordinate-system
+    https://stackoverflow.com/questions/3798333/image-information-along-a-polar-coordinate-system
     
     """
     # bottom-left coordinate system requires numpy image to be np.flipud

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -22,18 +22,18 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
     ----------
     data : 2D np.array
     origin : tuple
-        The coordinate of the image center, relative to bottom-left
+        The coordinate of the image origin, relative to bottom-left
     Jacobian : boolean
-        Include ``r`` intensity scaling in the coordinate transform. 
-        This should be included to account for the changing pixel size that 
+        Include `r` intensity scaling in the coordinate transform.
+        This should be included to account for the changing pixel size that
         occurs during the transform.
     dr : float
         Radial coordinate spacing for the grid interpolation
         tests show that there is not much point in going below 0.5
     dt : float
         Angular coordinate spacing (in radians)
-        if ``dt=None``, dt will be set such that the number of theta values
-        is equal to the maximum value between the height or the width of 
+        if ``dt=None``, **dt** will be set such that the number of theta values
+        is equal to the maximum value between the height or the width of
         the image.
 
     Returns
@@ -44,31 +44,31 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
         meshgrid of radial coordinates
     theta_grid : 2D np.array
         meshgrid of theta coordinates
-        
+
     Notes
     -----
-    Adapted from: 
+    Adapted from:
     https://stackoverflow.com/questions/3798333/image-information-along-a-polar-coordinate-system
-    
+
     """
     # bottom-left coordinate system requires numpy image to be np.flipud
     data = np.flipud(data)
 
     ny, nx = data.shape[:2]
     if origin is None:
-        origin = (nx//2, ny//2) 
+        origin = (nx // 2, ny // 2)
 
     # Determine that the min and max r and theta coords will be...
     x, y = index_coords(data, origin=origin)  # (x,y) coordinates of each pixel
     r, theta = cart2polar(x, y)  # convert (x,y) -> (r,θ), note θ=0 is vertical
 
-    nr = np.int(np.ceil((r.max()-r.min())/dr))
+    nr = np.int(np.ceil((r.max() - r.min()) / dr))
 
     if dt is None:
         nt = max(nx, ny)
     else:
         # dt in radians
-        nt = np.int(np.ceil((theta.max()-theta.min())/dt))
+        nt = np.int(np.ceil((theta.max() - theta.min()) / dt))
 
     # Make a regular (in polar space) grid based on the min and max r & theta
     r_i = np.linspace(r.min(), r.max(), nr, endpoint=False)
@@ -87,30 +87,30 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
     output = zi.reshape((nr, nt))
 
     if Jacobian:
-        output = output*r_i[:, np.newaxis]
+        output = output * r_i[:, np.newaxis]
 
     return output, r_grid, theta_grid
 
 
 def index_coords(data, origin=None):
     """
-    Creates x & y coords for the indicies in a numpy array
-    
+    Creates `x` and `y` coordinates for the indices in a numpy array.
+
     Parameters
     ----------
     data : numpy array
         2D data
-    origin : (x,y) tuple
-        defaults to the center of the image. Specify origin=(0,0)
+    origin : tuple
+        (x, y). Defaults to the center of the image. Specify ``origin=(0,0)``
         to set the origin to the *bottom-left* corner of the image.
-    
+
     Returns
     -------
         x, y : arrays
     """
     ny, nx = data.shape[:2]
     if origin is None:
-        origin_x, origin_y = nx//2, ny//2
+        origin_x, origin_y = nx // 2, ny // 2
     else:
         origin_x, origin_y = origin
 
@@ -123,18 +123,18 @@ def index_coords(data, origin=None):
 
 def cart2polar(x, y):
     """
-    Transform Cartesian coordinates to polar
-    
+    Transform Cartesian coordinates to polar.
+
     Parameters
     ----------
     x, y : floats or arrays
         Cartesian coordinates
-    
+
     Returns
     -------
     r, theta : floats or arrays
         Polar coordinates
-        
+
     """
     r = np.sqrt(x**2 + y**2)
     theta = np.arctan2(x, y)  # θ referenced to vertical
@@ -143,13 +143,13 @@ def cart2polar(x, y):
 
 def polar2cart(r, theta):
     """
-    Transform polar coordinates to Cartesian
-    
+    Transform polar coordinates to Cartesian.
+
     Parameters
     -------
     r, theta : floats or arrays
         Polar coordinates
-        
+
     Returns
     ----------
     x, y : floats or arrays

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -64,7 +64,7 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
         if origin[1] < 0:
             origin[1] += nx
 
-    # Determine that the min and max r and theta coords will be...
+    # Determine what the min and max r and theta coords will be...
     x, y = index_coords(data, origin=origin)  # (x,y) coordinates of each pixel
     r, theta = cart2polar(x, y)  # convert (x,y) -> (r,θ), note θ=0 is vertical
 

--- a/abel/tools/symmetry.py
+++ b/abel/tools/symmetry.py
@@ -35,7 +35,7 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
         Include quadrant (Q0, Q1, Q2, Q3) in the symmetry combination(s)
         and final image
 
-    symmetrize_method: str
+    symmetrize_method : str
         Method used for symmetrizing the image.
 
         ``average``
@@ -46,9 +46,11 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
             projection should be real. Removing the imaginary components in
             reciprocal space leaves a symmetric projection.
 
-        (ref: Overstreet, K., et al. "Multiple scattering and the density
-        distribution of a Cs MOT." Optics express 13.24 (2005): 9672-9682.
-        http://dx.doi.org/10.1364/OPEX.13.009672)
+            K. R. Overstreet, P. Zabawa, J. Tallant, A. Schwettmann,
+            J. P. Shaffer,
+            "Multiple scattering and the density distribution of a Cs MOT",
+            `Optics Express 13, 9672–9682 (2005)
+            <https://dx.doi.org/10.1364/OPEX.13.009672>`_.
 
     Returns
     -------
@@ -60,17 +62,17 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
     Notes
     -----
 
-    The symmetry_axis keyword averages quadrants like this: ::
+    The symmetry_axis keyword averages quadrants like this::
 
-         +--------+--------+
-         | Q1   * | *   Q0 |
-         |   *    |    *   |
-         |  *     |     *  |               cQ1 | cQ0
-         +--------o--------+ --(output) -> ----o----
-         |  *     |     *  |               cQ2 | cQ3
-         |   *    |    *   |
-         | Q2  *  | *   Q3 |          cQi == combined quadrants
-         +--------+--------+
+        +--------+--------+
+        | Q1   * | *   Q0 |
+        |   *    |    *   |
+        |  *     |     *  |               cQ1 | cQ0
+        +--------o--------+ --(output) -> ----o----
+        |  *     |     *  |               cQ2 | cQ3
+        |   *    |    *   |
+        | Q2  *  | *   Q3 |          cQi == combined quadrants
+        +--------+--------+
 
         symmetry_axis = None - individual quadrants
         symmetry_axis = 0 (vertical) - average Q0+Q1, and Q2+Q3
@@ -78,7 +80,7 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
         symmetry_axis = (0, 1) (both) - combine and average all 4 quadrants
 
 
-    The end results look like this: ::
+    The end results look like this::
 
         (0) symmetry_axis = None
 
@@ -89,9 +91,9 @@ def get_image_quadrants(IM, reorient=True, symmetry_axis=None,
         (1) symmetry_axis = 0
 
             Combine:  Q01 = Q0 + Q1, Q23 = Q2 + Q3
-            returned image    Q01 | Q01
-                             -----o-----
-                              Q23 | Q23
+            returned image   Q01 | Q01
+                            -----o-----
+                             Q23 | Q23
 
         (2) symmetry_axis = 1
 
@@ -198,9 +200,9 @@ def put_image_quadrants(Q, original_image_shape, symmetry_axis=None):
 
     Parameters
     ----------
-    Q: tuple of np.array  (Q0, Q1, Q2, Q3)
-       Image quadrants all oriented as Q0
-       shape (``rows//2+rows%2, cols//2+cols%2``) ::
+    Q : tuple of np.array (Q0, Q1, Q2, Q3)
+        Image quadrants all oriented as Q0
+        shape (``rows//2+rows%2, cols//2+cols%2``) ::
 
             +--------+--------+
             | Q1   * | *   Q0 |
@@ -212,20 +214,20 @@ def put_image_quadrants(Q, original_image_shape, symmetry_axis=None):
             | Q2  *  | *   Q3 |
             +--------+--------+
 
-    original_image_shape: tuple
-       (rows, cols)
+    original_image_shape : tuple
+        (rows, cols)
 
-       reverses the padding added by `get_image_quadrants()` for odd-axis sizes
+        reverses the padding added by `get_image_quadrants()` for odd-axis sizes
 
-       odd row trims 1 row from Q1, Q0
+        odd row trims 1 row from Q1, Q0
 
-       odd column trims 1 column from Q1, Q2
+        odd column trims 1 column from Q1, Q2
 
     symmetry_axis : int or tuple
-       impose image symmetry
+        impose image symmetry
 
-           ``symmetry_axis = 0 (vertical)   - Q0 == Q1 and Q3 == Q2``
-           ``symmetry_axis = 1 (horizontal) - Q2 == Q1 and Q3 == Q0``
+            ``symmetry_axis = 0 (vertical)   - Q0 == Q1 and Q3 == Q2``
+            ``symmetry_axis = 1 (horizontal) - Q2 == Q1 and Q3 == Q0``
 
 
     Returns
@@ -235,11 +237,11 @@ def put_image_quadrants(Q, original_image_shape, symmetry_axis=None):
 
             symmetry_axis =
 
-             None             0              1           (0,1)
+            None             0              1           (0,1)
 
-            Q1 | Q0        Q1 | Q1        Q1 | Q0       Q1 | Q1
-           ----o----  or  ----o----  or  ----o----  or ----o----
-            Q2 | Q3        Q2 | Q2        Q1 | Q0       Q1 | Q1
+             Q1 | Q0        Q1 | Q1        Q1 | Q0       Q1 | Q1
+            ----o----  or  ----o----  or  ----o----  or ----o----
+             Q2 | Q3        Q2 | Q2        Q1 | Q0       Q1 | Q1
 
     """
 

--- a/abel/tools/transform_pairs.py
+++ b/abel/tools/transform_pairs.py
@@ -20,9 +20,12 @@ import numpy as np
 __doc__ = """
 Analytical function Abel-transform pairs
 
-profiles 1--7, table 1 of:
-    `G. C.-Y Chan and G. M. Hieftje Spectrochimica Acta B 61, 31–41 (2006)
-    <https://doi.org/10.1016/j.sab.2005.11.009>`_
+profiles 1--7:
+    G. C.-Y. Chan, Gary M. Hieftje,
+    "Estimation of confidence intervals for radial emissivity and optimization
+    of data treatment techniques in Abel inversion",
+    `Spectrochimica Acta B 61, 31–41 (2006)
+    <https://doi.org/10.1016/j.sab.2005.11.009>`_, Table 1.
 
 Note:
     the transform pair functions are more conveniently accessed through
@@ -61,8 +64,10 @@ def a(n, r):
 
 def profile1(r):
     """**profile1**:
-    `Cremers and Birkebak App. Opt. 5, 1057–1064 (1966) Eq(13)
-    <https://doi.org/10.1364/AO.5.001057>`_
+    C. J. Cremers, R. C. Birkebak,
+    "Application of the Abel Integral Equation to Spectrographic Data",
+    `Appl. Opt. 5, 1057–1064 (1966)
+    <https://doi.org/10.1364/AO.5.001057>`_, Eq. (13).
 
     .. math::
 
@@ -142,8 +147,10 @@ def profile1(r):
 
 def profile2(r):
     """**profile2**:
-    `Cremers and Birkebak App. Opt. 5, 1057–1064 (1966) Eq(13)
-    <https://doi.org/10.1364/AO.5.001057>`_
+    C. J. Cremers, R. C. Birkebak,
+    "Application of the Abel Integral Equation to Spectrographic Data",
+    `Appl. Opt. 5, 1057–1064 (1966)
+    <https://doi.org/10.1364/AO.5.001057>`_, Eq. (11).
 
     .. math::
 
@@ -189,8 +196,10 @@ def profile2(r):
 
 def profile3(r):
     """**profile3**:
-    `Cremers and Birkebak App. Opt. 5, 1057–1064 (1966) Eq(13)
-    <https://doi.org/10.1364/AO.5.001057>`_
+    C. J. Cremers, R. C. Birkebak,
+    "Application of the Abel Integral Equation to Spectrographic Data",
+    `Appl. Opt. 5, 1057–1064 (1966)
+    <https://doi.org/10.1364/AO.5.001057>`_, Eq. (12).
 
     .. math::
 
@@ -256,8 +265,12 @@ def profile3(r):
 
 
 def profile4(r):
-    """**profile4**: `Alvarez, Rodero, Quintero Spectochim. Acta B 57,
-    1665–1680 (2002) <https://doi.org/10.1016/S0584-8547(02)00087-3>`_
+    """**profile4**:
+    R. Álvarez, A. Rodero, M. C. Quintero,
+    "An Abel inversion method for radially resolved measurements in the axial
+    injection torch",
+    `Spectochim. Acta B 57, 1665–1680 (2002)
+    <https://doi.org/10.1016/S0584-8547(02)00087-3>`_, Eq. (10).
 
     Note:
         Published projection has misprints
@@ -360,8 +373,11 @@ def profile4(r):
 
 
 def profile5(r):
-    """**profile5**: `Buie et al. J. Quant. Spectrosc. Radiat. Transfer 55,
-    231–243 (1996) <https://doi.org/10.1016/j.amc.2014.03.043>`_
+    """**profile5**:
+    M. J. Buie, J. T. P. Pender, J. P. Holloway, T. Vincent, P. L. G. Ventzek,
+    M. L. Brake,
+    `J. Quant. Spectrosc. Radiat. Transf. 55, 231–243 (1996)
+    <https://doi.org/10.1016/0022-4073(95)00149-2>`_, Table 1, № 1.
 
     .. math::
 
@@ -403,8 +419,11 @@ def profile5(r):
 
 
 def profile6(r):
-    """**profile6**: `Buie et al. J. Quant. Spectrosc. Radiat. Transfer 55,
-    231–243 (1996) <https://doi.org/10.1016/j.amc.2014.03.043>`_
+    """**profile6**:
+    M. J. Buie, J. T. P. Pender, J. P. Holloway, T. Vincent, P. L. G. Ventzek,
+    M. L. Brake,
+    `J. Quant. Spectrosc. Radiat. Transf. 55, 231–243 (1996)
+    <https://doi.org/10.1016/0022-4073(95)00149-2>`_, Table 1, № 7.
 
     .. math::
 
@@ -449,8 +468,11 @@ def profile6(r):
 
 def profile7(r):
     """**profile7**:
-    `Buie et al. J. Quant. Spectrosc. Radiat. Transfer 55, 231–243 (1996)
-    <https://doi.org/10.1016/j.amc.2014.03.043>`_
+    M. J. Buie, J. T. P. Pender, J. P. Holloway, T. Vincent, P. L. G. Ventzek,
+    M. L. Brake,
+    `J. Quant. Spectrosc. Radiat. Transf. 55, 231–243 (1996)
+    <https://doi.org/10.1016/0022-4073(95)00149-2>`_, Table 1, № 9 (divided by
+    2).
 
     .. math::
 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -13,6 +13,8 @@ from scipy.optimize import curve_fit
 from scipy.linalg import hankel, inv, pascal
 from scipy.special import legendre
 
+from abel import _deprecate
+
 
 def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     r"""Angular integration of the image.
@@ -105,7 +107,7 @@ def average_radial_intensity(IM, **kwargs):
     return R, intensity
 
 
-def radial_integration(IM, radial_ranges=None):
+def radial_integration(IM, origin=None, radial_ranges=None):
     r""" Intensity variation in the angular coordinate.
 
     This function is the :math:`\theta`-coordinate complement to
@@ -120,6 +122,10 @@ def radial_integration(IM, radial_ranges=None):
     ----------
     IM : 2D numpy.array
         the image data
+
+    origin : tuple or None
+        image origin in the (row, column) format. If ``None``, the geometric
+        center of the image (``rows // 2, cols // 2``) is used.
 
     radial_ranges : list of tuple ranges or int step
         tuple
@@ -150,8 +156,13 @@ def radial_integration(IM, radial_ranges=None):
     theta: 1D numpy.array
         angle coordinates, referenced to vertical direction
     """
+    if origin is not None and not isinstance(origin, tuple):
+        _deprecate('radial_integration() has 2nd argument "origin", '
+                   'use keyword argument "radial_ranges" or insert "None".')
+        radial_ranges = origin
+        origin = None
 
-    polarIM, r_grid, theta_grid = reproject_image_into_polar(IM)
+    polarIM, r_grid, theta_grid = reproject_image_into_polar(IM, origin)
 
     theta = theta_grid[0, :]  # theta coordinates
     r = r_grid[:, 0]          # radial coordinates

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -20,7 +20,7 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     Returns the one-dimensional intensity profile as a function of the
     radial coordinate.
 
-    Note: the use of Jacobian=True applies the correct Jacobian for the
+    Note: the use of ``Jacobian=True`` applies the correct Jacobian for the
     integration of a 3D object in spherical coordinates.
 
     Parameters
@@ -28,9 +28,9 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     IM : 2D numpy.array
         the image data
 
-    origin : tuple
-        image origin coordinates relative to *bottom-left* corner
-        defaults to ``rows // 2, cols // 2``.
+    origin : tuple or None
+        image origin in the (row, column) format. If ``None``, the geometric
+        center of the image (``rows // 2, cols // 2``) is used.
 
     Jacobian : bool
         Include :math:`r\sin\theta` in the angular sum (integration).
@@ -40,14 +40,14 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
         total Jacobian of :math:`r^2\sin\theta`.
 
     dr : float
-        radial grid spacing, in pixels (default 1). `dr=0.5` may
+        radial grid spacing in pixels (default 1). ``dr=0.5`` may
         reduce pixel granularity of the speed profile.
 
-    dt : float
+    dt : float or None
         angular grid spacing in radians.
-        If ``dt=None``, **dt** will be set such that the number of theta values
-        is equal to the height of the image (which should typically ensure
-        good sampling.)
+        If ``None``, the number of theta values will be set to largest
+        dimension (the height or the width) of the image, which should
+        typically ensure good sampling.
 
     Returns
     ------
@@ -64,14 +64,14 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
 
     dt = T[0, 1] - T[0, 0]
 
-    if Jacobian:  # x r sinθ
-        polarIM = polarIM * R * np.abs(np.sin(T))
+    if Jacobian:  # × r sinθ
+        polarIM *= R * np.abs(np.sin(T))
 
     speeds = np.trapz(polarIM, axis=1, dx=dt)
 
     n = speeds.shape[0]
 
-    return R[:n, 0], speeds   # limit radial coordinates range to match speed
+    return R[:n, 0], speeds  # limit radial coordinates range to match speed
 
 
 def average_radial_intensity(IM, **kwargs):
@@ -80,8 +80,7 @@ def average_radial_intensity(IM, **kwargs):
     in that it returns the average intensity, and not the integrated intensity
     of a 3D image. It is equivalent to calling
     :func:`abel.tools.vmi.angular_integration` with
-    `Jacobian=True` and then dividing the result by 2π.
-
+    ``Jacobian=True`` and then dividing the result by 2π.
 
     Parameters
     ----------
@@ -98,7 +97,7 @@ def average_radial_intensity(IM, **kwargs):
         radial coordinates
 
     intensity : 1D numpy.array
-        intensity profile as a function of the radial coordinate.
+        intensity profile as a function of the radial coordinate
 
     """
     R, intensity = angular_integration(IM, Jacobian=False, **kwargs)
@@ -110,7 +109,7 @@ def radial_integration(IM, radial_ranges=None):
     r""" Intensity variation in the angular coordinate.
 
     This function is the :math:`\theta`-coordinate complement to
-    :func:`abel.tools.vmi.angular_integration`
+    :func:`abel.tools.vmi.angular_integration`.
 
     Evaluates intensity vs angle for defined radial ranges.
     Determines the anisotropy parameter for each radial range.
@@ -143,13 +142,13 @@ def radial_integration(IM, radial_ranges=None):
         corresponding to the radial ranges
 
     Rmidpt : numpy float 1D array
-        radial-mid point of each radial range
+        radial mid-point of each radial range
 
     Intensity_vs_theta: 2D numpy.array
-        intensity vs angle distribution for each selected radial range.
+        intensity vs angle distribution for each selected radial range
 
     theta: 1D numpy.array
-        angle coordinates, referenced to vertical direction.
+        angle coordinates, referenced to vertical direction
     """
 
     polarIM, r_grid, theta_grid = reproject_image_into_polar(IM)
@@ -186,19 +185,18 @@ def radial_integration(IM, radial_ranges=None):
 def anisotropy_parameter(theta, intensity, theta_ranges=None):
     r"""
     Evaluate anisotropy parameter :math:`\beta`, for :math:`I` vs
-    :math:`\theta` data.
+    :math:`\theta` data:
 
     .. math::
 
-        I = \frac{\sigma_\text{total}}{4\pi} [ 1 + \beta P_2(\cos\theta) ]
+        I = \frac{\sigma_\text{total}}{4\pi} [ 1 + \beta P_2(\cos\theta) ],
 
-    where :math:`P_2(x)=\frac{3x^2-1}{2}` is a 2nd order Legendre polynomial.
+    where :math:`P_2(x)=\frac{3x^2-1}{2}` is a 2nd-order Legendre polynomial.
 
     J. Cooper, R. N. Zare,
     "Angular Distribution of Photoelectrons",
     `J. Chem. Phys. 48, 942–943 (1968)
     <https://dx.doi.org/10.1063/1.1668742>`_.
-
 
     Parameters
     ----------

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -630,6 +630,11 @@ class Distributions(object):
         # Determine origin [row, col].
         if np.ndim(self.origin) == 1:  # explicit numbers
             row, col = self.origin
+            # wrap negative coordinates
+            if row < 0:
+                row += height
+            if col < 0:
+                col += width
         else:  # string with codes
             if len(self.origin) == 2:
                 r, c = self.origin

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -26,38 +26,38 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     Parameters
     ----------
     IM : 2D numpy.array
-        The data image.
+        the image data
 
     origin : tuple
-        Image center coordinate relative to *bottom-left* corner
-        defaults to ``rows//2, cols//2``.
+        image origin coordinates relative to *bottom-left* corner
+        defaults to ``rows // 2, cols // 2``.
 
-    Jacobian : boolean
+    Jacobian : bool
         Include :math:`r\sin\theta` in the angular sum (integration).
         Also, ``Jacobian=True`` is passed to
         :func:`abel.tools.polar.reproject_image_into_polar`,
-        which includes another value of ``r``, thus providing the appropriate
+        which includes another value of `r`, thus providing the appropriate
         total Jacobian of :math:`r^2\sin\theta`.
 
     dr : float
-        Radial coordinate grid spacing, in pixels (default 1). `dr=0.5` may
+        radial grid spacing, in pixels (default 1). `dr=0.5` may
         reduce pixel granularity of the speed profile.
 
     dt : float
-        Theta coordinate grid spacing in radians.
-        if ``dt=None``, dt will be set such that the number of theta values
+        angular grid spacing in radians.
+        If ``dt=None``, **dt** will be set such that the number of theta values
         is equal to the height of the image (which should typically ensure
         good sampling.)
 
     Returns
     ------
     r : 1D numpy.array
-         radial coordinates
+        radial coordinates
 
     speeds : 1D numpy.array
-         Integrated intensity array (vs radius).
+        integrated intensity array (vs radius).
 
-     """
+    """
 
     polarIM, R, T = reproject_image_into_polar(
         IM, origin, Jacobian=Jacobian, dr=dr, dt=dt)
@@ -80,25 +80,25 @@ def average_radial_intensity(IM, **kwargs):
     in that it returns the average intensity, and not the integrated intensity
     of a 3D image. It is equivalent to calling
     :func:`abel.tools.vmi.angular_integration` with
-    `Jacobian=True` and then dividing the result by 2*pi.
+    `Jacobian=True` and then dividing the result by 2π.
 
 
     Parameters
     ----------
     IM : 2D numpy.array
-     The data image.
+        the image data
 
     kwargs :
-      additional keyword arguments to be passed to
-      :func:`abel.tools.vmi.angular_integration`
+        additional keyword arguments to be passed to
+        :func:`abel.tools.vmi.angular_integration`
 
     Returns
     -------
     r : 1D numpy.array
-      radial coordinates
+        radial coordinates
 
     intensity : 1D numpy.array
-      one-dimensional intensity profile as a function of the radial coordinate.
+        intensity profile as a function of the radial coordinate.
 
     """
     R, intensity = angular_integration(IM, Jacobian=False, **kwargs)
@@ -115,12 +115,12 @@ def radial_integration(IM, radial_ranges=None):
     Evaluates intensity vs angle for defined radial ranges.
     Determines the anisotropy parameter for each radial range.
 
-    See :doc:`examples/example_PAD.py <examples>`
+    See :doc:`examples/example_PAD.py <examples>`.
 
     Parameters
     ----------
     IM : 2D numpy.array
-        Image data
+        the image data
 
     radial_ranges : list of tuple ranges or int step
         tuple
@@ -142,16 +142,14 @@ def radial_integration(IM, radial_ranges=None):
         (amp0, error_amp_fit0), (amp1, error_amp_fit1), ...
         corresponding to the radial ranges
 
-    Rmidpt : numpy float 1d array
+    Rmidpt : numpy float 1D array
         radial-mid point of each radial range
 
     Intensity_vs_theta: 2D numpy.array
-       Intensity vs angle distribution for each selected radial range.
+        intensity vs angle distribution for each selected radial range.
 
     theta: 1D numpy.array
-       Angle coordinates, referenced to vertical direction.
-
-
+        angle coordinates, referenced to vertical direction.
     """
 
     polarIM, r_grid, theta_grid = reproject_image_into_polar(IM)
@@ -204,16 +202,16 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
 
     Parameters
     ----------
-    theta: 1D numpy array
-       Angle coordinates, referenced to the vertical direction.
+    theta : 1D numpy array
+        angle coordinates, referenced to the vertical direction.
 
-    intensity: 1D numpy array
-       Intensity variation with angle
+    intensity : 1D numpy array
+        intensity variation with angle
 
     theta_ranges: list of tuples
-       Angular ranges over which to fit
-       ``[(theta1, theta2), (theta3, theta4)]``.
-       Allows data to be excluded from fit, default include all data
+        angular ranges over which to fit
+        ``[(theta1, theta2), (theta3, theta4)]``.
+        Allows data to be excluded from fit, default include all data.
 
     Returns
     -------
@@ -224,11 +222,11 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
         (amplitude of signal, fit error)
 
     """
-    def P2(x):   # 2nd order Legendre polynomial
+    def P2(x):  # 2nd-order Legendre polynomial
         return (3 * x * x - 1) / 2
 
     def PAD(theta, beta, amplitude):
-        return amplitude * (1 + beta * P2(np.cos(theta)))   # Eq. (1) as above
+        return amplitude * (1 + beta * P2(np.cos(theta)))  # Eq. (1) as above
 
     # angular range of data to be included in the fit
     if theta_ranges is not None:
@@ -260,16 +258,16 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
     Convert speed radial coordinate into electron kinetic or electron binding
     energy.  Return the photoelectron spectrum (PES).
 
-    This calculation uses a single scaling factor ``energy_cal_factor``
+    This calculation uses a single scaling factor **energy_cal_factor**
     to convert the radial pixel coordinate into electron kinetic energy.
 
-    Additional experimental parameters: ``photon_energy`` will give the
+    Additional experimental parameters: **photon_energy** will give the
     energy scale as electron binding energy, in the same energy units,
-    while ``Vrep``, the VMI lens repeller voltage (volts), provides for a
-    voltage independent scaling factor. i.e. ``energy_cal_factor`` should
+    while **Vrep**, the VMI lens repeller voltage (volts), provides for a
+    voltage-independent scaling factor. i.e. **energy_cal_factor** should
     remain approximately constant.
 
-    The ``energy_cal_factor`` is readily determined by comparing the
+    The **energy_cal_factor** is readily determined by comparing the
     generated energy scale with published spectra. e.g. for O\ :sup:`−`
     photodetachment, the strongest fine-structure transition occurs at the
     electron affinity :math:`EA = 11\,784.676(7)` cm\ :math:`^{-1}`. Values for
@@ -297,26 +295,24 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
     per_energy_scaling : bool
 
         sets the intensity Jacobian.
-        If `True`, the returned intensities correspond to an "intensity per eV"
-        or "intensity per cm\ :sup:`-1` ". If `False`, the returned intensities
-        correspond to an "intensity per pixel".
-
-     Optional:
+        If ``True``, the returned intensities correspond to an "intensity per
+        eV" or "intensity per cm\ :sup:`-1` ". If ``False``, the returned
+        intensities correspond to an "intensity per pixel".
 
     photon_energy : None or float
 
         measurement photon energy. The output energy scale is then set to
-        electron-binding-energy in units of `energy_cal_factor`. The
-        conversion from wavelength (nm) to `photon_energy` (cm\ :sup:`−1`)
-        is :math:`10^{7}/\lambda` (nm) e.g. `1.0e7/812.51` for
+        electron-binding-energy in units of **energy_cal_factor**. The
+        conversion from wavelength (nm) to **photon_energy** (cm\ :sup:`−1`)
+        is :math:`10^{7}/\lambda` (nm) e.g. ``1.0e7/812.51`` for
         "examples/data/O-ANU1024.txt".
 
     Vrep : None or float
 
         repeller voltage. Convenience parameter to allow the
-        `energy_cal_factor` to remain constant, for different VMI lens repeller
-        voltages. Defaults to `None`, in which case no extra scaling is
-        applied. e.g. `-98 volts`, for "examples/data/O-ANU1024.txt".
+        **energy_cal_factor** to remain constant, for different VMI lens
+        repeller voltages. Defaults to `None`, in which case no extra scaling
+        is applied. e.g. ``-98`` (volts), for "examples/data/O-ANU1024.txt".
 
     zoom : float
 
@@ -325,16 +321,16 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
 
     Returns
     -------
-    eKBE : numpy 1d-array of floats
+    eKBE : numpy 1D array of floats
 
         energy scale for the photoelectron spectrum in units of
-        `energy_cal_factor`.  Note that the data is no-longer on
+        **energy_cal_factor**.  Note that the data is no longer on
         a uniform grid.
 
-    PES : numpy 1d-array of floats
+    PES : numpy 1D array of floats
 
         the photoelectron spectrum, scaled according to the
-        `per_energy_scaling` input parameter.
+        **per_energy_scaling** input parameter.
 
     """
 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -196,8 +196,10 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
 
     where :math:`P_2(x)=\frac{3x^2-1}{2}` is a 2nd order Legendre polynomial.
 
-    `Cooper and Zare "Angular distribution of photoelectrons"
-    J Chem Phys 48, 942-943 (1968) <http://dx.doi.org/10.1063/1.1668742>`_
+    J. Cooper, R. N. Zare,
+    "Angular Distribution of Photoelectrons",
+    `J. Chem. Phys. 48, 942–943 (1968)
+    <https://dx.doi.org/10.1063/1.1668742>`_.
 
 
     Parameters

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -115,7 +115,7 @@ def radial_integration(IM, radial_ranges=None):
     Evaluates intensity vs angle for defined radial ranges.
     Determines the anisotropy parameter for each radial range.
 
-    See :doc:`examples/example_PAD.py <examples>`.
+    See :doc:`examples/example_O2_PES_PAD.py <example_O2_PES_PAD>`.
 
     Parameters
     ----------
@@ -272,7 +272,7 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
     photodetachment, the strongest fine-structure transition occurs at the
     electron affinity :math:`EA = 11\,784.676(7)` cm\ :math:`^{-1}`. Values for
     the ANU experiment are given below, see also
-    `examples/example_hansenlaw.py`.
+    :doc:`examples/example_hansenlaw.py <example_hansenlaw>`.
 
     Parameters
     ----------

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -19,17 +19,285 @@ from . import tools
 
 
 class Transform(object):
-    """Abel transform image class.
+    """
+    Abel transform image class.
 
     This class provides whole image forward and inverse Abel
-    transformations, together with preprocessing (centering, symmetrizing) 
-    and post processing (integration) functions. 
+    transformations, together with preprocessing (centering, symmetrizing)
+    and post processing (integration) functions.
+
+    Parameters
+    ----------
+
+    IM : a NxM numpy array
+        This is the image to be transformed
+
+    direction : str
+        The type of Abel transform to be performed.
+
+        ``forward``
+            A 'forward' Abel transform takes a (2D) slice of a 3D image and
+            returns the 2D projection.
+
+        ``inverse``
+            An 'inverse' Abel transform takes a 2D projection and reconstructs
+            a 2D slice of the 3D image.
+
+        The default is ``inverse``.
+
+    method : str
+        specifies which numerical approximation to the Abel transform should be
+        employed (see below). The options are
+
+        ``hansenlaw``
+            the recursive algorithm described by Hansen and Law.
+        ``basex``
+            the Gaussian "basis set expansion" method of Dribinski et al.
+        ``direct``
+            a naive implementation of the analytical formula by Roman Yurchuk.
+        ``two_point``
+            the two-point transform of Dasch (1992).
+        ``three_point``
+            the three-point transform of Dasch (1992).
+        ``onion_bordas``
+            the algorithm of Bordas and co-workers (1996),
+            re-implemented by Rallis, Wells and co-workers (2014).
+        ``onion_peeling``
+            the onion peeling deconvolution as described by Dasch (1992).
+        ``linbasex``
+            the 1d-projections of VM-images in terms of 1d spherical functions
+            by Gerber et al. (2013).
+
+    center : tuple or str
+        If a tuple (float, float) is provided, this specifies the image center
+        in (y,x) (row, column) format. A value `None` can be supplied if no
+        centering is desired in one dimension, for example 'center=(None,
+        250)'. If a string is provided, an automatic centering algorithm is
+        used
+
+        ``image_center``
+            center is assumed to be the center of the image.
+        ``convolution``
+            center the image by convolution of two projections along each axis.
+        ``slice``
+            the center is found my comparing slices in the horizontal and
+            vertical directions
+        ``com``
+            the center is calculated as the center of mass
+        ``gaussian``
+            the center is found using a fit to a Gaussian function. This only
+            makes sense if your data looks like a Gaussian.
+        ``none``
+            (default)
+            No centering is performed. An image with an odd number of columns
+            must be provided.
+
+    symmetry_axis : None, int or tuple
+        Symmetrize the image about the numpy axis
+        0 (vertical), 1 (horizontal), (0,1) (both axes)
+
+    use_quadrants : tuple of 4 booleans
+        select quadrants to be used in the analysis: (Q0,Q1,Q2,Q3).
+        Quadrants are numbered counter-clockwide from upper right.
+        See note below for description of quadrants.
+        Default is ``(True, True, True, True)``, which uses all quadrants.
+
+    symmetrize_method : str
+        Method used for symmetrizing the image.
+
+        ``average``
+            average the quadrants, in accordance with the `symmetry_axis`
+        ``fourier``
+            axial symmetry implies that the Fourier components of the 2-D
+            projection should be real. Removing the imaginary components in
+            reciprocal space leaves a symmetric projection.
+
+            K. R. Overstreet, P. Zabawa, J. Tallant, A. Schwettmann,
+            J. P. Shaffer,
+            "Multiple scattering and the density distribution of a Cs MOT",
+            `Optics Express 13, 9672–9682 (2005)
+            <https://dx.doi.org/10.1364/OPEX.13.009672>`_.
+
+    angular_integration : bool
+        integrate the image over angle to give the radial (speed) intensity
+        distribution
+
+    transform_options : tuple
+        Additional arguments passed to the individual transform functions.
+        See the documentation for the individual transform method for options.
+
+    center_options : tuple
+        Additional arguments to be passed to the centering function.
+
+    angular_integration_options : tuple (or dict)
+        Additional arguments passed to the angular_integration transform
+        functions.  See the documentation for angular_integration for options.
+
+    recast_as_float64 : bool
+        True/False that determines if the input image should be recast to
+        ``float64``. Many images are imported in other formats (such as
+        ``uint8`` or ``uint16``) and this does not always play well with the
+        transorm algorithms. This should probably always be set to True.
+        (Default is True.)
+
+    verbose : bool
+        True/False to determine if non-critical output should be printed.
+
+
+    .. note:: Quadrant combining
+        The quadrants can be combined (averaged) using the ``use_quadrants``
+        keyword in order to provide better data quality.
+
+        The quadrants are numbered starting from Q0 in the upper right and
+        proceeding counter-clockwise::
+
+            +--------+--------+
+            | Q1   * | *   Q0 |
+            |   *    |    *   |
+            |  *     |     *  |                               AQ1 | AQ0
+            +--------o--------+ --(inverse Abel transform)--> ----o----
+            |  *     |     *  |                               AQ2 | AQ3
+            |   *    |    *   |
+            | Q2  *  | *   Q3 |          AQi == inverse Abel transform
+            +--------+--------+                 of quadrant Qi
+
+        Three cases are possible:
+
+        1) symmetry_axis = 0 (vertical)::
+
+            Combine:  Q01 = Q0 + Q1, Q23 = Q2 + Q3
+            inverse image   AQ01 | AQ01
+                            -----o----- (left and right sides equivalent)
+                            AQ23 | AQ23
+
+
+        2) symmetry_axis = 1 (horizontal)::
+
+            Combine: Q12 = Q1 + Q2, Q03 = Q0 + Q3
+            inverse image   AQ12 | AQ03
+                            -----o----- (top and bottom equivalent)
+                            AQ12 | AQ03
+
+
+        3) symmetry_axis = (0, 1) (both)::
+
+            Combine: Q = Q0 + Q1 + Q2 + Q3
+            inverse image   AQ | AQ
+                            ---o---  (all quadrants equivalent)
+                            AQ | AQ
+
+    Notes
+    -----
+    As mentioned above, PyAbel offers several different approximations to the
+    the exact Abel transform. All the the methods should produce similar
+    results, but depending on the level and type of noise found in the image,
+    certain methods may perform better than others. Please see the
+    :ref:`TransformMethods` section of the documentation for complete
+    information.
+
+    The methods marked with a * indicate methods that generate basis sets. The
+    first time they are run for a new image size, it takes seconds to minutes
+    to generate the basis set. However, this basis set is saved to disk can can
+    be reloaded, meaning that future transforms are performed much more
+    quickly.
+
+    ``hansenlaw``
+        This "recursive algorithm" produces reliable results and is quite fast
+        (~0.1 s for a 1001×1001 image). It makes no assumptions about the data
+        (apart from cylindrical symmetry). It tends to require that the data is
+        finely sampled for good convergence.
+
+        E. W. Hansen, P.-L. Law,
+        "Recursive methods for computing the Abel transform and its inverse",
+        `J. Opt. Soc. Am. A 2, 510–520 (1985)
+        <https://dx.doi.org/10.1364/JOSAA.2.000510>`_.
+
+    ``basex`` *
+        The "basis set exapansion" algorithm describes the data in terms of
+        gaussian functions, which themselves can be abel transformed
+        analytically. Because the gaussian functions are approximately the size
+        of each pixel, this method also does not make any assumption about the
+        shape of the data. This method is one of the de-facto standards in
+        photoelectron/photoion imaging.
+
+        V. Dribinski, A. Ossadtchi, V. A. Mandelshtam, H. Reisler,
+        "Reconstruction of Abel-transformable images: The Gaussian basis-set
+        expansion Abel transform method",
+        `Rev. Sci. Instrum. 73, 2634–2642 (2002)
+        <https://dx.doi.org/10.1063/1.1482156>`_.
+
+    ``direct``
+        This method attempts a direct integration of the Abel transform
+        integral. It makes no assumptions about the data (apart from
+        cylindrical symmetry), but it typically requires fine sampling to
+        converge. Such methods are typically inefficient, but thanks to this
+        Cython implementation (by Roman Yurchuk), this 'direct' method is
+        competitive with the other methods.
+
+    ``linbasex`` *
+        VM-images are composed of projected Newton spheres with a common
+        centre. The 2D images are usually evaluated by a decomposition into
+        base vectors each representing the 2D projection of a set of particles
+        starting from a centre with a specific velocity distribution.
+        `linbasex` evaluate 1D projections of VM-images in terms of 1D
+        projections of spherical functions, instead.
+
+        Th. Gerber, Yu. Liu, G. Knopp, P. Hemberger, A. Bodi, P. Radi,
+        Ya. Sych,
+        "Charged particle velocity map image reconstruction with
+        one-dimensional projections of spherical functions",
+        `Rev. Sci. Instrum. 84, 033101 (2013)
+        <https://doi.org/10.1063/1.4793404>`_.
+
+    ``onion_bordas``
+        The onion peeling method, also known as "back projection", originates
+        from
+        C. Bordas, F. Paulig,
+        "Photoelectron imaging spectrometry: Principle and inversion method",
+        `Rev. Sci. Instrum. 67, 2257–2268 (1996)
+        <https://doi.org/10.1063/1.1147044>`_.
+
+        The algorithm was subsequently coded in MatLab by
+        C. E. Rallis, T. G. Burwitz, P. R. Andrews, M. Zohrabi, R. Averin,
+        S. De, B. Bergues, B. Jochim, A. V. Voznyuk, N. Gregerson, B. Gaire,
+        I. Znakovskaya, J. McKenna, K. D. Carnes, M. F. Kling, I. Ben-Itzhak,
+        E. Wells,
+        "Incorporating real time velocity map image reconstruction into
+        closed-loop coherent control",
+        `Rev. Sci. Instrum. 85, 113105 (2014)
+        <https://doi.org/10.1063/1.4899267>`_,
+        which was used as the basis of this Python port. See `issue #56
+        <https://github.com/PyAbel/PyAbel/issues/56>`_.
+
+    ``onion_peeling`` *
+        This is one of the most compact and fast algorithms, with the inverse
+        Abel transform achieved in one Python code-line, `PR #155
+        <https://github.com/PyAbel/PyAbel/pull/155>`_. See also ``three_point``
+        is the onion peeling algorithm as described by Dasch (1992), reference
+        below.
+
+    ``two_point`` *
+        Another Dasch method. Simple, and fast, but not as accurate as the
+        other methods.
+
+    ``three_point`` *
+        The "Three Point" Abel transform method exploits the observation that
+        the value of the Abel inverted data at any radial position r is
+        primarily determined from changes in the projection data in the
+        neighborhood of r. This method is also very efficient once it has
+        generated the basis sets.
+
+        C. J. Dasch,
+        "One-dimensional tomography: a comparison of Abel, onion-peeling, and
+        filtered backprojection methods",
+        `Appl. Opt. 31, 1146–1152 (1992)
+        <https://doi.org/10.1364/AO.31.001146>`_.
 
     The following class attributes are available, depending on the calculation.
-  
+
     Returns
     -------
-    transform : numpy 2D array 
+    transform : numpy 2D array
         the 2D forward/reverse Abel transform.
 
     angular_integration : tuple
@@ -40,7 +308,7 @@ class Transform(object):
     residual : numpy 2D array
         residual image (not currently implemented).
 
-    IM: numpy 2D array
+    IM : numpy 2D array
         the input image, re-centered (optional) with an odd-size width.
 
     method : str
@@ -52,18 +320,18 @@ class Transform(object):
     Beta : numpy 2D array
         with ``linbasex`` :func:`transform_options=dict(return_Beta=True)`
         Beta array coefficients of Newton sphere spherical harmonics
-        
+
             Beta[0] - the radial intensity variation
 
             Beta[1] - the anisotropy parameter variation
 
             ...Beta[n] - higher order terms up to `legedre_orders = [0, ..., n]`
-        
-    radial : numpy 1d array
+
+    radial : numpy 1D array
         with ``linbasex`` :func:`transform_options=dict(return_Beta=True)`
         radial-grid for Beta array
 
-    projection : 
+    projection : numpy 2D array
         with ``linbasex`` :func:`transform_options=dict(return_Beta=True)`
         radial projection profiles at angles `proj_angles`
 
@@ -78,267 +346,8 @@ class Transform(object):
               transform_options=dict(), center_options=dict(),
               angular_integration_options=dict(),
               recast_as_float64=True, verbose=False):
-        """The one stop transform function.
-
-        Parameters
-        ----------
-
-        IM : a NxM numpy array
-            This is the image to be transformed
-
-        direction : str
-            The type of Abel transform to be performed.
-
-            ``forward``
-                A 'forward' Abel transform takes a (2D) slice of a 3D image
-                and returns the 2D projection.
-
-            ``inverse``
-                An 'inverse' Abel transform takes a 2D projection
-                and reconstructs a 2D slice of the 3D image.
-
-            The default is ``inverse``.
-
-        method : str
-            specifies which numerical approximation to the Abel transform
-            should be employed (see below). The options are
-
-            ``hansenlaw``
-                        the recursive algorithm described by Hansen and Law.
-            ``basex``
-                        the Gaussian "basis set expansion" method
-                        of Dribinski et al.
-            ``direct``
-                        a naive implementation of the analytical
-                        formula by Roman Yurchuk.
-            ``two_point``
-                        the two-point transform of Dasch (1992).
-            ``three_point``
-                        the three-point transform of Dasch (1992).
-            ``onion_bordas``
-                        the algorithm of Bordas and co-workers (1996), 
-                        re-implemented by Rallis, Wells and co-workers (2014).
-
-            ``onion_peeling``
-                        the onion peeling deconvolution as described by 
-                        Dasch (1992).
-
-            ``linbasex``
-                        the 1d-projections of VM-images in terms of 1d
-                        spherical functions by Gerber et al. (2013).
-
-        center : tuple or str
-            If a tuple (float, float) is provided, this specifies
-            the image center in (y,x) (row, column) format.
-            A value `None` can be supplied
-            if no centering is desired in one dimension,
-            for example 'center=(None, 250)'.
-            If a string is provided, an automatic centering algorithm is used
-
-            ``image_center``
-                center is assumed to be the center of the image.
-            ``convolution``
-                center the image by convolution of two projections along each axis.
-            ``slice``
-                the center is found my comparing slices in the horizontal and
-                vertical directions
-            ``com``
-                the center is calculated as the center of mass
-            ``gaussian``
-                the center is found using a fit to a Gaussian function. This
-                only makes sense if your data looks like a Gaussian.
-            ``none``
-                (Default)
-                No centering is performed. An image with an odd
-                number of columns must be provided.
-
-        symmetry_axis : None, int or tuple
-            Symmetrize the image about the numpy axis 
-            0 (vertical), 1 (horizontal), (0,1) (both axes)
-            
-        use_quadrants : tuple of 4 booleans
-            select quadrants to be used in the analysis: (Q0,Q1,Q2,Q3).
-            Quadrants are numbered counter-clockwide from upper right.
-            See note below for description of quadrants. 
-            Default is ``(True, True, True, True)``, which uses all quadrants.
-
-        symmetrize_method: str
-           Method used for symmetrizing the image.
-
-           ``average`` 
-                 average the quadrants, in accordance with the `symmetry_axis`
-           ``fourier``
-                axial symmetry implies that the Fourier components of the 2-D
-                projection should be real. Removing the imaginary components
-                in reciprocal space leaves a symmetric projection.
-                ref: Overstreet, K., et al. 
-                "Multiple scattering and the density distribution of a Cs MOT." 
-                Optics express 13.24 (2005): 9672-9682.
-                http://dx.doi.org/10.1364/OPEX.13.009672
-
-        angular_integration: boolean
-            integrate the image over angle to give the radial (speed) intensity
-            distribution
-
-        transform_options : tuple
-            Additional arguments passed to the individual transform functions.
-            See the documentation for the individual transform method for options.
-
-        center_options : tuple
-            Additional arguments to be passed to the centering function.
-            
-        angular_integration_options : tuple (or dict)
-            Additional arguments passed to the angular_integration transform 
-            functions.  See the documentation for angular_integration for options.
-
-        recast_as_float64 : boolean
-            True/False that determines if the input image should be recast to 
-            ``float64``. Many images are imported in other formats (such as 
-            ``uint8`` or ``uint16``) and this does not always play well with the 
-            transorm algorithms. This should probably always be set to True. 
-            (Default is True.)
-
-        verbose : boolean
-            True/False to determine if non-critical output should be printed.
-
-            
-        .. note:: Quadrant combining 
-             The quadrants can be combined (averaged) using the 
-             ``use_quadrants`` keyword in order to provide better data quality.
-             
-             The quadrants are numbered starting from
-             Q0 in the upper right and proceeding counter-clockwise: ::
-
-                  +--------+--------+
-                  | Q1   * | *   Q0 |
-                  |   *    |    *   |
-                  |  *     |     *  |                               AQ1 | AQ0
-                  +--------o--------+ --(inverse Abel transform)--> ----o----
-                  |  *     |     *  |                               AQ2 | AQ3
-                  |   *    |    *   |
-                  | Q2  *  | *   Q3 |          AQi == inverse Abel transform
-                  +--------+--------+                 of quadrant Qi
-                  
-        
-            Three cases are possible: 
-            
-            1) symmetry_axis = 0 (vertical): ::
-
-                    Combine:  Q01 = Q0 + Q1, Q23 = Q2 + Q3
-                    inverse image   AQ01 | AQ01
-                                    -----o----- (left and right sides equivalent)
-                                    AQ23 | AQ23
-
-
-            2) symmetry_axis = 1 (horizontal): ::
-
-                    Combine: Q12 = Q1 + Q2, Q03 = Q0 + Q3
-                    inverse image   AQ12 | AQ03
-                                    -----o----- (top and bottom equivalent)
-                                    AQ12 | AQ03
-                            
-
-            3) symmetry_axis = (0, 1) (both): ::
-
-                    Combine: Q = Q0 + Q1 + Q2 + Q3
-                    inverse image   AQ | AQ
-                                    ---o---  (all quadrants equivalent)
-                                    AQ | AQ
-
-        Notes
-        -----
-        As mentioned above, PyAbel offers several different approximations
-        to the the exact abel transform.
-        All the the methods should produce similar results, but
-        depending on the level and type of noise found in the image,
-        certain methods may perform better than others. Please see the 
-        "Transform Methods" section of the documentation for complete information.
-
-        ``hansenlaw`` 
-            This "recursive algorithm" produces reliable results
-            and is quite fast (~0.1 sec for a 1001x1001 image).
-            It makes no assumptions about the data
-            (apart from cylindrical symmetry). It tends to require that the data
-            is finely sampled for good convergence.
-
-            E. W. Hansen and P.-L. Law "Recursive methods for computing
-            the Abel transform and its inverse"
-            J. Opt. Soc. A*2, 510-520 (1985)
-            http://dx.doi.org/10.1364/JOSAA.2.000510
-
-        ``basex`` * 
-            The "basis set exapansion" algorithm describes the data in terms
-            of gaussian functions, which themselves can be abel transformed
-            analytically. Because the gaussian functions are approximately the 
-            size of each pixel, this method also does not make any assumption 
-            about the shape of the data. This method is one of the de-facto 
-            standards in photoelectron/photoion imaging.
-
-             Dribinski et al, 2002 (Rev. Sci. Instrum. 73, 2634)
-             http://dx.doi.org/10.1063/1.1482156
-
-        ``direct``
-            This method attempts a direct integration of the Abel
-            transform integral. It makes no assumptions about the data
-            (apart from cylindrical symmetry),
-            but it typically requires fine sampling to converge.
-            Such methods are typically inefficient,
-            but thanks to this Cython implementation (by Roman Yurchuk),
-            this 'direct' method is competitive with the other methods.
-
-        ``linbasex`` *
-            VM-images are composed of projected Newton spheres with a common 
-            centre. The 2D images are usually evaluated by a decomposition into
-            base vectors each representing the 2D projection of a set of 
-            particles starting from a centre with a specific velocity 
-            distribution. `linbasex` evaluate 1D projections of VM-images in 
-            terms of 1D projections of spherical functions, instead.
-            
-            ..Rev. Sci. Instrum. 84, 033101 (2013): <http://scitation.aip.org/content/aip/journal/rsi/84/3/10.1063/1.4793404>
-
-        ``onion_bordas``
-            The onion peeling method, also known as "back projection",
-            originates from Bordas *et al.*  `Rev. Sci. Instrum. 67, 2257 (1996)`_.
-
-          .. _Rev. Sci. Instrum. 67, 2257 (1996):  <http://scitation.aip.org/content/aip/journal/rsi/67/6/10.1063/1.1147044> 
-
-            The algorithm was subsequently coded in MatLab by Rallis, Wells and co-workers, `Rev. Sci. Instrum. 85, 113105 (2014)`_.
-
-          .. _Rev. Sci. Instrum. 85, 113105 (2014): <http://scitation.aip.org/content/aip/journal/rsi/85/11/10.1063/1.4899267>
-
-           which was used as the basis of this Python port. See issue `#56`_.
-
-        .. _#56: <https://github.com/PyAbel/PyAbel/issues/56>
-
-
-        ``onion_peeling`` *
-            This is one of the most compact and fast algorithms, with the
-            inverse Abel transfrom achieved in one Python code-line, PR #155.
-            See also ``three_point`` is the onion peeling algorithm as
-            described by Dasch (1992), reference below.
-
-         ``two_point`` *
-            Another Dasch method. Simple, and fast, but not as accurate as the
-            other methods.
-
-        ``three_point`` *
-            The "Three Point" Abel transform method
-            exploits the observation that the value of the Abel inverted data
-            at any radial position r is primarily determined from changes
-            in the projection data in the neighborhood of r.
-            This method is also very efficient
-            once it has generated the basis sets.
-
-            Dasch, 1992 (Applied Optics, Vol 31, No 8, March 1992, Pg 1146-1152).
-
-        ``*``
-            The methods marked with a * indicate methods that generate basis sets.
-            The first time they are run for a new image size,
-            it takes seconds to minutes to generate the basis set.
-            However, this basis set is saved to disk can can be reloaded,
-            meaning that future transforms are performed
-            much more quickly.
-
+        """
+        The one stop transform function.
         """
 
         # public class variables
@@ -360,10 +369,10 @@ class Transform(object):
 
         self._abel_transform_image(**transform_options)
 
-        self._integration(angular_integration, transform_options, 
+        self._integration(angular_integration, transform_options,
                           **angular_integration_options)
 
-    # end of class instance 
+    # end of class instance
 
     _verboseprint = print if _verbose else lambda *a, **k: None
 
@@ -385,11 +394,11 @@ class Transform(object):
 
     def _center_image(self, center, **center_options):
         if center != "none":
-            self.IM = tools.center.center_image(self.IM, center, 
+            self.IM = tools.center.center_image(self.IM, center,
                                                  **center_options)
 
     def _abel_transform_image(self, **transform_options):
-        if self.method == "linbasex" and self._symmetry_axis is not None: 
+        if self.method == "linbasex" and self._symmetry_axis is not None:
             self._abel_transform_image_full(**transform_options)
         else:
             self._abel_transform_image_by_quadrant(**transform_options)
@@ -404,7 +413,7 @@ class Transform(object):
         t0 = time.time()
 
         self._verboseprint('Calculating {0} Abel transform using {1} method -'
-                          .format(self.direction, self.method), 
+                          .format(self.direction, self.method),
                           '\n    image size: {:d}x{:d}'.format(*self.IM.shape))
 
         self.transform, radial, Beta, QLz = abel_transform[self.method](self.IM,
@@ -415,7 +424,7 @@ class Transform(object):
         self.Beta = Beta
         self.projection = QLz
         self.radial = radial
-            
+
 
     def _abel_transform_image_by_quadrant(self, **transform_options):
 
@@ -431,7 +440,7 @@ class Transform(object):
         }
 
         self._verboseprint('Calculating {0} Abel transform using {1} method -'
-                          .format(self.direction, self.method), 
+                          .format(self.direction, self.method),
                           '\n    image size: {:d}x{:d}'.format(*self.IM.shape))
 
         t0 = time.time()
@@ -439,11 +448,11 @@ class Transform(object):
         # split image into quadrants
         Q0, Q1, Q2, Q3 = tools.symmetry.get_image_quadrants(
                          self.IM, reorient=True,
-                         symmetry_axis=self._symmetry_axis, 
+                         symmetry_axis=self._symmetry_axis,
                          symmetrize_method=self._symmetrize_method)
 
         def selected_transform(Z):
-            return abel_transform[self.method](Z, direction=self.direction, 
+            return abel_transform[self.method](Z, direction=self.direction,
                                                **transform_options)
 
         AQ0 = AQ1 = AQ2 = AQ3 = None
@@ -484,7 +493,7 @@ class Transform(object):
 
         # reassemble image
         self.transform = tools.symmetry.put_image_quadrants(
-                                (AQ0, AQ1, AQ2, AQ3), 
+                                (AQ0, AQ1, AQ2, AQ3),
                                 original_image_shape=self.IM.shape,
                                 symmetry_axis=self._symmetry_axis)
 

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -73,10 +73,8 @@ class Transform(object):
         point.
 
         If a tuple (float, float) is provided, this specifies the image origin
-        in the (row, column) format. A value ``None`` can be supplied if no
-        centering is desired in one dimension, for example, ``origin=(None,
-        250)``. If a string is provided, an automatic centering algorithm is
-        used:
+        in the (row, column) format. If a string is provided, an automatic
+        centering algorithm is used:
 
         ``image_center``
             The origin is assumed to be the center of the image.

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -17,6 +17,8 @@ from . import linbasex
 from . import onion_bordas
 from . import tools
 
+from abel import _deprecated, _deprecate
+
 
 class Transform(object):
     """
@@ -343,15 +345,19 @@ class Transform(object):
     _verbose = False
 
     def __init__(self, IM,
-              direction='inverse', method='three_point', origin='none',
-              symmetry_axis=None, use_quadrants=(True, True, True, True),
-              symmetrize_method='average', angular_integration=False,
-              transform_options=dict(), center_options=dict(),
-              angular_integration_options=dict(),
-              recast_as_float64=True, verbose=False):
+                 direction='inverse', method='three_point', origin='none',
+                 symmetry_axis=None, use_quadrants=(True, True, True, True),
+                 symmetrize_method='average', angular_integration=False,
+                 transform_options=dict(), center_options=dict(),
+                 angular_integration_options=dict(),
+                 recast_as_float64=True, verbose=False, center=_deprecated):
         """
         The one-stop transform function.
         """
+        if center is not _deprecated:
+            _deprecate('abel.transform.Transform() '
+                       'argument "center" is deprecated, use "origin" instead.')
+            origin = center
 
         # public class variables
         self.IM = IM  # (optionally) centered, odd-width image
@@ -406,7 +412,6 @@ class Transform(object):
         else:
             self._abel_transform_image_by_quadrant(**transform_options)
 
-
     def _abel_transform_image_full(self, **transform_options):
 
         abel_transform = {
@@ -427,7 +432,6 @@ class Transform(object):
         self.Beta = Beta
         self.projection = QLz
         self.radial = radial
-
 
     def _abel_transform_image_by_quadrant(self, **transform_options):
 

--- a/doc/abel.rst
+++ b/doc/abel.rst
@@ -7,7 +7,7 @@ abel.transform module
 
 .. automodule:: abel.transform
     :members:
-    :special-members:
+    :undoc-members:
     :show-inheritance:
 
 abel.basex module

--- a/doc/anisotropy_parameter.rst
+++ b/doc/anisotropy_parameter.rst
@@ -7,7 +7,7 @@ For linearly polarized light the angular distribution of photodetached electrons
 
   I(\epsilon, \theta) = \frac{\sigma_\text{total}(\epsilon)}{4\pi} [ 1 + \beta(\epsilon) P_2(\cos\theta)],
 
-where :math:`\beta(\epsilon)` is the electron kinetic energy (:math:`\epsilon`) dependent anisotropy parameter, which varies between −1 and +2, and :math:`P_2(\cos\theta)` is the 2nd-order Legendre polynomial in :math:`\cos\theta`. :math:`\sigma_\text{total}` is the total photodetachment cross section. The anisotropy parameter provides phase information about the dynamics of the photon process [1].
+where :math:`\beta(\epsilon)` is the electron kinetic energy (:math:`\epsilon`) dependent anisotropy parameter, which varies between −1 and +2, and :math:`P_2(\cos\theta)` is the 2nd-order Legendre polynomial in :math:`\cos\theta`. :math:`\sigma_\text{total}` is the total photodetachment cross section. The anisotropy parameter provides phase information about the dynamics of the photon process [1]_.
 
 
 Methods
@@ -51,4 +51,4 @@ See :doc:`example_anisotropy_parameter`. In this case the anisotropy parameter i
 Reference
 ---------
 
-[1] `J. Cooper and R. N. Zare, "Angular distribution of photoelectrons", J. Chem. Phys. 48, 942 (1968) <http://scitation.aip.org/content/aip/journal/jcp/48/2/10.1063/1.1668742>`_
+.. [1] \ J. Cooper, R. N. Zare, "Angular Distribution of Photoelectrons", `J. Chem. Phys. 48, 942–943 (1968) <https://dx.doi.org/10.1063/1.1668742>`_.

--- a/doc/circularize_image.rst
+++ b/doc/circularize_image.rst
@@ -22,13 +22,14 @@ compares the radial positions of strong features in angular slice intensity prof
         ^        ^    slice#
     radial peak position
 
-Peak alignment is achieved through a radial scaling factor :math:`R_i(actual) = R_i \times scalefactor_i`. The scalefactor is determined by a choice of methods, ``argmax``, where :math:`scalefactor_i = R_0/R_i`, with :math:`R_0` a reference peak. Or ``lsq``, which directly determines the radial scaling factor that best aligns adjacent slice intensity profiles.
+Peak alignment is achieved through a radial scaling factor :math:`R_i(\text{actual}) = R_i \times \text{scalefactor}_i`. The scalefactor is determined by a choice of methods, ``argmax``, where :math:`scalefactor_i = R_0/R_i`, with :math:`R_0` a reference peak. Or ``lsq``, which directly determines the radial scaling factor that best aligns adjacent slice intensity profiles.
 
 This is a simplified radial scaling version of the algorithm described in 
-`J. R. Gascooke and S. T. Gibson and W. D. Lawrance: 'A "circularisation"
-method to repair deformations and determine the centre of velocity map 
-images' J. Chem. Phys. 147, 013924 (2017).
-<https://dx.doi.org/10.1063/1.4981024>`_
+J. R. Gascooke, S. T. Gibson, W. D. Lawrance,
+"A 'circularisation' method to repair deformations and determine the centre of
+velocity map images",
+`J. Chem. Phys. 147, 013924 (2017)
+<https://dx.doi.org/10.1063/1.4981024>`_.
 
 
 Implementation

--- a/doc/docutils.conf
+++ b/doc/docutils.conf
@@ -1,0 +1,2 @@
+[general]
+footnote_backlinks: off

--- a/doc/example_basex_step.rst
+++ b/doc/example_basex_step.rst
@@ -1,0 +1,8 @@
+Example: Basex step function
+============================
+
+
+.. plot:: ../examples/example_basex_step.py
+   :include-source:
+
+

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -8,9 +8,11 @@ Contents:
    example_direct_gaussian
    example_hansenlaw
    example_O2_PES_PAD
+   example_hansenlaw
    example_hansenlaw_Xe
    example_basex_gaussian
    example_basex_photoelectron
+   example_basex_step
    example_all_dribinski
    example_dasch_methods
    example_onion_bordas

--- a/doc/transform_methods.rst
+++ b/doc/transform_methods.rst
@@ -1,3 +1,5 @@
+.. _TransformMethods:
+
 Transform Methods
 =================
 

--- a/doc/transform_methods/basex.rst
+++ b/doc/transform_methods/basex.rst
@@ -8,7 +8,7 @@ Introduction
 ------------
 
 The BASEX (“basis set expansion”) Abel-transform method utilizes well-behaved functions (i.e., functions that have a known analytic Abel transform) to transform images.
-In the current iteration of PyAbel, these functions (called basis functions) are Gaussian-like functions, following the original description of the method, developed in 2002 at USC and UC Irvine by Dribinski, Ossadtchi, Mandelshtam, and Reisler [Dribinski2002]_.
+In the current iteration of PyAbel, these functions (called basis functions) are Gaussian-like functions, following the original description of the method, developed in 2002 at USC and UC Irvine by Dribinski, Ossadtchi, Mandelshtam, and Reisler [1]_.
 
 
 How it works
@@ -17,7 +17,7 @@ How it works
 This method is based on expressing line-of-sight projection images (``raw_data``) as sums of functions that have known analytic Abel inverses. The provided raw images are expanded in a basis set composed of these basis functions, with the expansion coefficients determined through a least-squares fitting process.
 These coefficients are then applied to the (known) analytic inverse of these basis functions, which directly provides the Abel inverse of the raw images. Thus, the transform can be completed using simple linear algebra.
 
-In the current iteration of PyAbel, these basis functions are Gaussian-like (see equations (14) and (15) in [Dribinski2002]_). The process of evaluating these functions is computationally intensive, and the basis-set generation process can take several seconds to minutes for larger images (larger than ~1000×1000 pixels). However, once calculated, these basis sets can be reused, and are therefore stored on disk and loaded quickly for future use.
+In the current iteration of PyAbel, these basis functions are Gaussian-like (see equations (14) and (15) in [1]_). The process of evaluating these functions is computationally intensive, and the basis-set generation process can take several seconds to minutes for larger images (larger than ~1000×1000 pixels). However, once calculated, these basis sets can be reused, and are therefore stored on disk and loaded quickly for future use.
 The transform then proceeds very quickly, since each raw-image Abel inversion is a simple matrix multiplication.
 
 
@@ -67,7 +67,7 @@ The behavior of the original `BASEX.exe` program by Karpichev with top–bottom 
 PyAbel improvements
 -------------------
 
-* As noted above, the BASEX method implementation in PyAbel uses correct expressions for the basis projections, so unlike `BASEX.exe`, it is consistent with the original method description in [Dribinski2002]_ and with other methods implemented in PyAbel.
+* As noted above, the BASEX method implementation in PyAbel uses correct expressions for the basis projections, so unlike `BASEX.exe`, it is consistent with the original method description in [1]_ and with other methods implemented in PyAbel.
 
 * Basis sets for any image size are generated automatically.
 
@@ -87,4 +87,6 @@ Some additional information on the implementation is given in :ref:`BASEXcomp`.
 
 Citation
 --------
-.. [Dribinski2002] `Dribinski et al, 2002 (Rev. Sci. Instrum. 73, 2634) <http://dx.doi.org/10.1063/1.1482156>`_, (`pdf <http://www-bcf.usc.edu/~reisler/assets/pdf/67.pdf>`_)
+
+.. [1] \ V. Dribinski, A. Ossadtchi, V. A. Mandelshtam, H. Reisler, "Reconstruction of Abel-transformable images: The Gaussian basis-set expansion Abel transform method", `Rev. Sci. Instrum. 73, 2634–2642 (2002)
+ <https://dx.doi.org/10.1063/1.1482156>`_, (`PDF <http://www-bcf.usc.edu/~reisler/assets/pdf/67.pdf>`_).

--- a/doc/transform_methods/fh.rst
+++ b/doc/transform_methods/fh.rst
@@ -5,9 +5,9 @@ Fourier–Hankel
 Introduction
 ------------
 
-The Fourier–Hankel method breaks the Abel transform in to a Fourier transform and a Hankel transform. It takes advantage of the fact that there are fast numerical implementations of the Fourier and Hankel transforms to provide a quick alorithm. It is known to produce artifacts in the transform [Dribinski2002]_
+The Fourier–Hankel method breaks the Abel transform in to a Fourier transform and a Hankel transform. It takes advantage of the fact that there are fast numerical implementations of the Fourier and Hankel transforms to provide a quick alorithm. It is known to produce artifacts in the transform [1]_
 
-This method is not yet implemented in PyAbel. See the discussion in Issue `#26 <https://github.com/PyAbel/PyAbel/issues/24>`_ for more information.
+This method is not yet implemented in PyAbel. See the discussion in `issue #26 <https://github.com/PyAbel/PyAbel/issues/24>`_ for more information.
 
 
 How it works
@@ -38,7 +38,8 @@ Notes
 
 
 
-
 Citation
 --------
 
+.. [1] \ V. Dribinski, A. Ossadtchi, V. A. Mandelshtam, H. Reisler, "Reconstruction of Abel-transformable images: The Gaussian basis-set expansion Abel transform method", `Rev. Sci. Instrum. 73, 2634–2642 (2002)
+ <https://dx.doi.org/10.1063/1.1482156>`_, (`PDF <http://www-bcf.usc.edu/~reisler/assets/pdf/67.pdf>`_).

--- a/doc/transform_methods/hansenlaw.rst
+++ b/doc/transform_methods/hansenlaw.rst
@@ -1,4 +1,4 @@
-.. |nbsp| unicode:: 0xA0 
+.. |nbsp| unicode:: 0xA0
    :trim:
 
 Hansen–Law
@@ -8,16 +8,16 @@ Hansen–Law
 Introduction
 ------------
 
-The Hansen and Law transform [1, 2] is a fast (linear time) Abel transform.
- 
-In their words, Hansen and Law [1] present:
+The Hansen and Law transform [1]_ [2]_ is a fast (linear time) Abel transform.
 
-*"... new family of algorithms, principally for Abel inversion, that are 
-recursive and hence computationally efficient. The methods are based on a 
-linear, space-variant, state-variable model of the Abel transform. The model 
+In their words, Hansen and Law [1]_ present:
+
+*"... new family of algorithms, principally for Abel inversion, that are
+recursive and hence computationally efficient. The methods are based on a
+linear, space-variant, state-variable model of the Abel transform. The model
 is the basis for deterministic algorithms."*
 
-and [2]:
+and [2]_:
 
 *"... Abel transform, which maps an axisymmetric two-dimensional function into a line integral projection."*
 
@@ -34,24 +34,24 @@ How it works
    :align: right
    :figclass: align-center
 
-   Projection geometry (Fig. 1 [1])
+   Projection geometry (Fig. 1 [1]_)
 
-For an axis-symmetric source image the projection of a source image, 
+For an axis-symmetric source image the projection of a source image,
 :math:`g(R)`, is given by the forward Abel transform:
 
-.. math:: g(R) = 2 \int_R^\infty \frac{f(r) r}{\sqrt{r^2 - R^2}} dr 
+.. math:: g(R) = 2 \int_R^\infty \frac{f(r) r}{\sqrt{r^2 - R^2}} dr
 
-The corresponding inverse Abel transform is: 
+The corresponding inverse Abel transform is
 
 .. math:: f(r) = -\frac{1}{\pi}  \int_r^\infty \frac{g^\prime(R)}{\sqrt{R^2 - r^2}} dR
 
 The Hansen and Law method makes a coordinate transformation to model the Abel transform as a set of linear differential equation, with the driving function
-either the source image :math:`f(r)`,  for the forward transform, or the 
-projection image gradient :math:`g^\prime(R)`, for the inverse transform. 
+either the source image :math:`f(r)`,  for the forward transform, or the
+projection image gradient :math:`g^\prime(R)`, for the inverse transform.
 More detail is given in themath_ below.
 
 
-.. figure:: https://cloud.githubusercontent.com/assets/10932229/13544803/13bf0d0e-e2cf-11e5-97d5-bece1e61d904.png 
+.. figure:: https://cloud.githubusercontent.com/assets/10932229/13544803/13bf0d0e-e2cf-11e5-97d5-bece1e61d904.png
    :width: 350px
    :alt: recursion
    :align: right
@@ -60,11 +60,11 @@ More detail is given in themath_ below.
    Recursion: pixel value from adjacent outer-pixel
 
 
-Forward transform is:
+Forward transform is
 
-.. math:: 
+.. math::
 
-  x_{n-1} &= \Phi_n x_n + B_{0n} f_n + B_{1n} f_{n-1}  
+  x_{n-1} &= \Phi_n x_n + B_{0n} f_n + B_{1n} f_{n-1}
 
   g_n &= \tilde{C} x_n,
 
@@ -72,29 +72,29 @@ where :math:`B_{1n}=0` for the zero-order hold approximation.
 
 Inverse transform:
 
-.. math:: 
+.. math::
 
-  x_{n-1} &= \Phi_n x_n + B_{0n} g^\prime_n + B_{1n} g^\prime_{n-1} 
+  x_{n-1} &= \Phi_n x_n + B_{0n} g^\prime_n + B_{1n} g^\prime_{n-1}
 
   f_n &= \tilde{C} x_n
 
 
-Note the only difference between the *forward* and *inverse* algorithms is 
+Note the only difference between the *forward* and *inverse* algorithms is
 the exchange of :math:`f_n` with :math:`g^\prime_n` (or :math:`g_n`).
 
 Details on the evaluation of :math:`\Phi, B_{0n},` and :math:`B_{1n}` are given below, themath_.
 
-The algorithm iterates along each individual row of the image, starting at 
-the out edge, ending at the center-line. Since all rows in an image can be 
-processed simultaneously, the operation can be easily vectorized and is 
+The algorithm iterates along each individual row of the image, starting at
+the out edge, ending at the center-line. Since all rows in an image can be
+processed simultaneously, the operation can be easily vectorized and is
 therefore numerically efficient.
 
 
 When to use it
 --------------
 
-The Hansen-Law algorithm offers one of the fastest, most robust methods for 
-both the forward and inverse transforms. It requires reasonably fine sampling 
+The Hansen-Law algorithm offers one of the fastest, most robust methods for
+both the forward and inverse transforms. It requires reasonably fine sampling
 of the data to provide exact agreement with the analytical result, but otherwise
 this method is a hidden gem of the field.
 
@@ -102,21 +102,21 @@ this method is a hidden gem of the field.
 How to use it
 -------------
 
-To complete the forward or inverse transform of a full image with the 
-``hansenlaw method``, simply use the :class:`abel.Transform`: class ::
+To complete the forward or inverse transform of a full image with the
+``hansenlaw method``, simply use the :class:`abel.Transform`: class::
 
     abel.Transform(myImage, method='hansenlaw', direction='forward').transform
     abel.Transform(myImage, method='hansenlaw', direction='inverse').transform
 
 
-If you would like to access the Hansen-Law algorithm directly (to transform a 
+If you would like to access the Hansen-Law algorithm directly (to transform a
 right-side half-image), you can use :func:`abel.hansenlaw.hansenlaw_transform`.
 
 
 Tips
 ----
 
-`hansenlaw` tends to perform better with images of large size :math:`n \gt 1001` pixel width. For smaller images the angular_integration (speed) profile may look better if sub-pixel sampling is used via: ::
+`hansenlaw` tends to perform better with images of large size :math:`n \gt 1001` pixel width. For smaller images the angular_integration (speed) profile may look better if sub-pixel sampling is used::
 
     angular_integration_options=dict(dr=0.5)
 
@@ -132,11 +132,11 @@ Example
 Historical Note
 ---------------
 
-The Hansen and Law algorithm was almost lost to the scientific community. It was 
-rediscovered by Jason Gascooke (Flinders University, South Australia) for use in 
-his velocity-map image analysis, and written up in his PhD thesis [3]. 
+The Hansen and Law algorithm was almost lost to the scientific community. It was
+rediscovered by Jason Gascooke (Flinders University, South Australia) for use in
+his velocity-map image analysis, and written up in his PhD thesis [3]_.
 
-Eric Hansen provided guidence, algebra, and explanations, to aid the implementation of his first-order hold algorithm, described in Ref. [2] (April 2018).
+Eric Hansen provided guidance, algebra, and explanations, to aid the implementation of his first-order hold algorithm, described in Ref. [2]_ (April 2018).
 
 .. _themath:
 
@@ -153,11 +153,11 @@ with inverse:
 
  .. math::
 
-   x^\prime(R) = -\frac{1}{R} \tilde{A} x(R) - 2\tilde{B} f(R),      
+   x^\prime(R) = -\frac{1}{R} \tilde{A} x(R) - 2\tilde{B} f(R),
 
-where :math:`[\tilde{A}, \tilde{B}, \tilde{C}]` realize the impulse response: :math:`\tilde{h}(t) = \tilde{C} \exp{(\tilde{A} t)}\tilde{B} = \left[1-e^{-2t}\right]^{-\frac{1}{2}}`, with:
+where :math:`[\tilde{A}, \tilde{B}, \tilde{C}]` realize the impulse response: :math:`\tilde{h}(t) = \tilde{C} \exp{(\tilde{A} t)}\tilde{B} = \left[1-e^{-2t}\right]^{-\frac{1}{2}}`, with
 
-  .. math:: 
+  .. math::
 
     \tilde{A} = \rm{diag}[\lambda_1, \lambda_2, ..., \lambda_K]
 
@@ -169,7 +169,7 @@ The differential equations have the transform solutions, forward:
 
  .. math:: x(r) = \Phi(r, r_0) x(r_0) + 2 \int_{r_0}^{r} \Phi(r, \epsilon) \tilde{B} f(\epsilon) d\epsilon.
 
-and, inverse:
+and inverse:
 
  .. math:: x(r) = \Phi(r, r_0) x(r_0) - \frac{1}{\pi} \int_{r_0}^{r} \frac{\Phi(r, \epsilon)}{r} \tilde{B} g^\prime(\epsilon) d\epsilon,
 
@@ -178,26 +178,27 @@ with :math:`\Phi(r, r_0) = \rm{diag}[(\frac{r_0}{r})^{\lambda_1}, ..., (\frac{r_
 
 To evaluate the (superposition) integral, the driven part of the solution, the
 driving function :math:`f(\epsilon)` or :math:`g^\prime(\epsilon)` is assumed to
-either be constant across each grid interval, the **zero-order hold** approximation, :math:`f(\epsilon) \sim f(r_0)`, or linear, a **first-order hold** approximation, :math:`f(\epsilon) \sim p + q\epsilon = (r_0f(r) - rf(r_0))/\Delta + (f(r_0) - f(r))\epsilon/\Delta`. The integrand then separates into a sum over terms multiplied by :math:`h_k`, 
+either be constant across each grid interval, the **zero-order hold** approximation, :math:`f(\epsilon) \sim f(r_0)`, or linear, a **first-order hold** approximation, :math:`f(\epsilon) \sim p + q\epsilon = (r_0f(r) - rf(r_0))/\Delta + (f(r_0) - f(r))\epsilon/\Delta`. The integrand then separates into a sum over terms multiplied by :math:`h_k`,
 
  .. math::
 
     \sum_k h_k f(r_0) \int_{r_0}^{r} \Phi_k(r, \epsilon) d\epsilon
 
-with each integral:
+with each integral
 
  .. math::
 
   \int_{r_0}^{r} \left(\frac{\epsilon}{r}\right)^\lambda_k d\epsilon = \frac{r}{r_0}\left[ 1 - \left(\frac{r}{r_0}\right)^{\lambda_k + 1}\right] = \frac{(n-1)^a}{\lambda_k + a} \left[ 1 - \left(\frac{n}{n-1}\right)^{\lambda_k+a} \right],
 
-where, the right-most-side of the equation has an additional parameter, :math:`a` to generalize the power of :math:`\lambda_k`.  For the inverse transform, there is an additional factor :math:`\frac{1}{\pi r}` in the state equation, and hence the integrand has :math:`\lambda_k` power, reduced by -1. While, for the 
-first-order hold approximation, the linear :math:`\epsilon` term increases :math:`\lambda_k` by +1. 
+where, the right-most-side of the equation has an additional parameter, :math:`a` to generalize the power of :math:`\lambda_k`.  For the inverse transform, there is an additional factor :math:`\frac{1}{\pi r}` in the state equation, and hence the integrand has :math:`\lambda_k` power, reduced by −1. While, for the
+first-order hold approximation, the linear :math:`\epsilon` term increases :math:`\lambda_k` by +1.
 
 
 Citation
 --------
-[1] `E. W. Hansen and P.-L. Law, "Recursive methods for computing the Abel transform and its inverse", J. Opt. Soc. A2, 510-520 (1985). <http://dx.doi.org/10.1364/JOSAA.2.000510>`_
 
-[2] `E. W. Hansen, "Fast Hankel Transform", IEEE Trans. Acoust. Speech Signal Proc. 33, 666 (1985). <https://dx.doi.org/10.1109/TASSP.1985.1164579>`_
+.. [1] \ E. W. Hansen, P.-L. Law, "Recursive methods for computing the Abel transform and its inverse", `J. Opt. Soc. Am. A 2, 510–520 (1985) <https://dx.doi.org/10.1364/JOSAA.2.000510>`_.
 
-[3] `J. R. Gascooke, PhD Thesis: "Energy Transfer in Polyatomic-Rare Gas Collisions and Van Der Waals Molecule Dissociation", Flinders University (2000). <https://github.com/PyAbel/abel_info>`_
+.. [2] \ E. W. Hansen, "Fast Hankel transform algorithm", `IEEE Trans. Acoust. Speech Signal Proc. 33, 666–671 (1985) <https://dx.doi.org/10.1109/TASSP.1985.1164579>`_
+
+.. [3] \ J. R. Gascooke, PhD Thesis: "Energy Transfer in Polyatomic-Rare Gas Collisions and Van Der Waals Molecule Dissociation", Flinders University (2000), (`record <https://trove.nla.gov.au/version/41486301>`_, `PDF <https://github.com/PyAbel/abel_info/raw/master/Gascooke_Thesis.pdf>`_).

--- a/doc/transform_methods/linbasex.rst
+++ b/doc/transform_methods/linbasex.rst
@@ -9,7 +9,7 @@ Introduction
 ------------
 
 Inversion procedure based on 1-dimensional projections of VM-images as 
-described in Gerber et al. [1]. 
+described in Gerber et al. [1]_.
 
 [ *from the abstract* ]
 
@@ -160,5 +160,5 @@ PyAbel python code was extracted from this `jupyter notebook <https://www.psi.ch
 
 Citation
 --------
-[1] `Gerber, Thomas, Yuzhu Liu, Gregor Knopp, Patrick Hemberger, Andras Bodi, Peter Radi, and Yaroslav Sych, "Charged Particle Velocity Map Image Reconstruction with One-Dimensional Projections of Spherical Functions.” Rev. Sci. Instrum. 84, no. 3, 033101 (2013) <http://dx.doi.org/10.1063/1.4793404>`_
 
+.. [1] \ Th. Gerber, Yu. Liu, G. Knopp, P. Hemberger, A. Bodi, P. Radi, Ya. Sych, "Charged particle velocity map image reconstruction with one-dimensional projections of spherical functions", `Rev. Sci. Instrum. 84, 033101 (2013) <https://doi.org/10.1063/1.4793404>`_.

--- a/doc/transform_methods/onion_bordas.rst
+++ b/doc/transform_methods/onion_bordas.rst
@@ -8,10 +8,9 @@ Introduction
 The onion peeling method, also known as "back projection" has been 
 ported to Python from the original Matlab implementation, created by 
 Chris Rallis and Eric Wells of Augustana University, and described in 
-this paper [1]. The algorithm actually originates from this 1996 RSI paper 
-by Bordas ~et al.[2]
+[1]_. The algorithm actually originates from Bordas ~et al. [2]_.
 
-See the discussion here: https://github.com/PyAbel/PyAbel/issues/56
+See the discussion in `issue #56 <https://github.com/PyAbel/PyAbel/issues/56>`_.
 
 
 How it works
@@ -54,6 +53,7 @@ Example
 
 Citation
 --------
-[1] http://scitation.aip.org/content/aip/journal/rsi/85/11/10.1063/1.4899267
 
-[2] http://scitation.aip.org/content/aip/journal/rsi/67/6/10.1063/1.1147044
+.. [1] \ C. E. Rallis, T. G. Burwitz, P. R. Andrews, M. Zohrabi, R. Averin, S. De, B. Bergues, B. Jochim, A. V. Voznyuk, N. Gregerson, B. Gaire, I. Znakovskaya, J. McKenna, K. D. Carnes, M. F. Kling, I. Ben-Itzhak, E. Wells, "Incorporating real time velocity map image reconstruction into closed-loop coherent control", `Rev. Sci. Instrum. 85, 113105 (2014) <https://doi.org/10.1063/1.4899267>`_.
+
+.. [2] \ C. Bordas, F. Paulig, "Photoelectron imaging spectrometry: Principle and inversion method", `Rev. Sci. Instrum. 67, 2257–2268 (1996) <https://doi.org/10.1063/1.1147044>`_.

--- a/doc/transform_methods/onion_peeling.rst
+++ b/doc/transform_methods/onion_peeling.rst
@@ -6,22 +6,22 @@ Introduction
 ------------
 
 The "Dasch onion peeling" deconvolution algorithm is one of several
-described in the Dasch [1] paper. See also the ``two_point`` and 
+described in the Dasch paper [1]_. See also the ``two_point`` and
 ``three_point`` descriptions.
 
 How it works
 ------------
 
 In the onion-peeling method the projection is approximated by rings
-of constant property between 
-:math:`r_j - \Delta r/2` and :math:`r_j + \Delta r/2` for each data 
+of constant property between
+:math:`r_j - \Delta r/2` and :math:`r_j + \Delta r/2` for each data
 point :math:`r_j`.
 
 The projection data is given by :math:`P(r_i) = \Delta r \sum_{j=i}^\infty W_{ij} F(r_j)`
 
-where 
+where
 
-.. math:: W_{ij} = 0 \, \, (j < i) 
+.. math:: W_{ij} = 0 \, \, (j < i)
 
        \sqrt{(2j+1)^2 - 4i^2} \, \, (j=i)
 
@@ -55,11 +55,11 @@ Example
     :include-source:
 
 
-or more information on the PyAbel implementation of the ``onion_peeling`` algorithm, please see `Pull Request #155 <https://github.com/PyAbel/PyAbel/pull/155>`_.
+or more information on the PyAbel implementation of the ``onion_peeling`` algorithm, please see `PR #155 <https://github.com/PyAbel/PyAbel/pull/155>`_.
 
 
 
 Citation
 --------
-[1] `Dasch, Applied Optics, Vol 31, No 8, March 1992, Pg 1146-1152 <(http://dx.doi.org/10.1364/AO.31.001146>`_.
 
+.. [1] \ C. J. Dasch, "One-dimensional tomography: a comparison of Abel, onion-peeling, and filtered backprojection methods", `Appl. Opt. 31, 1146–1152 (1992) <https://doi.org/10.1364/AO.31.001146>`_.

--- a/doc/transform_methods/pop.rst
+++ b/doc/transform_methods/pop.rst
@@ -5,9 +5,9 @@ Polar Onion Peeling (not implemented)
 Introduction
 ------------
 
-The polar onion peeling (POP) method is still under development.
+The polar onion peeling (POP) method [1]_ [2]_ is still under development.
 
-See the discussion here: https://github.com/PyAbel/PyAbel/issues/30
+See the discussion in `issue #30 <https://github.com/PyAbel/PyAbel/issues/30>`_.
 
 
 How it works
@@ -36,6 +36,7 @@ Put it here!
 
 Citation
 --------
-[1] http://dx.doi.org/10.1063/1.3126527
 
-[2] http://www.mathworks.com/matlabcentral/fileexchange/41064-polar-onion-peeling
+.. [1] \ G. M. Roberts, J. L. Nixon, J. Lecointre, E. Wrede, J. R. R. Verlet, "Toward real-time charged-particle image reconstruction using polar onion-peeling", `Rev. Sci. Instrum. 80, 053104 (2009) <https://dx.doi.org/10.1063/1.3126527>`_.
+
+.. [2] \ A. Natan, `PolarOnionPeeling <http://www.mathworks.com/matlabcentral/fileexchange/41064-polar-onion-peeling>`_ (MathWorks).

--- a/doc/transform_methods/three_point.rst
+++ b/doc/transform_methods/three_point.rst
@@ -5,7 +5,7 @@ Three Point
 Introduction
 ------------
 
-The "Three Point" Abel transform method exploits the observation that the value of the Abel inverted data at any radial position ``r`` is primarily determined from changes in the projection data in the neighborhood of ``r``. This technique was developed by Dasch [1].
+The "Three Point" Abel transform method exploits the observation that the value of the Abel inverted data at any radial position ``r`` is primarily determined from changes in the projection data in the neighborhood of ``r``. This technique was developed by Dasch [1]_.
 
 How it works
 ------------
@@ -46,15 +46,14 @@ Example
 Notes
 -----
 
-The algorithm contained two typos in Eq (7) in the original citation [1]. A corrected form of these equations is presented in Karl Martin's 2002 PhD thesis [2]. PyAbel uses the corrected version of the algorithm.
+The algorithm contained two typos in Eq. (7) in the original citation [1]_. A corrected form of these equations is presented in Karl Martin's 2002 PhD thesis [2]_. PyAbel uses the corrected version of the algorithm.
 
-For more information on the PyAbel implementation of the three-point algorithm, please see `Issue #61 <https://github.com/PyAbel/PyAbel/issues/61>`_ and `Pull Request #64 <https://github.com/PyAbel/PyAbel/pull/64>`_.
-
+For more information on the PyAbel implementation of the three-point algorithm, please see `issue #61 <https://github.com/PyAbel/PyAbel/issues/61>`_ and `Pull Request #64 <https://github.com/PyAbel/PyAbel/pull/64>`_.
 
 
 Citation
 --------
-[1] `Dasch, Applied Optics, Vol 31, No 8, March 1992, Pg 1146-1152 <(http://dx.doi.org/10.1364/AO.31.001146>`_.
 
-[2] Martin, Karl. PhD Thesis, University of Texas at Austin. Acoustic Modification of Sooting Combustion. 2002: https://www.lib.utexas.edu/etd/d/2002/martinkm07836/martinkm07836.pdf
+.. [1] \ C. J. Dasch, "One-dimensional tomography: a comparison of Abel, onion-peeling, and filtered backprojection methods", `Appl. Opt. 31, 1146–1152 (1992) <https://doi.org/10.1364/AO.31.001146>`_.
 
+.. [2] \ K. Martin, PhD Thesis: "Acoustic Modification of Sooting Combustion", University of Texas at Austin (2002) (`record <http://hdl.handle.net/2152/1654>`_, `PDF <https://repositories.lib.utexas.edu/bitstream/handle/2152/1654/martinkm07836.pdf>`_).

--- a/doc/transform_methods/two_point.rst
+++ b/doc/transform_methods/two_point.rst
@@ -6,15 +6,15 @@ Introduction
 ------------
 
 The "Dasch two-point" deconvolution algorithm is one of several
-described in the Dasch [1] paper. See also the ``three_point`` and 
+described in the Dasch paper [1]_. See also the ``three_point`` and
 ``onion_peeling`` descriptions.
 
 How it works
 ------------
 
-The Abel integral is broken into intervals between the :math:`r_j` 
+The Abel integral is broken into intervals between the :math:`r_j`
 points, and :math:`P^\prime(r)` is assumed constant between :math:`r_j` and
-:math:`r_{j+1}`. 
+:math:`r_{j+1}`.
 
 When to use it
 --------------
@@ -40,11 +40,10 @@ Example
     :include-source:
 
 
-or more information on the PyAbel implementation of the ``two_point`` algorithm, please see `Pull Request #155 <https://github.com/PyAbel/PyAbel/pull/155#issuecomment-200630188>`_.
-
+For more information on the PyAbel implementation of the ``two_point`` algorithm, please see `PR #155 <https://github.com/PyAbel/PyAbel/pull/155#issuecomment-200630188>`_.
 
 
 Citation
 --------
-[1] `Dasch, Applied Optics, Vol 31, No 8, March 1992, Pg 1146-1152 <(http://dx.doi.org/10.1364/AO.31.001146>`_.
 
+.. [1] \ C. J. Dasch, "One-dimensional tomography: a comparison of Abel, onion-peeling, and filtered backprojection methods", `Appl. Opt. 31, 1146–1152 (1992) <https://doi.org/10.1364/AO.31.001146>`_.

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -25,7 +25,7 @@ from six.moves import tkinter_tkfiledialog as filedialog
 Abel_methods = ['basex', 'direct', 'hansenlaw', 'linbasex', 'onion_peeling',
                 'onion_bordas', 'two_point', 'three_point']
 
-center_methods = ['center-of-mass', 'convolution', 'gaussian', 'slice']
+center_methods = ['com', 'convolution', 'gaussian', 'slice']
 
 
 class PyAbel:  # (tk.Tk):
@@ -354,7 +354,7 @@ class PyAbel:  # (tk.Tk):
         self.canvas.draw()
 
         # center image via chosen method
-        self.IM = abel.tools.center.center_image(self.IM, center=center_method,
+        self.IM = abel.tools.center.center_image(self.IM, method=center_method,
                                                  odd_size=True)
         # self.text.insert(tk.END, "\ncenter offset = {:}".format(self.offset))
         self.text.see(tk.END)

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -26,7 +26,7 @@ rows, cols = IM.shape    # image size
 # Image center should be mid-pixel, i.e. odd number of colums
 if cols % 2 != 1: 
     print ("even pixel width image, make it odd and re-adjust image center")
-    IM = abel.tools.center.center_image(IM, center="slice")
+    IM = abel.tools.center.center_image(IM, method="slice")
     rows, cols = IM.shape   # new image size
 
 r2 = rows//2   # half-height image size

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -43,7 +43,7 @@ imagefile = bz2.BZ2File('data/O2-ANU1024.txt.bz2')
 IM = np.loadtxt(imagefile)
 
 # recenter the image to mid-pixel (odd image width)
-IModd = abel.tools.center.center_image(IM, center="slice", odd_size=True)
+IModd = abel.tools.center.center_image(IM, method="slice", odd_size=True)
 
 h, w = IModd.shape
 print("centered image 'data/O2-ANU2048.txt' shape = {:d}x{:d}".format(h, w))
@@ -76,10 +76,10 @@ for q, method in enumerate(transforms.keys()):
     # inverse Abel transform using 'method'
     IAQ0 = transforms[method](Q0, direction="inverse", dr=0.1,
                               basis_dir='bases')
-    print ("                    {:.1f} sec".format(time()-t0))
+    print ("                    {:.1f} s".format(time()-t0))
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0),
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(-1, 0),
                                                        dr=0.1)
 
     # normalize image intensity and speed distribution

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -50,6 +50,10 @@ print ("quadrant shape {}".format(Q0.shape))
 
 iabelQ = []  # keep inverse Abel transformed image
 
+# subplots: 121 — whole image, 122 — speed distributions
+ax_im = plt.subplot(121)
+ax_sp = plt.subplot(122)
+
 for q, method in enumerate(transforms.keys()):
 
     Q0 = Q0fresh.copy()   # top-right quadrant of O2- image
@@ -60,19 +64,16 @@ for q, method in enumerate(transforms.keys()):
     # inverse Abel transform using 'method'
     IAQ0 = transforms[method](Q0, direction="inverse", basis_dir='bases')
 
-    print ("                    {:.1f} sec".format(time()-t0))
+    print ("                    {:.1f} s".format(time()-t0))
 
     iabelQ.append(IAQ0)  # store for plot
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0))
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(-1, 0))
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0.max()  
     speed /= speed.max()
-
-    # plots    #121 whole image,   #122 speed distributions
-    plt.subplot(121) 
 
     # method label for each quadrant
     annot_angle = -(45+q*90)*np.pi/180  # -ve because numpy coords from top
@@ -80,11 +81,10 @@ for q, method in enumerate(transforms.keys()):
         annot_angle += 50*np.pi/180    # shared quadrant - move the label  
     annot_coord = (h/2+(h*0.9)*np.cos(annot_angle)/2, 
                    w/2+(w*0.9)*np.sin(annot_angle)/2)
-    plt.annotate(method, annot_coord, color="yellow")
+    ax_im.annotate(method, annot_coord, color="yellow")
 
     # plot speed distribution
-    plt.subplot(122) 
-    plt.plot(radial, speed, label=method)
+    ax_sp.plot(radial, speed, label=method)
 
 # reassemble image, each quadrant a different method
 
@@ -106,13 +106,11 @@ im = abel.tools.symmetry.put_image_quadrants((iabelQ[0], iabelQ[1],
                                               iabelQ[2], iabelQ[3]), 
                                               original_image_shape=IM.shape)
 
-plt.subplot(121)
-plt.imshow(im, vmin=0, vmax=0.8)
+ax_im.imshow(im, vmin=0, vmax=0.8)
 
-plt.subplot(122)
 plt.title("Ominus sample image")
-plt.axis(ymin=-0.05, ymax=1.1)
-plt.legend(loc=0, labelspacing=0.1)
+ax_sp.axis(ymin=-0.05, ymax=1.1)
+ax_sp.legend(loc=0, labelspacing=0.1)
 plt.tight_layout()
 plt.savefig('plot_example_all_Ominus.png', dpi=100)
 plt.show()

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -63,12 +63,12 @@ for q, method in enumerate(transforms.keys()):
     # inverse Abel transform using 'method'
     IAQ0 = transforms[method](Q0, direction="inverse", basis_dir='bases')
 
-    print ("                    {:.4f} sec".format(time()-t0))
+    print ("                    {:.4f} s".format(time()-t0))
 
     iabelQ.append(IAQ0)  # store for plot
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(0, 0), Jacobian=False)
+    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(-1, 0), Jacobian=False)
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0.max()  

--- a/examples/example_anisotropy_parameter.py
+++ b/examples/example_anisotropy_parameter.py
@@ -58,7 +58,7 @@ r_range = [(145, 162), (200, 218), (230, 250), (255, 280), (280, 310),
 
 # anisotropy parameter from image for each tuple r_range
 Beta, Amp, Rmid, Ivstheta, theta =\
-              abel.tools.vmi.radial_integration(HIM.transform, r_range)
+    abel.tools.vmi.radial_integration(HIM.transform, radial_ranges=r_range)
 
 # OR  anisotropy parameter for ranges (0, 20), (20, 40) ...
 # Beta_whole_grid, Amp_whole_grid, Radial_midpoints =\

--- a/examples/example_anisotropy_parameter.py
+++ b/examples/example_anisotropy_parameter.py
@@ -27,7 +27,7 @@ threshold = 0.2  # threshold for normalization of higher order Newton spheres
 clip = 0  # clip first vectors (smallest Newton spheres) to avoid singularities
 
 # linbasex method - center and center_options ensure image has odd square shape
-LIM = abel.Transform(IM, method='linbasex', center='slice',
+LIM = abel.Transform(IM, method='linbasex', origin='slice',
                      center_options=dict(square=True),
                      transform_options=dict(basis_dir=None,
                      proj_angles=proj_angles, radial_step=radial_step,
@@ -36,7 +36,7 @@ LIM = abel.Transform(IM, method='linbasex', center='slice',
 
 
 # === Hansen & Law inverse Abel transform ==================
-HIM = abel.Transform(IM, center="slice", method="hansenlaw",
+HIM = abel.Transform(IM, origin="slice", method="hansenlaw",
                      symmetry_axis=None, angular_integration=True)
 
 # speed distribution

--- a/examples/example_basex_photoelectron.py
+++ b/examples/example_basex_photoelectron.py
@@ -35,17 +35,17 @@ output_plot  = filename[:-4] + '_comparison.pdf'
 print('Loading ' + filename)
 raw_data = plt.imread(filename).astype('float64')
 
-# Step 2: Specify the center in y,x (vert,horiz) format
-center = (245,340)
+# Step 2: Specify the origin in (row, col) format
+origin = (245, 340)
 # or, use automatic centering
-# center = 'com'
-# center = 'gaussian'
+# origin = 'com'
+# origin = 'gaussian'
 
 # Step 3: perform the BASEX transform!
 print('Performing the inverse Abel transform:')
 
 recon = abel.Transform(raw_data, direction='inverse', method='basex',
-                       center=center, transform_options=dict(basis_dir='bases'),
+                       origin=origin, transform_options=dict(basis_dir='bases'),
                        verbose=True).transform
                       
 speeds = abel.tools.vmi.angular_integration(recon)

--- a/examples/example_basex_step.py
+++ b/examples/example_basex_step.py
@@ -10,8 +10,8 @@ plt.title('Abel tranforms of a step function')
 n = 301
 r_max = 50
 A0 = 10.0
-r1 = 6.0
-r2 = 14.0
+r1 = 6.5
+r2 = 14.5
 
 # define a symmetric step function and calculate its analytical Abel transform
 st = StepAnalytical(n, r_max, r1, r2, A0)

--- a/examples/example_dasch_methods.py
+++ b/examples/example_dasch_methods.py
@@ -18,7 +18,7 @@ IM = abel.tools.analytical.SampleImage(n).image
 origQ = abel.tools.symmetry.get_image_quadrants(IM)
 
 # speed distribution of original image
-orig_speed = abel.tools.vmi.angular_integration(origQ[0], origin=(0,0))
+orig_speed = abel.tools.vmi.angular_integration(origQ[0], origin=(-1, 0))
 scale_factor = orig_speed[1].max()
 
 plt.plot(orig_speed[0], orig_speed[1]/scale_factor, linestyle='dashed', 
@@ -41,7 +41,7 @@ for method in dasch_transform.keys():
 # method inverse Abel transform
     AQ0 = dasch_transform[method](Q0, basis_dir='bases')
 # speed distribution
-    speed = abel.tools.vmi.angular_integration(AQ0, origin=(0,0))
+    speed = abel.tools.vmi.angular_integration(AQ0, origin=(-1, 0))
 
     plt.plot(speed[0], speed[1]*orig_speed[1][14]/speed[1][14]/scale_factor, 
              label=method)

--- a/examples/example_hansenlaw.py
+++ b/examples/example_hansenlaw.py
@@ -22,7 +22,7 @@ IM = np.loadtxt(imagefile)
 rows, cols = IM.shape    # image size
 
 # center image returning odd size
-IMc = abel.tools.center.center_image(IM, center='com')
+IMc = abel.tools.center.center_image(IM, method='com')
 
 # dr=0.5 may help reduce pixel grid coarseness
 # NB remember to also pass as an option to angular_integration

--- a/examples/example_hansenlaw_Xe.py
+++ b/examples/example_hansenlaw_Xe.py
@@ -39,7 +39,7 @@ print('Performing Hansen and Law inverse Abel transform:')
 
 recon = abel.Transform(im, method="hansenlaw", direction="inverse", 
                        symmetry_axis=None, verbose=True, 
-                       center=(240,340)).transform
+                       origin=(240,340)).transform
                        
 r, speeds = abel.tools.vmi.angular_integration(recon)
 

--- a/examples/example_linbasex.py
+++ b/examples/example_linbasex.py
@@ -37,7 +37,7 @@ radial_step = 1
 clip = 0
 
 # linbasex inverse Abel transform
-LIM = abel.Transform(IM, method="linbasex", center="convolution",
+LIM = abel.Transform(IM, method="linbasex", origin="convolution",
                      center_options=dict(square=True),
                      transform_options=dict(basis_dir=None, return_Beta=True,
                                             legendre_orders=un,

--- a/examples/example_linbasex_hansenlaw.py
+++ b/examples/example_linbasex_hansenlaw.py
@@ -14,15 +14,15 @@ clip=0  # clip first vectors (smallest Newton spheres) to avoid singularities
 
 # linbasex method - center ensures image has odd square shape
 #                 - speed and anisotropy parameters evaluated by method
-LIM = abel.Transform(IM, method='linbasex', center='convolution',
+LIM = abel.Transform(IM, method='linbasex', origin='convolution',
                      center_options=dict(square=True),
                      transform_options=dict(basis_dir=None,
                      proj_angles=proj_angles, radial_step=radial_step,
-                     smoothing=smoothing, threshold=threshold, clip=clip, 
+                     smoothing=smoothing, threshold=threshold, clip=clip,
                      return_Beta=True, verbose=True))
 
 # hansenlaw method - speed and anisotropy parameters evaluated by integration
-HIM = abel.Transform(IM, method="hansenlaw", center='convolution', 
+HIM = abel.Transform(IM, method="hansenlaw", origin='convolution',
                      center_options=dict(square=True),
                      angular_integration=True)
 

--- a/examples/example_onion_bordas.py
+++ b/examples/example_onion_bordas.py
@@ -14,7 +14,7 @@ IM = abel.tools.analytical.SampleImage(n=501).image
 origQ = abel.tools.symmetry.get_image_quadrants(IM)
 
 # speed distribution
-orig_speed = abel.tools.vmi.angular_integration(origQ[0], origin=(0,0))
+orig_speed = abel.tools.vmi.angular_integration(origQ[0], origin=(-1, 0))
 
 # forward Abel projection
 fIM = abel.Transform(IM, direction="forward", method="hansenlaw").transform
@@ -26,7 +26,7 @@ Q0 = Q[0].copy()
 # onion_bordas inverse Abel transform
 borQ0 = abel.onion_bordas.onion_bordas_transform(Q0)
 # speed distribution
-bor_speed = abel.tools.vmi.angular_integration(borQ0, origin=(0,0))
+bor_speed = abel.tools.vmi.angular_integration(borQ0, origin=(-1, 0))
 
 plt.plot(*orig_speed, linestyle='dashed', label="Dribinski sample")
 plt.plot(bor_speed[0], bor_speed[1], label="onion_bordas")

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -24,7 +24,7 @@ from six.moves import tkinter_tkfiledialog as filedialog
 Abel_methods = ['basex', 'direct', 'hansenlaw', 'linbasex', 'onion_peeling',
                 'onion_bordas', 'two_point', 'three_point']
 
-center_methods = ['center-of-mass', 'convolution', 'gaussian', 'slice']
+center_methods = ['com', 'convolution', 'gaussian', 'slice']
 
 # GUI window -------------------
 
@@ -77,19 +77,19 @@ def _getfilename():
 def _center():
     global cent, IM, text
 
-    center = cent.get()
+    method = cent.get()
 
     # update information text box
     text.delete(1.0, tk.END)
     text.insert(
         tk.END,
-        "centering image using abel.tools.center_image(center={})\n"
-        .format(center))
+        "centering image using abel.tools.center_image(method={})\n"
+        .format(method))
     canvas.draw()
 
     # center image via horizontal (left, right), and vertical (top, bottom)
     # intensity slices
-    IM = abel.tools.center.center_image(IM, center=center, odd_size=True)
+    IM = abel.tools.center.center_image(IM, method=method, odd_size=True)
 
     _display()
 


### PR DESCRIPTION
This one is difficult but is better to be done sooner than later...
It addresses the inconsistent conventions for the image origin, see #263, and also tries to rename the related functions and parameters more appropriately, as also discussed in #263.

## Summary
* The image origin (center of symmetry) is now called “origin” everywhere.
* The word “center” now refers to the geometric center (midpoint) of the frame (matrix) and as a verb refers to shifting/cropping the image to move its _origin_ to the _center_.
* The parameter selecting the method of this centering is now called `method` when possible (some functions already had a parameter `method` for selecting the Abel transform).
* Most importantly, all functions that accept or return the origin are now using the (row, column) format, which is consistent with matrix indexing in NumPy and `scipy.ndimage`.
* To facilitate coding, negative values are now allowed for row and column, with the same meaning as in Python and NumPy, that is, counting form the end. For example, the quadrant Q0 (upper right) can have its origin (lower left) defined as `[-1, 0]` (_last_ row, 0th column).

## Compatibility issues
The renaming is accompanied by compatibility “shims” that print a deprecation warning and pass control to the corresponding new methods (or copy the parameters). This should not break old programs and should make their conversion to the new API easier (the warning tells where the problem is and what to use instead).

The “(row, column)” change might be problematic, because there is no automatic way to tell whether the code is using the old format (which sometime was (x, y) from the _bottom_ left, sometimes (column, row), and sometimes (row, column) as now) or the new. In some cases, when the function/parameter name is changed, the deprecation warning described above should help to locate the problematic code, but in general it seems that manual testing is the only way. I have mentioned this in the changelog, hopefully people will pay attention to it...

So, everybody, please test how your existing code works with the new API. Maybe we can develop better recommendations to simplify the transition (and/or do some other changes to the API).

## Additional changes
During this revision I've noticed that some links (internal and external) were broken or had errors, so I have repaired them and reformatted all literature references consistently, with full titles and author lists. And linked the examples that were referenced (and actually existed) but not included in the documentation.
