### PR TITLE
rBasex, a better pBasex

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Unreleased
   See PR #267.
 * Fixed the GUI examples (example_GUI.py and example_simple_GUI.py)
   so that they work with the lastest versions of tk (PR #269).
+* New method rBasex for velocity-map images, based on pBasex and the work of
+  Mikhail Ryazanov (PR #270).
+* Added "orders", "sinpowers" and "valid" to tools.vmi.Distributions results,
+  reordered cossin() powers for consistency (PR #270).
+* Improved tools.vmi.Distributions performance on Windows (PR #270).
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ The outcome of the numerical Abel transform depends on the exact method used. So
 
     8. ``linbasex`` - the 1D-spherical basis set expansion of Gerber *et al.*
 
+    9. ``rbasex`` - a pBasex-like method formulated in terms of radial distributions.
+
 
 Installation
 ------------
@@ -176,6 +178,8 @@ License
 
 PyAble is licensed under the `MIT license <https://github.com/PyAbel/PyAbel/blob/master/LICENSE.txt>`_, so it can be used for pretty much whatever you want! Of course, it is provided "as is" with absolutely no warranty.
 
+
+.. _READMEcitation:
 
 Citation
 --------

--- a/abel/__init__.py
+++ b/abel/__init__.py
@@ -29,6 +29,7 @@ from . import direct
 from . import hansenlaw
 from . import linbasex
 from . import onion_bordas
+from . import rbasex
 from . import tools
 from . import transform
 from . import tests

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -474,7 +474,7 @@ class AbelTiming(object):
         # benchmark the basis generation (default parameters)
         def gen_basis():
             rbasex.cache_cleanup()
-            rbasex.get_bs_cached(self.w)
+            rbasex.get_bs_cached(self.w - 1)  # Rmax = half-width - 1
         self._benchmark('bs', 'rbasex',
                         gen_basis)
 

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -468,7 +468,8 @@ class AbelTiming(object):
     def _time_onion_peeling(self):
         self._time_dasch('onion_peeling')
 
-    @_skip((['bs', 'inverse', 'forward'], 'rbasex'))
+    @_skip(('bs', 'rbasex'),
+           (['inverse', 'forward'], ['rbasex', 'rbasex(None)']))
     def _time_rbasex(self):
         # benchmark the basis generation (default parameters)
         def gen_basis():
@@ -485,6 +486,10 @@ class AbelTiming(object):
             self._benchmark(direction, 'rbasex',
                             rbasex.rbasex_transform,
                             self.whole_image)
+            # same without output image
+            self._benchmark(direction, 'rbasex(None)',
+                            rbasex.rbasex_transform,
+                            self.whole_image, out=None)
 
             # discard the unneeded transform matrix
             basex.cache_cleanup(direction)

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -107,8 +107,8 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
             channels. Not implemented for odd orders > 1.
 
             Notice that this method is nonlinear, which also means that it is
-            considerably slower than the linear methods and might produce
-            slightly biased results.
+            considerably slower than the linear methods and the transform
+            operator cannot be cached.
 
         In all cases, `strength` = 0 provides no regularization. For the
         Tikhonov methods, `strength` ~ 100 is a reasonable value for megapixel
@@ -134,7 +134,7 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
             half for ``odd=True``
         ``None``:
             no image (**recon** will be ``None``). Can be useful to avoid
-            unnecessary calculations if only the transformed radial
+            unnecessary calculations when only the transformed radial
             distributions (**distr**) are needed.
 
     Returns
@@ -374,7 +374,7 @@ def get_bs_cached(Rmax, order=2, odd=False, direction='inverse', reg=None):
         include odd angular orders
     direction : str: ``'forward'`` or ``'inverse'``
         type of Abel transform to be performed
-    reg : None or tuple (str, float)
+    reg : None or str or tuple (str, float)
         regularization type and strength for inverse transform
     Returns
     -------

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -220,7 +220,7 @@ def get_bs_cached(Rmax, direction='inverse'):
         return _tri
 
 
-def cache_cleanup():
+def cache_cleanup(select='all'):
     """
     Utility function.
 
@@ -230,7 +230,15 @@ def cache_cleanup():
 
     Parameters
     ----------
-    None
+    select : str
+        selects which caches to clean:
+
+        ``all`` (default)
+            everything, including basis;
+        ``forward``
+            forward transform;
+        ``inverse``
+            inverse transform.
 
     Returns
     -------
@@ -238,9 +246,12 @@ def cache_cleanup():
     """
     global _prm, _dst, _bs_prm, _bs, _trf, _tri
 
-    _prm = None
-    _dst = None
-    _bs_prm = None
-    _bs = None
-    _trf = None
-    _tri = None
+    if select == 'all':
+        _prm = None
+        _dst = None
+        _bs_prm = None
+        _bs = None
+    if select in ('all', 'forward'):
+        _trf = None
+    if select in ('all', 'inverse'):
+        _tri = None

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from scipy.linalg import inv
+from scipy.linalg import solve_triangular
 
 from abel.tools.vmi import Distributions
 from abel.tools.symmetry import put_image_quadrants
@@ -36,23 +36,23 @@ from abel.tools.symmetry import put_image_quadrants
 
 
 # Caches and their parameters
-_prm = None  # [shape, origin, rmax, weights]
+_prm = None  # [shape, origin, rmax, order, odd, weights]
 _dst = None  # Distribution object
-_bs_prm = None  # [Rmax]
-_bs = None  # [P0, P2] — projected functions
-_trf = None  # [Af0, Af2] — forward transform matrices
-_tri = None  # [Ai0, Ai2] — inverse transform matrices
+_bs_prm = None  # [Rmax, order, odd]
+_bs = None  # [P[n]] — projected functions
+_trf = None  # [Af[n]] — forward transform matrices
+_tri = None  # [Ai[n]] — inverse transform matrices
 
 
-def rbasex_transform(IM, origin='center', rmax='MIN',
+def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
                      weights=None, direction='inverse'):
     """
     This function takes the input image and outputs its forward or inverse Abel
     transform as an image and its radial distributions.
 
-    The **origin**, **rmax** and **weights** parameters are passed to
-    :class:`abel.tools.vmi.Distributions`, so see its documentation for their
-    detailed descriptions.
+    The **origin**, **rmax**, **order**, **odd** and **weights** parameters are
+    passed to :class:`abel.tools.vmi.Distributions`, so see its documentation
+    for their detailed descriptions.
 
     Parameters
     ----------
@@ -63,6 +63,10 @@ def rbasex_transform(IM, origin='center', rmax='MIN',
         string
     rmax : int or string
         largest radius to include in the transform
+    order : int
+        highest order in the angular distributions, ≥ 0
+    odd : bool
+        include odd angular orders (enabled automatically if **order** is odd)
     weights : m × n numpy array, optional
         weighting factors for each pixel. The array shape must match the image
         shape. Parts of the image can be excluded from analysis by assigning
@@ -79,27 +83,41 @@ def rbasex_transform(IM, origin='center', rmax='MIN',
         the object from which various distributions for the transformed image
         can be retrieved, see :class:`abel.tools.vmi.Distributions.Results`
     """
+    if order == 0:
+        odd = False  # (to eliminate additional checks)
+    elif order % 2:
+        odd = True  # enable automatically for odd orders
 
-    p0, p2 = _profiles(IM, origin, rmax, weights)
+    # extract radial profiles from input image
+    p = _profiles(IM, origin, rmax, order, odd, weights)
 
     Rmax = _dst.rmax
 
-    A0, A2 = get_bs_cached(Rmax, direction)
+    # get appropriate transform matrices
+    A = get_bs_cached(Rmax, order, odd, direction)
 
-    c0 = A0.dot(p0)
-    c2 = A2.dot(p2)
+    # transform radial profiles
+    c = [An.dot(pn) for An, pn in zip(A, p)]
 
-    distr = Distributions.Results(np.arange(Rmax + 1), np.array([c0, c2]),
-                                  2, False)
-    Q = _image(c0, c2)[::-1]
-    height, width = _dst.Qheight, _dst.Qwidth
-    recon = put_image_quadrants((Q, Q, Q, Q),
-                                (2 * height - 1, 2 * width - 1))
+    # construct output (transformed) distributions
+    distr = Distributions.Results(np.arange(Rmax + 1), np.array(c), order, odd)
+
+    # construct output (transformed) image from transformed radial profiles
+    if odd:
+        Q = _image(c)  # actually right half
+        # combine with left half (mirrored without central column)
+        recon = np.hstack((Q[:, :0:-1], Q))
+    else:
+        Q = _image(c)[::-1]  # flip to upper right (Q0)
+        # assemble full image
+        height, width = _dst.Qheight, _dst.Qwidth
+        recon = put_image_quadrants((Q, Q, Q, Q),
+                                    (2 * height - 1, 2 * width - 1))
 
     return recon, distr
 
 
-def _profiles(IM, origin, rmax, weights):
+def _profiles(IM, origin, rmax, order, odd, weights):
     """
     Get radial profiles of cos^n theta terms from the input image.
     """
@@ -108,75 +126,92 @@ def _profiles(IM, origin, rmax, weights):
     # image
     global _prm, _dst
 
-    prm = [IM.shape, origin, rmax, weights]
+    prm = [IM.shape, origin, rmax, order, odd, weights]
     if _prm != prm:
         _prm = prm
-        _dst = Distributions(origin=origin, rmax=rmax, weights=weights,
-                             use_sin=False, method='linear')
+        _dst = Distributions(origin=origin, rmax=rmax, order=order, odd=odd,
+                             weights=weights, use_sin=False, method='linear')
 
     return _dst(IM).cos()
 
 
-def _image(c0, c2):
+def _image(c):
     """
-    Create transformed image from its cos^n theta radial profiles.
+    Create transformed image (lower right quadrant for even-only,
+    right half for odd) from its cos^n theta radial profiles.
     """
-    rbin, wl, wu, cos2 = _dst.bin, _dst.wl, _dst.wu, _dst.c[1]
+    rbin, wl, wu, cos = _dst.bin, _dst.wl, _dst.wu, _dst.c
 
-    c0l = np.append(c0, 0)
-    c2l = np.append(c2, 0)
-    c0u = np.append(c0[1:], [0, 0])
-    c2u = np.append(c2[1:], [0, 0])
+    # 0th order (isotropic)
+    IM = (wl * np.append(c[0], [0])[rbin] +  # lower bins
+          wu * np.append(c[0][1:], [0, 0])[rbin])  # upper bins
+    # add all other orders
+    for cn, cosn in zip(c[1:], cos[1:]):
+        IM += (wl * np.append(cn, [0])[rbin] +
+               wu * np.append(cn[1:], [0, 0])[rbin]) * cosn
+    # (weighting for each order is somehow faster than processing lower and
+    #  upper bins separately and then combining)
 
-    return wl * (c0l[rbin] + c2l[rbin] * cos2) + \
-           wu * (c0u[rbin] + c2u[rbin] * cos2)
+    return IM
 
 
-def _bs_rbasex(Rmax):
+def _bs_rbasex(Rmax, order, odd):
     """
     Compute radial parts of basis projections for R and radii up to Rmax.
     """
-    def psqrt(x):
-        return np.sqrt(x, out=np.zeros_like(x), where=x > 0)
+    # all needed orders (even or all) from 0 to order
+    orders = range(0, order + 1, 1 if odd else 2)
 
-    def plog(x):
-        return np.log(x, out=np.zeros_like(x), where=x > 0)
+    # list of matrces for projections: P[i][R, r] = p_{R:n_i}(r),
+    # sampled at r = 0, ..., R, for R = 0, ..., Rmax and orders n
+    P = [np.eye(Rmax + 1, order='F') for n in orders]  # ('F' is faster here)
+    # (p_{0;0}(0) = 1 indeed, but p_{0;n}(0) = 0 for all other orders,
+    #  so P[i][0, 0] are also set to 1 to make P[i] nondegenerate)
 
-    def F1(n, r, z):
-        if n == 0:
-            return z
-        elif n == 2:
-            return r * np.arctan2(z, r)
+    # fill p_{R>0;0}(0) = 2 (all other p_{R>0;n}(0) = 0 already)
+    P[0][1:, 0] = 2
 
-    def Frho(n, r, z):
-        rho = np.sqrt(r**2 + z**2)
-        if n == 0:
-            return (z * rho + r**2 * plog(z + rho)) / 2
-        elif n == 2:
-            return r**2 * plog(z + rho)
+    # fill all other r > 0 columns (only functions with R >= r are non-zero)
+    for r in range(1, Rmax + 1):
+        # all needed R - 1, R, R + 1 for current r
+        R = np.arange(r - 1, Rmax + 2, dtype=float)
 
-    def Z(R, r):
-        return psqrt(R**2 - r**2)
+        # rho = max(r, R)
+        rho = R.copy()
+        rho[0] = r
 
-    def p(R, n, r):
-        ZR = Z(R, r)
-        ZRm1 = Z(R - 1, r)
-        ZRp1 = Z(R + 1, r)
-        return 2 * (2 * (Frho(n, r, ZR) - R * F1(n, r, ZR)) +
-                    (R - 1) * F1(n, r, ZRm1) - Frho(n, r, ZRm1) +
-                    (R + 1) * F1(n, r, ZRp1) - Frho(n, r, ZRp1))
+        # since z = sqrt(R^2 - r^2) for R >= r, otherwise 0,
+        # it is z = sqrt(max(r, R)^2 - r^2) = sqrt(rho^2 - r^2)
+        z = np.sqrt(rho**2 - r**2)
 
-    r = np.arange(Rmax + 1, dtype=float)
-    P0 = np.empty((Rmax + 1, Rmax + 1))
-    P2 = np.empty((Rmax + 1, Rmax + 1))
-    for R in range(Rmax + 1):
-        P0[R] = p(R, 0, r)
-        P2[R] = p(R, 2, r)
+        f = r / rho  # "f" means "fraction r / rho"
 
-    return P0.T, P2.T
+        rln = r * np.log(z + rho)
+
+        # define F_n for all needed n
+        F = {-1: (z / f + rln) / 2, 0: z}
+        if order >= 1:
+            F[1] = rln
+        if order >= 2:
+            F[2] = r * np.arccos(f)
+        if order >= 3:
+            F[3] = z * f
+        if order >= 4:
+            fn = f.copy()  # current (r / rho)^n
+            for n in range(2, order - 1):  # from 4 - 2 to order - 2
+                fn *= f
+                F[n + 2] = (z * fn + (n - 1) * F[n]) / n
+
+        # compute p_{R;n}(r) for all needed R and n
+        for i, n in enumerate(orders):
+            rFRF = r * F[n - 1] - R * F[n]
+            P[i][r:, r] = 2 * (2 * rFRF[1:-1] - rFRF[2:] - rFRF[:-2])
+            #    R >= r                 at R         R - 1      R + 1
+
+    return P
 
 
-def get_bs_cached(Rmax, direction='inverse'):
+def get_bs_cached(Rmax, order=2, odd=False, direction='inverse'):
     """
     Internal function.
 
@@ -188,21 +223,25 @@ def get_bs_cached(Rmax, direction='inverse'):
     ----------
     Rmax : int
         largest radius to be transformed
+    order : int
+        highest angular order
+    odd : bool
+        include odd angular orders
     direction : str: ``'forward'`` or ``'inverse'``
         type of Abel transform to be performed
 
     Returns
     -------
-    A : tuple of 2D numpy arrays
+    A : list of 2D numpy arrays
         (**Rmax** + 1) × (**Rmax** + 1) matrices of the Abel transform (forward
         or inverse) for each angular order
     """
     global _bs_prm, _bs, _trf, _tri
 
-    prm = [Rmax]
+    prm = [Rmax, order, odd]
     if _bs is None or _bs_prm != prm:
         _bs_prm = prm
-        _bs = _bs_rbasex(Rmax)
+        _bs = _bs_rbasex(Rmax, order, odd)
         _trf = None
         _tri = None
 
@@ -212,11 +251,12 @@ def get_bs_cached(Rmax, direction='inverse'):
         return _trf
     else:  # 'inverse'
         if _tri is None:
-            A0, A2 = _bs
-            A2[0, 0] = 1  # (to avoid degeneracy)
-            Ai0 = inv(A0)
-            Ai2 = inv(A2)
-            _tri = (Ai0, Ai2)
+            # P[n] are triangular, thus can be inverted faster than general
+            # matrices, however, NumPy/SciPy do not have such functions;
+            # nevertheless, solve_triangular() is ~twice faster than inv()
+            # (and ...(Pn, I, lower=True).T is faster than ...(Pn.T, I))
+            I = np.eye(Rmax + 1)
+            _tri = [solve_triangular(Pn, I, lower=True).T for Pn in _bs]
         return _tri
 
 

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -467,11 +467,17 @@ def _load_bs(basis_dir, Rmax, order, odd, inv=False, verbose=False):
         print('Cached basis file incompatible!')
         return None, None
 
-    # pick orders
+    # pick orders parity
     if best_prm['odd'] > odd:  # odd present but not needed
         bs = bs[::2]  # take only even
         if verbose:
             print('(odd orders skipped)')
+    # crop orders
+    if best_prm['order'] > order:
+        n = 1 + (order if odd else order // 2)
+        bs = bs[:n]
+        if verbose:
+            print('(higher orders skipped)')
     # crop to Rmax
     if best_prm['Rmax'] > Rmax:
         bs = [M[:Rmax + 1, :Rmax + 1] for M in bs]

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -365,7 +365,7 @@ def get_bs_cached(Rmax, order=2, odd=False, direction='inverse', reg=None):
 
     if direction == 'forward':
         if _trf is None:
-            _trf = _bs
+            _trf = [Pn.T for Pn in _bs]
         return _trf
     else:  # 'inverse'
         if _tri_prm != [reg]:

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -105,7 +105,8 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
         ``('SVD', strength)``:
             truncated SVD (singular value decomposition) with
             N = `strength` × **rmax** largest singular values removed for each
-            angular order. This mimics the approach proposed in pBasex.
+            angular order. This mimics the approach proposed (but in fact not
+            used) in pBasex. `Not recommended` due to generally poor results.
         ``'pos'``:
             non-parameterized method, finds the best (in the least-squares
             sense) solution with non-negative :math:`\cos^n\theta \sin^m\theta`

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from scipy.linalg import inv
+
+from abel.tools.vmi import Distributions
+from abel.tools.symmetry import put_image_quadrants
+
+###############################################################################
+#
+# rBasex — Abel transform for velocity-map images (~spherical harmonics),
+#          similar to pBasex, but with analytical basis functions and without
+#          pixel-grid transformation; a simplified version of the method
+#          described in M. Ryazanov Ph.D. dissertation.
+#
+# pBasex:
+#   Gustavo A. Garcia, Laurent Nahon, Ivan Powis,
+#   “Two-dimensional charged particle image inversion using a polar basis
+#    function expansion”,
+#   Review of Scientific Instruments 75, 4989 (2004).
+#   http://dx.doi.org/10.1063/1.1807578
+#
+# Ryazanov:
+#   Mikhail Ryazanov,
+#   “Development and implementation of methods for sliced velocity map imaging.
+#    Studies of overtone-induced dissociation and isomerization dynamics of
+#    hydroxymethyl radical (CH₂OH and CD₂OH)”,
+#   Ph.D. dissertation, University of Southern California, 2012.
+#   https://search.proquest.com/docview/1289069738
+#   http://digitallibrary.usc.edu/cdm/ref/collection/p15799coll3/id/112619
+#
+###############################################################################
+
+
+# Caches and their parameters
+_prm = None  # [shape, origin, rmax, weights]
+_dst = None  # Distribution object
+_bs_prm = None  # [Rmax]
+_bs = None  # [P0, P2] — projected functions
+_trf = None  # [Af0, Af2] — forward transform matrices
+_tri = None  # [Ai0, Ai2] — inverse transform matrices
+
+
+def rbasex_transform(IM, origin='center', rmax='MIN',
+                     weights=None, direction='inverse'):
+    """
+    This function takes the input image and outputs its forward or inverse Abel
+    transform as an image and its radial distributions.
+
+    The **origin**, **rmax** and **weights** parameters are passed to
+    :class:`abel.tools.vmi.Distributions`, so see its documentation for their
+    detailed descriptions.
+
+    Parameters
+    ----------
+    IM : m × n numpy array
+        the image to be transformed
+    origin : tuple of int or str
+        image origin, explicit in the (row, column) format, or as a location
+        string
+    rmax : int or string
+        largest radius to include in the transform
+    weights : m × n numpy array, optional
+        weighting factors for each pixel. The array shape must match the image
+        shape. Parts of the image can be excluded from analysis by assigning
+        zero weights to their pixels.
+    direction : str: ``'forward'`` or ``'inverse'``
+        type of Abel transform to be performed
+
+    Returns
+    -------
+    recon : 2D numpy array
+        the transformed image. Is centered and might have different dimensions
+        than the input image.
+    distr : Distributions.Results object
+        the object from which various distributions for the transformed image
+        can be retrieved, see :class:`abel.tools.vmi.Distributions.Results`
+    """
+
+    p0, p2 = _profiles(IM, origin, rmax, weights)
+
+    Rmax = _dst.rmax
+
+    A0, A2 = get_bs_cached(Rmax, direction)
+
+    c0 = A0.dot(p0)
+    c2 = A2.dot(p2)
+
+    distr = Distributions.Results(np.arange(Rmax + 1), np.array([c0, c2]),
+                                  2, False)
+    Q = _image(c0, c2)[::-1]
+    height, width = _dst.Qheight, _dst.Qwidth
+    recon = put_image_quadrants((Q, Q, Q, Q),
+                                (2 * height - 1, 2 * width - 1))
+
+    return recon, distr
+
+
+def _profiles(IM, origin, rmax, weights):
+    """
+    Get radial profiles of cos^n theta terms from the input image.
+    """
+    # the Distributions object is cached to speed up further calculations,
+    # plus its cos^n theta matrices are used later to construct the transformed
+    # image
+    global _prm, _dst
+
+    prm = [IM.shape, origin, rmax, weights]
+    if _prm != prm:
+        _prm = prm
+        _dst = Distributions(origin=origin, rmax=rmax, weights=weights,
+                             use_sin=False, method='linear')
+
+    return _dst(IM).cos()
+
+
+def _image(c0, c2):
+    """
+    Create transformed image from its cos^n theta radial profiles.
+    """
+    rbin, wl, wu, cos2 = _dst.bin, _dst.wl, _dst.wu, _dst.c[1]
+
+    c0l = np.append(c0, 0)
+    c2l = np.append(c2, 0)
+    c0u = np.append(c0[1:], [0, 0])
+    c2u = np.append(c2[1:], [0, 0])
+
+    return wl * (c0l[rbin] + c2l[rbin] * cos2) + \
+           wu * (c0u[rbin] + c2u[rbin] * cos2)
+
+
+def _bs_rbasex(Rmax):
+    """
+    Compute radial parts of basis projections for R and radii up to Rmax.
+    """
+    def psqrt(x):
+        return np.sqrt(x, out=np.zeros_like(x), where=x > 0)
+
+    def plog(x):
+        return np.log(x, out=np.zeros_like(x), where=x > 0)
+
+    def F1(n, r, z):
+        if n == 0:
+            return z
+        elif n == 2:
+            return r * np.arctan2(z, r)
+
+    def Frho(n, r, z):
+        rho = np.sqrt(r**2 + z**2)
+        if n == 0:
+            return (z * rho + r**2 * plog(z + rho)) / 2
+        elif n == 2:
+            return r**2 * plog(z + rho)
+
+    def Z(R, r):
+        return psqrt(R**2 - r**2)
+
+    def p(R, n, r):
+        ZR = Z(R, r)
+        ZRm1 = Z(R - 1, r)
+        ZRp1 = Z(R + 1, r)
+        return 2 * (2 * (Frho(n, r, ZR) - R * F1(n, r, ZR)) +
+                    (R - 1) * F1(n, r, ZRm1) - Frho(n, r, ZRm1) +
+                    (R + 1) * F1(n, r, ZRp1) - Frho(n, r, ZRp1))
+
+    r = np.arange(Rmax + 1, dtype=float)
+    P0 = np.empty((Rmax + 1, Rmax + 1))
+    P2 = np.empty((Rmax + 1, Rmax + 1))
+    for R in range(Rmax + 1):
+        P0[R] = p(R, 0, r)
+        P2[R] = p(R, 2, r)
+
+    return P0.T, P2.T
+
+
+def get_bs_cached(Rmax, direction='inverse'):
+    """
+    Internal function.
+
+    Gets the basis set (from cache or runs computations)
+    and calculates the transform matrix.
+    Loaded/calculated matrices are also cached in memory.
+
+    Parameters
+    ----------
+    Rmax : int
+        largest radius to be transformed
+    direction : str: ``'forward'`` or ``'inverse'``
+        type of Abel transform to be performed
+
+    Returns
+    -------
+    A : tuple of 2D numpy arrays
+        (**Rmax** + 1) × (**Rmax** + 1) matrices of the Abel transform (forward
+        or inverse) for each angular order
+    """
+    global _bs_prm, _bs, _trf, _tri
+
+    prm = [Rmax]
+    if _bs is None or _bs_prm != prm:
+        _bs_prm = prm
+        _bs = _bs_rbasex(Rmax)
+        _trf = None
+        _tri = None
+
+    if direction == 'forward':
+        if _trf is None:
+            _trf = _bs
+        return _trf
+    else:  # 'inverse'
+        if _tri is None:
+            A0, A2 = _bs
+            A2[0, 0] = 1  # (to avoid degeneracy)
+            Ai0 = inv(A0)
+            Ai2 = inv(A2)
+            _tri = (Ai0, Ai2)
+        return _tri
+
+
+def cache_cleanup():
+    """
+    Utility function.
+
+    Frees the memory caches created by ``get_bs_cached()``.
+    This is usually pointless, but might be required after working
+    with very large images, if more RAM is needed for further tasks.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+    """
+    global _prm, _dst, _bs_prm, _bs, _trf, _tri
+
+    _prm = None
+    _dst = None
+    _bs_prm = None
+    _bs = None
+    _trf = None
+    _tri = None

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -102,7 +102,7 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
         ``'SVD'``:
             truncated SVD (singular value decomposition) with
             N = `strength` × **rmax** largest singular values removed for each
-            angular order. This mimics the approach used in pBasex.
+            angular order. This mimics the approach proposed in pBasex.
         ``'pos'``:
             non-parameterized method, finds the best (in the least-squares
             sense) solution with non-negative :math:`\cos^n\theta \sin^m\theta`

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -70,36 +70,39 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
         the image to be transformed
     origin : tuple of int or str
         image origin, explicit in the (row, column) format, or as a location
-        string
+        string (by default, the image center)
     rmax : int or string
-        largest radius to include in the transform
+        largest radius to include in the transform (by default, the largest
+        radius with at least one full quadrant of data)
     order : int
-        highest angular order present in the data, ≥ 0
+        highest angular order present in the data, ≥ 0 (by default, 2)
     odd : bool
-        include odd angular orders (enabled automatically if **order** is odd)
+        include odd angular orders (by default is `False`, but is enabled
+        automatically if **order** is odd)
     weights : m × n numpy array, optional
         weighting factors for each pixel. The array shape must match the image
         shape. Parts of the image can be excluded from analysis by assigning
-        zero weights to their pixels.
+        zero weights to their pixels. By default is `None`, which applies equal
+        weight to all pixels.
     direction : str: ``'forward'`` or ``'inverse'``
-        type of Abel transform to be performed
+        type of Abel transform to be performed (by default, inverse)
     reg : None or str or tuple (str, float), optional
-        regularization to use for inverse Abel transform. ``None`` means no
-        regularization, a string selects a non-parameterized regularization
-        method, and parameterized methods are selected by a tuple (`method`,
-        `strength`). Available methods are:
+        regularization to use for inverse Abel transform. ``None`` (default)
+        means no regularization, a string selects a non-parameterized
+        regularization method, and parameterized methods are selected by a
+        tuple (`method`, `strength`). Available methods are:
 
-        ``'L2'``:
+        ``('L2', strength)``:
             Tikhonov :math:`L_2` regularization with `strength` as the square
             of the Tikhonov factor. This is the same as “Tikhonov
             regularization” used in BASEX, with almost identical effects on the
             radial distributions.
-        ``'diff'``:
+        ``('diff', strength)``:
             Tikhonov regularization with the difference operator (approximation
             of the derivative) multiplied by the square root of `strength` as
             the Tikhonov matrix. This tends to produce less blurring, but more
             negative overshoots than ``'L2'``.
-        ``'SVD'``:
+        ``('SVD', strength)``:
             truncated SVD (singular value decomposition) with
             N = `strength` × **rmax** largest singular values removed for each
             angular order. This mimics the approach proposed in pBasex.
@@ -121,23 +124,24 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
         Tikhonov methods, `strength` ~ 100 is a reasonable value for megapixel
         images. For truncated SVD, `strength` must be < 1; `strength` ~ 0.1 is
         a reasonable value; `strength` ~ 0.5 can produce noticeable ringing
-        artifacts.
+        artifacts. See the :ref:`full description <rBasexmathreg>` and examples
+        there.
     out : str or None
         shape of the output image:
 
         ``'same'`` (default):
             same shape and origin as the input
         ``'fold'`` (fastest):
-            Q0 quadrant (for ``odd=False``) or right half (for ``odd=True``) up
-            to **rmax**, but limited to the largest input-image quadrant (or
-            half)
+            Q0 (upper right) quadrant (for ``odd=False``) or right half (for
+            ``odd=True``) up to **rmax**, but limited to the largest
+            input-image quadrant (or half)
         ``'unfold'``:
-            like ``'fold'``, but symmetrically “unfolded”
+            like ``'fold'``, but symmetrically “unfolded” to all 4 quadrants
         ``'full'``:
             all pixels with radii up to **rmax**
         ``'full-unique'``:
-            the unique part of ``'full'``: Q0 quadrant for ``odd=False``, right
-            half for ``odd=True``
+            the unique part of ``'full'``: Q0 (upper right) quadrant for
+            ``odd=False``, right half for ``odd=True``
         ``None``:
             no image (**recon** will be ``None``). Can be useful to avoid
             unnecessary calculations when only the transformed radial
@@ -146,9 +150,10 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
         path to the directory for saving / loading the basis set (useful only
         for the inverse transform without regularization; time savings in other
         cases are small and might be negated by the disk-access overhead).
-        If ``None``, the basis set will not be loaded from or saved to disk.
+        If ``None`` (default), the basis set will not be loaded from or saved
+        to disk.
     verbose : bool
-        print information about processing (for debugging)
+        print information about processing (for debugging), disabled by default
 
     Returns
     -------

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -306,8 +306,8 @@ def _get_image_bs(height, width, row, verbose):
         # arrays of r^2 and r
         r2 = x**2 + y2
         r = np.sqrt(r2)
-        # radial bins
-        rbin = r.astype(int)  # round down (floor)
+        # radial bins (as "indexing integers")
+        rbin = r.astype(np.intp)  # round down (floor)
         rbin[rbin > rmax] = rmax + 1  # last bin is then discarded
         # weights for upper and lower bins
         wu = r - rbin
@@ -692,15 +692,15 @@ def get_bs_cached(Rmax, order=2, odd=False, direction='inverse', reg=None,
                     raise ValueError('Wrong SVD truncation factor {} > 1'.
                                      format(reg[1]))
                 # truncation index (smallest SV of P -> largest SV of inverse)
-                rmax = int((1 - reg[1]) * Rmax) + 1
+                smax = int((1 - reg[1]) * Rmax) + 1
                 _tri = []
                 # loop over angular orders
                 for An in Af():
                     U, s, Vh = svd(An.T)
                     # truncate matrices
-                    U = U[:, :rmax]
-                    s = 1 / s[:rmax]  # inverse
-                    Vh = Vh[:rmax]
+                    U = U[:, :smax]
+                    s = 1 / s[:smax]  # inverse
+                    Vh = Vh[:smax]
                     # regularized inverse for this angular order
                     _tri.append((U * s).dot(Vh))
             else:

--- a/abel/tests/test_rbasex.py
+++ b/abel/tests/test_rbasex.py
@@ -1,13 +1,15 @@
+#!/usr/bin/python3
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_less
 
 import abel
-from abel.rbasex import rbasex_transform
+from abel.rbasex import rbasex_transform, cache_cleanup
 from abel.tools.analytical import GaussianAnalytical
+from abel.hansenlaw import hansenlaw_transform
 
 
 def test_rbasex_shape():
@@ -64,7 +66,155 @@ def test_rbasex_gaussian():
                     rtol=0.02, atol=1e-4)
 
 
+def run_orders(odd=False):
+    """
+    Test angular orders using Gaussian peaks by comparison with hansenlaw.
+    """
+    maxorder = 6
+    sigma = 5.0  # Gaussian sigma
+    step = 6 * sigma  # distance between peak centers
+
+    for order in range(maxorder + 1):
+        rmax = int((order + 2) * step)
+        if odd:
+            if order == 0:
+                continue  # 0th order cannot be odd
+            height = 2 * rmax + 1
+        else:  # even only
+            if order % 2:
+                continue  # skip odd
+            height = rmax + 1
+        # coordinates (Q0 or right half):
+        x = np.arange(float(rmax + 1))
+        y = rmax - np.arange(float(height))[:, None]
+        # radius
+        r = np.sqrt(x**2 + y**2)
+        # cos, sin
+        r[rmax, 0] = np.inf
+        c = y / r
+        s = x / r
+        r[rmax, 0] = 0
+
+        # Gaussian peak with one cossin angular term
+        def peak(i):
+            m = i  # cos power
+            k = (order - m) & ~1  # sin power (round down to even)
+            return c ** m * s ** k * \
+                   np.exp(-(r - (i + 1) * step) ** 2 / (2 * sigma**2))
+
+        # create source distribution
+        src = peak(0)
+        for i in range(1, order + 1):
+            if not odd and i % 2:
+                continue  # skip odd
+            src += peak(i)
+
+        # reference forward transform
+        abel = hansenlaw_transform(src, direction='forward', hold_order=1)
+
+        param = ', order = {}, odd = {}, '.format(order, odd)
+
+        # test forward transform
+        for mode in ['clean', 'cached']:
+            if mode == 'clean':
+                cache_cleanup()
+            proj, _ = rbasex_transform(src, origin=(rmax, 0),
+                                       order=order, odd=odd,
+                                       direction='forward', out='fold')
+            assert_allclose(proj, abel, rtol=0.003, atol=0.4,
+                            err_msg='-> forward' + param + mode)
+
+        # test inverse transforms
+        for reg in [None, ('L2', 1), ('diff', 1), ('SVD', 1 / rmax)]:
+            for mode in ['clean', 'cached']:
+                if mode == 'clean':
+                    cache_cleanup()
+                recon, _ = rbasex_transform(abel, origin=(rmax, 0),
+                                            order=order, odd=odd,
+                                            reg=reg, out='fold')
+                recon[rmax-2:rmax+3, :2] = 0  # exclude pixels near center
+                assert_allclose(recon, src, atol=0.03,
+                                err_msg='-> reg = ' + str(reg) + param + mode)
+
+
+def test_rbasex_orders():
+    run_orders()
+
+
+def test_rbasex_orders_odd():
+    run_orders(odd=True)
+
+
+def test_rbasex_pos():
+    """
+    Test positive regularization as in run_orders().
+    """
+    sigma = 5.0  # Gaussian sigma
+    step = 6 * sigma  # distance between peak centers
+
+    for order in [0, 1, 2, 4, 6]:
+        rmax = int((order + 2) * step)
+        if order == 1:  # odd
+            rmax += int(step)  # 3 peaks instead of 2
+            height = 2 * rmax + 1
+        else:  # even only
+            height = rmax + 1
+        # coordinates (Q0 or right half):
+        x = np.arange(float(rmax + 1))
+        y = rmax - np.arange(float(height))[:, None]
+        # radius
+        r = np.sqrt(x**2 + y**2)
+        # cos, sin
+        r[rmax, 0] = np.inf
+        c = y / r
+        s = x / r
+        r[rmax, 0] = 0
+
+        # Gaussian peak with one cossin angular term
+        def peak(i, isotropic=False):
+            if isotropic:
+                return np.exp(-(r - (i + 1) * step) ** 2 / (2 * sigma**2))
+            m = i  # cos power
+            k = (order - m) & ~1  # sin power (round down to even)
+            return c ** m * s ** k * \
+                   np.exp(-(r - (i + 1) * step) ** 2 / (2 * sigma**2))
+
+        # create source distribution
+        src = peak(0)
+        if order == 1:  # special case
+            src += (1 + c) * peak(1, True)  # 1 + cos >= 0
+            src += (1 - c) * peak(2, True)  # 1 - cos >= 0
+        else:  # other even orders
+            for i in range(2, order + 1, 2):
+                src += peak(i)
+        # array for nonnegativity test (with some tolerance)
+        zero = np.full_like(src, -1e-15)
+
+        # reference forward transform
+        abel = hansenlaw_transform(src, direction='forward', hold_order=1)
+        # with some noise
+        abel += 0.05 * np.random.RandomState(0).rand(*abel.shape)
+
+        param = '-> order = {}, '.format(order)
+
+        # test inverse transform
+        for mode in ['clean', 'cached']:
+            if mode == 'clean':
+                cache_cleanup()
+            recon, _ = rbasex_transform(abel, origin=(rmax, 0),
+                                        order=order,
+                                        reg='pos', out='fold')
+            recon[rmax-3:rmax+4, :2] = 0  # exclude pixels near center
+            assert_allclose(recon, src, atol=0.05,
+                            err_msg=param + mode)
+            # check nonnegativity
+            assert_array_less(zero, recon)
+
+
 if __name__ == '__main__':
     test_rbasex_shape()
     test_rbasex_zeros()
     test_rbasex_gaussian()
+    test_rbasex_orders()
+    test_rbasex_orders_odd()
+    test_rbasex_pos()

--- a/abel/tests/test_rbasex.py
+++ b/abel/tests/test_rbasex.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import abel
+from abel.rbasex import rbasex_transform
+from abel.tools.analytical import GaussianAnalytical
+
+
+def test_rbasex_shape():
+    rmax = 11
+    n = 2 * rmax - 1
+    im = np.ones((n, n), dtype='float')
+
+    fwd_im, fwd_distr = rbasex_transform(im, direction='forward')
+    assert fwd_im.shape == (n, n)
+    assert fwd_distr.r.shape == (rmax,)
+
+    inv_im, inv_distr = rbasex_transform(im)
+    assert inv_im.shape == (n, n)
+    assert inv_distr.r.shape == (rmax,)
+
+
+def test_rbasex_zeros():
+    rmax = 11
+    n = 2 * rmax - 1
+    im = np.zeros((n, n), dtype='float')
+
+    fwd_im, fwd_distr = rbasex_transform(im, direction='forward')
+    assert fwd_im.shape == (n, n)
+    assert fwd_distr.r.shape == (rmax,)
+
+    inv_im, inv_distr = rbasex_transform(im)
+    assert inv_im.shape == (n, n)
+    assert inv_distr.r.shape == (rmax,)
+
+
+def test_rbasex_gaussian():
+    """Check an isotropic gaussian solution for rBasex"""
+    rmax = 100
+    sigma = 30
+    n = 2 * rmax - 1
+
+    ref = GaussianAnalytical(n, rmax, symmetric=True, sigma=sigma)
+    # images as direct products
+    src = ref.func * ref.func[:, None]
+    proj = ref.abel * ref.func[:, None]  # (vertical is not Abel-transformed)
+
+    fwd_im, fwd_distr = rbasex_transform(src, direction='forward')
+    # whole image
+    assert_allclose(fwd_im, proj, rtol=0.02, atol=0.001)
+    # radial intensity profile (without r = 0)
+    assert_allclose(fwd_distr.harmonics()[0, 1:], ref.abel[rmax:],
+                    rtol=0.02, atol=5e-4)
+
+    inv_im, inv_distr = rbasex_transform(proj)
+    # whole image
+    assert_allclose(inv_im, src, rtol=0.02, atol=0.02)
+    # radial intensity profile (without r = 0)
+    assert_allclose(inv_distr.harmonics()[0, 1:], ref.func[rmax:],
+                    rtol=0.02, atol=1e-4)
+
+
+if __name__ == '__main__':
+    test_rbasex_shape()
+    test_rbasex_zeros()
+    test_rbasex_gaussian()

--- a/abel/tests/test_tools_distributions.py
+++ b/abel/tests/test_tools_distributions.py
@@ -53,7 +53,7 @@ def run_order(method, tol):
 
         # Gaussian peak with one cossin angular term.
         def peak(i):
-            return c2 ** (n - i) * s2 ** i * \
+            return c2 ** i * s2 ** (n - i) * \
                    np.exp(-(r - (i + 1) * step) ** 2 / (2 * sigma**2))
 
         # quadrant with all peaks
@@ -76,15 +76,15 @@ def run_order(method, tol):
 
 
 def test_order_nearest():
-    run_order('nearest', [0.0018, 0.0020, 0.0019, 0.0022, 0.0055])
+    run_order('nearest', [0.0018, 0.0018, 0.0022, 0.0062, 0.020])
 
 
 def test_order_linear():
-    run_order('linear', [0.0031, 0.0033, 0.0034, 0.0034, 0.011])
+    run_order('linear', [0.0031, 0.0034, 0.0034, 0.0067, 0.029])
 
 
 def test_order_remap():
-    run_order('remap', [5e-6, 6e-6, 7e-6, 8e-6, 2e-5])
+    run_order('remap', [5e-6, 6e-6, 6e-6, 2e-5, 7e-5])
 
 
 def run_order_odd(method, tol):
@@ -111,7 +111,7 @@ def run_order_odd(method, tol):
 
         # Gaussian peak with one cossin angular term
         def peak(i):
-            m = n - i  # cos power
+            m = i  # cos power
             k = (n - m) & ~1  # sin power (round down to even)
             return c ** m * s ** k * \
                    np.exp(-(r - (i + 1) * step) ** 2 / (2 * sigma**2))
@@ -137,15 +137,15 @@ def run_order_odd(method, tol):
 
 
 def test_order_odd_nearest():
-    run_order_odd('nearest', [0.0018, 0.0020, 0.0020, 0.0019, 0.0019])
+    run_order_odd('nearest', [0.0018, 0.0018, 0.0018, 0.0018, 0.0020])
 
 
 def test_order_odd_linear():
-    run_order_odd('linear', [0.0032, 0.0033, 0.0034, 0.0034, 0.0035])
+    run_order_odd('linear', [0.0032, 0.0034, 0.0034, 0.0034, 0.0035])
 
 
 def test_order_odd_remap():
-    run_order_odd('remap', [5e-6, 5e-6, 6e-6, 7e-6, 7e-6])
+    run_order_odd('remap', [5e-6, 5e-6, 6e-6, 6e-6, 6e-6])
 
 
 def run_method(method, rmax, tolP0, tolP2, tolI, tolbeta, weq=True):

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -980,6 +980,9 @@ class Distributions(object):
             self.C = np.array([invn(hankel(p[:self.N], p[self.N - 1:]))
                                for p in pc])
 
+        # valid radii
+        self.valid = (self.C[:, 0, 0] != 0)
+
         self.ready = True
 
     class Results(object):
@@ -1025,14 +1028,21 @@ class Distributions(object):
             sine powers :math:`m` in the :math:`\cos^n\theta \cdot
             \sin^m\theta` terms from :meth:`cossin`; cosine powers :math:`n`
             are given by :attr:`orders` (see above)
+        valid : bool array
+            flags for each radius indicating whether it has valid data (radii
+            that have zero weights for all pixels will have no valid data)
         """
-        def __init__(self, r, cn, order, odd):
+        def __init__(self, r, cn, order, odd, valid=None):
             self.r = r
             self.cn = cn
             self.order = order
             self.odd = odd
             self.orders = list(range(0, order + 1, 1 if odd else 2))
             self.sinpowers = [(order - n) & ~1 for n in self.orders]
+            if valid is None:
+                self.valid = np.full_like(r, True)
+            else:
+                self.valid = valid
 
         def cos(self):
             r"""
@@ -1307,7 +1317,7 @@ class Distributions(object):
         # radii
         r = np.arange(self.rmax + 1)
 
-        return self.Results(r, I, self.order, self.odd)
+        return self.Results(r, I, self.order, self.odd, self.valid)
 
     def __call__(self, IM):
         return self.image(IM)

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -676,8 +676,11 @@ class Distributions(object):
         row_ = height - 1 - row
         col_ = width - 1 - col
         # min/max spans
-        hor, HOR = min(col, col_), max(col, col_)
         ver, VER = min(row, row_), max(row, row_)
+        hor, HOR = min(col, col_), max(col, col_)
+
+        # save these values for rbasex
+        self.row, self.col, self.VER, self.HOR = row, col, VER, HOR
 
         # Determine rmax.
         rmax_in = self.rmax_in

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -1007,12 +1007,23 @@ class Distributions(object):
         ----------
         r : numpy array
             radii from 0 to **rmax**
+        order : int
+            highest order in the angular distributions
+        odd : bool
+            whether odd angular orders are present
+        orders : list of int
+            orders for all angular terms:
+
+                [0, 2, ..., **order**] for **odd** = ``False``,
+
+                [0, 1, 2, ..., **order**] for **odd** = ``True``
         """
         def __init__(self, r, cn, order, odd):
             self.r = r
             self.cn = cn
             self.order = order
             self.odd = odd
+            self.orders = list(range(0, order + 1, 1 if odd else 2))
 
         def cos(self):
             r"""

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -785,11 +785,11 @@ class Distributions(object):
             # array of r
             r = np.sqrt(r2)
 
-            # Radial bins.
+            # Radial bins (as "indexing integers").
             if self.method == 'nearest':
-                self.bin = np.array(r.round(), dtype=int)
+                self.bin = r.round().astype(np.intp)
             else:  # 'linear'
-                self.bin = r.astype(int)  # round down (floor)
+                self.bin = r.astype(np.intp)  # round down (floor)
             self.bin[self.bin > rmax] = rmax + 1  # last bin is then discarded
 
             # Powers of cosine.

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -15,13 +15,14 @@ from . import direct
 from . import hansenlaw
 from . import linbasex
 from . import onion_bordas
+from . import rbasex
 from . import tools
 
 from abel import _deprecated, _deprecate
 
 
 class Transform(object):
-    """
+    r"""
     Abel transform image class.
 
     This class provides whole-image forward and inverse Abel
@@ -49,24 +50,29 @@ class Transform(object):
         specifies which numerical approximation to the Abel transform should be
         employed (see below). The options are
 
-        ``hansenlaw``
-            the recursive algorithm described by Hansen and Law.
         ``basex``
             the Gaussian "basis set expansion" method of Dribinski et al.
+            (2002).
         ``direct``
             a naive implementation of the analytical formula by Roman Yurchuk.
-        ``two_point``
-            the two-point transform of Dasch (1992).
-        ``three_point``
-            the three-point transform of Dasch (1992).
+        ``hansenlaw``
+            the recursive algorithm described by Hansen and Law (1985).
+        ``linbasex``
+            the 1D projections of velocity-mapping images in terms of 1D
+            spherical functions by Gerber et al. (2013).
         ``onion_bordas``
             the algorithm of Bordas and co-workers (1996),
             re-implemented by Rallis, Wells and co-workers (2014).
         ``onion_peeling``
             the onion peeling deconvolution as described by Dasch (1992).
-        ``linbasex``
-            the 1D projections of velocity-mapping images in terms of 1D
-            spherical functions by Gerber et al. (2013).
+        ``rbasex``
+            a method similar to pBasex by Garcia et al. (2004) for
+            velocity-mapping images, but with analytical basis functions
+            developed by Ryazanov (2012).
+        ``three_point``
+            the three-point transform of Dasch (1992).
+        ``two_point``
+            the two-point transform of Dasch (1992).
 
     origin : tuple or str
         Before applying Abel transform, the image is centered around this
@@ -204,17 +210,6 @@ class Transform(object):
     be reloaded, meaning that future transforms are performed much more
     quickly.
 
-    ``hansenlaw``
-        This "recursive algorithm" produces reliable results and is quite fast
-        (~0.1 s for a 1001×1001 image). It makes no assumptions about the data
-        (apart from cylindrical symmetry). It tends to require that the data is
-        finely sampled for good convergence.
-
-        E. W. Hansen, P.-L. Law,
-        "Recursive methods for computing the Abel transform and its inverse",
-        `J. Opt. Soc. Am. A 2, 510–520 (1985)
-        <https://dx.doi.org/10.1364/JOSAA.2.000510>`_.
-
     ``basex`` *
         The "basis set exapansion" algorithm describes the data in terms of
         gaussian-like functions, which themselves can be Abel-transformed
@@ -236,6 +231,17 @@ class Transform(object):
         converge. Such methods are typically inefficient, but thanks to this
         Cython implementation (by Roman Yurchuk), this "direct" method is
         competitive with the other methods.
+
+    ``hansenlaw``
+        This "recursive algorithm" produces reliable results and is quite fast
+        (~0.1 s for a 1001×1001 image). It makes no assumptions about the data
+        (apart from cylindrical symmetry). It tends to require that the data is
+        finely sampled for good convergence.
+
+        E. W. Hansen, P.-L. Law,
+        "Recursive methods for computing the Abel transform and its inverse",
+        `J. Opt. Soc. Am. A 2, 510–520 (1985)
+        <https://dx.doi.org/10.1364/JOSAA.2.000510>`_.
 
     ``linbasex`` *
         Velocity-mapping images are composed of projected Newton spheres with
@@ -279,9 +285,30 @@ class Transform(object):
         is the onion peeling algorithm as described by Dasch (1992), reference
         below.
 
-    ``two_point`` *
-        Another Dasch method. Simple, and fast, but not as accurate as the
-        other methods.
+    ``rbasex`` *
+        The pBasex method by
+        G. A. Garcia, L. Nahon, I. Powis,
+        “Two-dimensional charged particle image inversion using a polar basis
+        function expansion”,
+        `Rev. Sci. Instrum. 75, 4989–2996 (2004)
+        <http://dx.doi.org/10.1063/1.1807578>`_
+        adapts the BASEX ("basis set expansion") method to the specific case of
+        velocity-mapping images by using a basis of 2D functions in polar
+        coordinates, such that the reconstructed radial distributions are
+        obtained directly from the expansion coefficients.
+
+        This method employs the same approach, but uses more convenient basis
+        functions, which have analytical Abel transforms separable into radial
+        and angular parts, developed in
+        M. Ryazanov,
+        “Development and implementation of methods for sliced velocity map
+        imaging. Studies of overtone-induced dissociation and isomerization
+        dynamics of hydroxymethyl radical (CH\ :sub:`2`\ OH and
+        CD\ :sub:`2`\ OH)”,
+        Ph.D. dissertation, University of Southern California, 2012
+        (`ProQuest <https://search.proquest.com/docview/1289069738>`_,
+        `USC <http://digitallibrary.usc.edu/cdm/ref/collection/p15799coll3/id/
+        112619>`_).
 
     ``three_point`` *
         The "Three Point" Abel transform method exploits the observation that
@@ -295,6 +322,10 @@ class Transform(object):
         filtered backprojection methods",
         `Appl. Opt. 31, 1146–1152 (1992)
         <https://doi.org/10.1364/AO.31.001146>`_.
+
+    ``two_point`` *
+        Another Dasch method. Simple, and fast, but not as accurate as the
+        other methods.
 
     The following class attributes are available, depending on the calculation.
 
@@ -338,6 +369,9 @@ class Transform(object):
         with ``method=linbasex, transform_options=dict(return_Beta=True)``:
         radial projection profiles at angles **proj_angles**
 
+    distr : Distributions.Results object
+        with ``method=rbasex``: the object from which various radial
+        distributions can be retrieved
     """
 
     _verbose = False
@@ -386,7 +420,7 @@ class Transform(object):
     def _verify_some_inputs(self):
         if self.IM.ndim == 1 or np.shape(self.IM)[0] <= 2:
             raise ValueError('Data must be 2-dimensional. \
-                              To transform a single row \
+                              To transform a single row, \
                               use the individual transform function.')
 
         if not np.any(self._use_quadrants):
@@ -405,31 +439,28 @@ class Transform(object):
                                                 **center_options)
 
     def _abel_transform_image(self, **transform_options):
-        if self.method == "linbasex" and self._symmetry_axis is not None:
-            self._abel_transform_image_full(**transform_options)
-        else:
-            self._abel_transform_image_by_quadrant(**transform_options)
-
-    def _abel_transform_image_full(self, **transform_options):
-
-        abel_transform = {
-            # "basex": basex.basex_transform,
-            "linbasex": linbasex.linbasex_transform_full
-        }
-        t0 = time.time()
-
         self._verboseprint('Calculating {0} Abel transform using {1} method -'
                           .format(self.direction, self.method),
                           '\n    image size: {:d}x{:d}'.format(*self.IM.shape))
+        t0 = time.time()
 
-        self.transform, radial, Beta, QLz = abel_transform[self.method](self.IM,
-                                                   **transform_options)
+        if self.method == "linbasex" and self._symmetry_axis is not None:
+            self._abel_transform_image_full_linbasex(**transform_options)
+        elif self.method == "rbasex":
+            self._abel_transform_image_full_rbasex(**transform_options)
+        else:
+            self._abel_transform_image_by_quadrant(**transform_options)
 
-        self._verboseprint("{:.2f} seconds".format(time.time()-t0))
+        self._verboseprint("{:.2f} seconds".format(time.time() - t0))
 
-        self.Beta = Beta
-        self.projection = QLz
-        self.radial = radial
+    def _abel_transform_image_full_linbasex(self, **transform_options):
+        self.transform, self.radial, self.Beta, self.projection = \
+            linbasex.linbasex_transform_full(self.IM, **transform_options)
+
+    def _abel_transform_image_full_rbasex(self, **transform_options):
+        self.transform, self.distr = \
+            rbasex.rbasex_transform(self.IM, direction=self.direction,
+                                    **transform_options)
 
     def _abel_transform_image_by_quadrant(self, **transform_options):
 

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -397,9 +397,11 @@ class Transform(object):
         self.direction = direction
 
         # private internal variables
+        self._origin = origin
         self._symmetry_axis = symmetry_axis
         self._symmetrize_method = symmetrize_method
         self._use_quadrants = use_quadrants
+        self._transform_options = transform_options
         self._recast_as_float64 = recast_as_float64
         _verbose = verbose
 
@@ -419,9 +421,9 @@ class Transform(object):
 
     def _verify_some_inputs(self):
         if self.IM.ndim == 1 or np.shape(self.IM)[0] <= 2:
-            raise ValueError('Data must be 2-dimensional. \
-                              To transform a single row, \
-                              use the individual transform function.')
+            raise ValueError('Data must be 2-dimensional. '
+                             'To transform a single row, '
+                             'use the individual transform function.')
 
         if not np.any(self._use_quadrants):
             raise ValueError('No image quadrants selected to use')
@@ -429,6 +431,19 @@ class Transform(object):
         if not isinstance(self._symmetry_axis, (list, tuple)):
             # if the user supplies an int, make it into a 1-element list:
             self._symmetry_axis = [self._symmetry_axis]
+
+        if self.method == 'rbasex' and self._origin != 'none':
+            if self._transform_options.get('origin') is not None:
+                raise ValueError('Either use the "origin" argument to center '
+                                 'the image, or pass "origin" to rbasex in '
+                                 '"transform_options" to use the image as '
+                                 'is, but don\'t do both.')
+            if self._transform_options.get('weights') is not None:
+                raise ValueError('Using the "origin" argument will center '
+                                 'the image but not the "weights" array '
+                                 'passed to rbasex. If you want to specify '
+                                 'the image origin, pass it in '
+                                 '"transform_options".')
 
         if self._recast_as_float64:
             self.IM = self.IM.astype('float64')

--- a/doc/abel.rst
+++ b/doc/abel.rst
@@ -26,6 +26,14 @@ abel.linbasex module
     :undoc-members:
     :show-inheritance:
 
+abel.rbasex module
+------------------
+
+.. automodule:: abel.rbasex
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 abel.hansenlaw module
 ---------------------
 

--- a/doc/anisotropy_parameter.rst
+++ b/doc/anisotropy_parameter.rst
@@ -17,7 +17,7 @@ Methods
 
    Method 1: :doc:`linbasex <transform_methods/linbasex>` evaluates :math:`\beta` directly, available as the class attribute `Beta[1]`.
 
-       This method fits spherical harmonic functions to the velocity-map image to directly determine the anisotropy parameter as a function of the radial coordinate. This parameter has greater uncertainty in radial regions of low intensity, and so it is commonly plotted as the product :math:`I \times \beta`.  See ``examples/example_linbasex.py``.
+       This method fits spherical harmonic functions to the velocity-map image to directly determine the anisotropy parameter as a function of the radial coordinate. This parameter has greater uncertainty in radial regions of low intensity, and so it is commonly plotted as the product :math:`I \times \beta`.  See :doc:`example_linbasex`.
 
    .. image:: https://cloud.githubusercontent.com/assets/10932229/17164544/94adacdc-540c-11e6-955a-c5c9092943cc.png
       :width: 600px
@@ -46,6 +46,8 @@ See :doc:`example_anisotropy_parameter`. In this case the anisotropy parameter i
    * In method 3, the anisotropy parameter is calculated with 9-pixel radial averaging and plotted only in the regions with > 1 % of the maximal intensity.
 
 .. plot:: ../examples/example_anisotropy_parameter.py 
+
+A demonstration of using :class:`~abel.tools.vmi.Distributions` for incomplete images is also included in :doc:`example_rbasex_block`.
 
 
 Reference

--- a/doc/example_rbasex_block.rst
+++ b/doc/example_rbasex_block.rst
@@ -1,0 +1,6 @@
+Example: rBasex beam block
+==========================
+
+
+.. plot:: ../examples/example_rbasex_block.py
+   :include-source:

--- a/doc/example_rbasex_multimass.rst
+++ b/doc/example_rbasex_multimass.rst
@@ -1,0 +1,6 @@
+Example: rBasex multimass
+=========================
+
+
+.. plot:: ../examples/example_rbasex_multimass.py
+   :include-source:

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -6,7 +6,6 @@ Contents:
    :maxdepth: 2
 
    example_direct_gaussian
-   example_hansenlaw
    example_O2_PES_PAD
    example_hansenlaw
    example_hansenlaw_Xe
@@ -17,5 +16,6 @@ Contents:
    example_dasch_methods
    example_onion_bordas
    example_linbasex
+   example_rbasex_block
    example_anisotropy_parameter
    example_circularize_image

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -17,5 +17,6 @@ Contents:
    example_onion_bordas
    example_linbasex
    example_rbasex_block
+   example_rbasex_multimass
    example_anisotropy_parameter
    example_circularize_image

--- a/doc/transform_methods.rst
+++ b/doc/transform_methods.rst
@@ -23,9 +23,11 @@ The numerical Abel transform is computationally intensive, and a basic numerical
 
     8. ``*`` The :doc:`linbasex <transform_methods/linbasex>` 1D-spherical basis method of Gerber et al. evaluates 1D projections of velocity-map images in terms of 1D projections of spherical functions. The results produce directly the coefficients of the involved spherical functions, making the reconstruction of sliced Newton spheres obsolete.
 
-    9. (Planned implementation) The :doc:`Fourier–Hankel <transform_methods/fh>` method, which is computationally efficient, but contains significant centerline noise and is known to introduce artifacts. 
+    9. ``*`` The :doc:`rbasex <transform_methods/rbasex>` method is based on the pBasex method of Garcia et al. and basis functions developed by Ryazanov. Evaluates radial distributions of velocity-map images and transforms them to radial distributions of the reconstructed 3D distributions.
 
-    10. (Planned implementation) The :doc:`POP <transform_methods/pop>` (polar onion peeling) method. POP projects the image onto a basis set of Legendre polynomial-based functions, which can greatly reduce the noise in the reconstruction. However, this method only applies to images that contain features at constant radii. I.e., it works for the spherical shells seen in photoelectron/ion spectra, but not for flames.
+    10. (Planned implementation) The :doc:`Fourier–Hankel <transform_methods/fh>` method, which is computationally efficient, but contains significant centerline noise and is known to introduce artifacts.
+
+    11. (Planned implementation) The :doc:`POP <transform_methods/pop>` (polar onion peeling) method. POP projects the image onto a basis set of Legendre polynomial-based functions, which can greatly reduce the noise in the reconstruction. However, this method only applies to images that contain features at constant radii. I.e., it works for the spherical shells seen in photoelectron/ion spectra, but not for flames.
 
     ``*`` Methods marked with an asterisk require the generation of basis sets. The first time each method is run for a specific image size, a basis set must be generated, which can take several seconds or minutes. However, this basis set is saved to disk (generally to the current directory) and can be reused, making subsequent transforms very efficient. Users who are transforming numerous images using these methods will want to keep this in mind and specify the directory containing the basis sets.
 
@@ -36,13 +38,16 @@ Contents:
    :maxdepth: 2
    
    transform_methods/comparison
+
    transform_methods/basex
    transform_methods/direct
    transform_methods/hansenlaw
    transform_methods/linbasex
-   transform_methods/two_point
-   transform_methods/three_point
-   transform_methods/onion_peeling
    transform_methods/onion_bordas
+   transform_methods/onion_peeling
+   transform_methods/rbasex
+   transform_methods/three_point
+   transform_methods/two_point
+
    transform_methods/pop
    transform_methods/fh

--- a/doc/transform_methods/rbasex-SVD.py
+++ b/doc/transform_methods/rbasex-SVD.py
@@ -1,0 +1,63 @@
+from __future__ import division, print_function
+
+import numpy as np
+from scipy.linalg import inv, svd
+import matplotlib.pyplot as plt
+
+from abel.rbasex import _bs_rbasex
+
+Rmax = 40
+
+# SVD for 0th-order inverse Abel transform
+P, = _bs_rbasex(Rmax, 0, False)
+A = inv(P.T)
+V, s, UT = svd(A)
+
+# setup x axis
+def setx():
+  plt.xlim((0, Rmax))
+  plt.xticks([0, 1/4 * Rmax, 1/2 * Rmax, 3/4 * Rmax, Rmax],
+             ['$0$', '', '', '', '$r_{\\rm max}$'])
+
+# plot i-th +- 0, 1 singular vectors
+def plotu(i, title):
+  plt.title('$\\mathbf{v}_i,\\quad i = ' + title + '$')
+  i = int(i)
+  plt.plot(V[:, i - 1], '#DD0000')
+  plt.plot(V[:, i], '#00AA00')
+  plt.plot(V[:, i + 1], '#0000FF')
+  setx()
+
+fig = plt.figure(figsize=(6, 6), frameon=False)
+
+# singular values
+plt.subplot(321)
+plt.title('$\\sigma_i$')
+plt.plot(s, 'k')
+setx()
+plt.ylim(bottom=0)
+
+# vectors near 0
+plt.subplot(322)
+plotu(1, '0, 1, 2')
+
+# vectors near 1/4
+plt.subplot(323)
+plotu(1/4 * Rmax, '\\frac{1}{4} r_{\\rm max} \\pm 0, 1')
+
+# vectors near middle
+plt.subplot(324)
+plotu(1/2 * Rmax, '\\frac{1}{2} r_{\\rm max} \\pm 0, 1')
+
+# vectors near 3/4
+plt.subplot(325)
+plotu(3/4 * Rmax, '\\frac{3}{4} r_{\\rm max} \\pm 0, 1')
+
+# vectors near end
+plt.subplot(326)
+plotu(Rmax - 1, 'r_{\\rm max} - 2, 1, 0')
+
+plt.tight_layout()
+
+#plt.savefig('rbasex-SVD.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-bR.py
+++ b/doc/transform_methods/rbasex-bR.py
@@ -1,0 +1,29 @@
+from __future__ import print_function, division
+
+import matplotlib.pyplot as plt
+
+R = 4
+
+fig = plt.figure(figsize=(4, 2), frameon=False)
+
+ax = plt.gca()
+ax.spines['top'].set_visible(False)
+ax.spines['right'].set_visible(False)
+
+plt.xlim((0, 2 * R))
+plt.xticks([0, R - 1, R, R + 1], ['$0$', '$R - 1$', '$R$', '$R + 1$'])
+
+plt.ylim((0, 1.1))
+plt.yticks([0, 1], ['0', '1'])
+
+plt.vlines([R], 0, 1, color='lightgray')
+plt.hlines([1], 0, R, color='lightgray')
+
+plt.plot([0, R - 1, R, R + 1, 2 * R],
+         [0,     0, 1,     0,     0],
+         'k')
+
+plt.tight_layout()
+
+#plt.savefig('rbasex-bR.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-coord.py
+++ b/doc/transform_methods/rbasex-coord.py
@@ -13,7 +13,7 @@ lo = 0.5  # label offset
 an = 11  # angle arc segments
 anc = an // 2  # index of central point
 
-fig = plt.figure(figsize=(3, 3)) #??, frameon=False
+fig = plt.figure(figsize=(3, 3), frameon=False)
 ax = fig.gca(projection='3d')
 ax.set_proj_type('ortho')
 ax.view_init(elev=30, azim=45)

--- a/doc/transform_methods/rbasex-coord.py
+++ b/doc/transform_methods/rbasex-coord.py
@@ -1,0 +1,92 @@
+from __future__ import print_function, division
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+
+mpl.rcParams['lines.solid_capstyle'] = 'round'
+
+xmax, ymax, zmax = 6, 7, 6  # axes
+x, y, z = 3, 6, 5  # vector
+lo = 0.5  # label offset
+an = 11  # angle arc segments
+anc = an // 2  # index of central point
+
+fig = plt.figure(figsize=(3, 3)) #??, frameon=False
+ax = fig.gca(projection='3d')
+ax.set_proj_type('ortho')
+ax.view_init(elev=30, azim=45)
+ax.set_axis_off()
+ax.set_xlim(0, zmax)
+ax.set_ylim(0, xmax)
+ax.set_zlim(0, ymax)
+
+sax = {'color': 'k', 'lw': 1, 'arrow_length_ratio': 0.1}  # axes style
+sb = {'c': 'k', 'lw': 0.5}  # "box" style
+sv = {'c': 'k', 'lw': 2}  # vectors style
+sa = {'c': 'k', 'lw': 1}  # angle arcs style
+sl = {'ha': 'center', 'va': 'center'}  # label style
+
+
+# axes
+ax.quiver(0, 0, 0, 0, xmax, 0, **sax); ax.text(lo, xmax, 0, '$x$', **sl)
+ax.quiver(0, 0, 0, 0, 0, ymax, **sax); ax.text(lo, 0, ymax, '$y$', **sl)
+ax.quiver(0, 0, 0, zmax, 0, 0, **sax); ax.text(zmax, lo, 0, '$z$', **sl)
+
+
+# "box"...
+ax.plot([0, 0], [0, x], [y, y], **sb)
+ax.plot([z, z], [0, x], [y, y], **sb)
+ax.plot([z, z], [0, x], [0, 0], **sb)
+
+ax.plot([0, 0], [x, x], [0, y], **sb)
+ax.plot([z, z], [x, x], [0, y], **sb)
+ax.plot([z, z], [0, 0], [0, y], **sb)
+
+ax.plot([0, z], [0, 0], [y, y], **sb)
+ax.plot([0, z], [x, x], [y, y], 'k--')  # "projection"
+ax.plot([0, z], [x, x], [0, 0], **sb)
+
+ax.plot([0, z], [0, x], [0, 0], **sb)
+ax.plot([0, z], [0, x], [y, y], **sb)
+
+
+# 3D vector...
+ax.plot([0, z], [0, x], [0, y], **sv); ax.scatter(z, x, y, c='k')
+# rho
+ax.text(z / 2 + lo / 1.5, x / 2, y / 2 - lo / 1.5, '$\\rho$', **sl)
+
+# theta'
+xz = np.sqrt(x**2 + z**2)
+t = np.linspace(0, np.arctan2(xz, y), an)
+ar = 2  # arc radius
+x_, y_, z_ = ar * x / xz * np.sin(t), ar * np.cos(t), ar * z / xz * np.sin(t)
+ax.plot(z_, x_, y_, **sa)
+ax.text(z_[anc] + lo / 1.5, x_[anc], y_[anc] + lo / 1.5, '$\\theta\'$', **sl)
+
+# phi'
+t = np.linspace(0, np.arctan2(z, x), an)
+ar = 1  # arc radius
+x_, y_, z_ = ar * np.cos(t), 0 * t, ar * np.sin(t)
+ax.plot(z_, x_, y_, **sa)
+ax.text(z_[anc] + lo, x_[anc] + lo, 0, '$\\varphi\'$', **sl)
+
+
+# 2D vector...
+ax.plot([0, 0], [0, x], [0, y], **sv); ax.scatter(0, x, y, c='k')
+# r
+ax.text(0, x / 2 + lo, y / 2, '$r$', **sl)
+
+# theta
+t = np.linspace(0, np.arctan2(x, y), an)
+ar = 1.5  # arc radius
+x_, y_, z_ = ar * np.sin(t), ar * np.cos(t), 0 * t
+ax.plot(z_, x_, y_, **sa)
+ax.text(0, x_[anc] + lo / 3, y_[anc] + lo, '$\\theta$', **sl)
+
+
+plt.tight_layout(pad=0, rect=(-0.1, -0.2, 1.1, 1))
+
+#plt.savefig('rbasex-coord.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-limits.py
+++ b/doc/transform_methods/rbasex-limits.py
@@ -1,0 +1,52 @@
+from __future__ import print_function, division
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+
+R = 5
+r = 2.5
+
+zRm1 = np.sqrt((R - 1)**2 - r**2)
+zR   = np.sqrt( R**2      - r**2)
+zRp1 = np.sqrt((R + 1)**2 - r**2)
+
+fig = plt.figure(figsize=(3.5, 3), frameon=False)
+
+ax = plt.gca()
+ax.set_aspect('equal')
+ax.spines['top'].set_visible(False)
+ax.spines['right'].set_visible(False)
+
+plt.xlim((0, R + 1.5))
+plt.xticks([0, r, R - 1, R, R + 1], ['$0$', '$r$', '$R - 1$', '$R$', '$R + 1$'])
+
+plt.ylim((0, R + 1.5))
+plt.yticks([0, zRm1, zR, zRp1], ['$0$', '$z_{R-1}$', '$z_R$', '$z_{R+1}$'])
+
+t = np.linspace(0, np.pi / 2, 30)
+xy = np.vstack((np.cos(t), np.sin(t)))
+xyRm1 = (R - 1) * xy
+xyR   =  R      * xy
+xyRp1 = (R + 1) * xy
+
+style = {'closed': False, 'lw': 2, 'fill': False, 'ec': 'lightgray'}
+ax.add_patch(Polygon(np.hstack((xyRm1, xyR[::-1])).T, hatch='//', **style))
+ax.add_patch(Polygon(np.hstack((xyR, xyRp1[::-1])).T, hatch='\\\\', **style))
+
+plt.plot(xyRm1[0], xyRm1[1], 'k')
+plt.plot(xyR[0]  , xyR[1]  , 'k')
+plt.plot(xyRp1[0], xyRp1[1], 'k')
+
+plt.plot(r, zRm1, 'ko')
+plt.plot(r, zR  , 'ko')
+plt.plot(r, zRp1, 'ko')
+
+plt.vlines([r], 0, zRp1, lw=2, linestyles='dashed')
+plt.hlines([zRm1, zR, zRp1], 0, r, lw=1)
+
+plt.tight_layout()
+
+#plt.savefig('rbasex-limits.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-math.rst
+++ b/doc/transform_methods/rbasex-math.rst
@@ -1,0 +1,807 @@
+.. _rBasexmath:
+
+rBasex: mathematical details
+============================
+
+
+Coordinates
+-----------
+
+The coordinate systems used here are defined such that the image is in the
+:math:`xy` plane, with the :math:`y` axis being the (vertical) axis of
+symmetry. Thus the image-space polar coordinates are
+
+.. math::
+    \begin{aligned}
+        r &= \sqrt{x^2 + y^2}, \\
+        \theta &= \arctan \frac{y}{x}, \\
+    \end{aligned}
+
+with the polar angle :math:`\theta` measured from the :math:`y` axis. The
+corresponding coordinate system for the underlying 3D distribution has the same
+:math:`x` and :math:`y` axes, plus a perpendicular :math:`z` axis, so the
+distribution-space spherical coordinates are
+
+.. math::
+    \begin{aligned}
+        \rho &= \sqrt{x^2 + y^2 + z^2}, \\
+        \theta' &= \arctan \frac{y}{\sqrt{x^2 + z^2}}, \\
+        \phi' &= \arctan \frac{z}{x},
+    \end{aligned}
+
+with the polar angle :math:`\theta` also measured from the :math:`y` axis (the
+symmetry axis). The Abel transform performs a projection along the :math:`z`
+axis:
+
+.. math::
+    (x, y, z) \mapsto (x, y),
+
+as shown by the dashed line:
+
+.. plot:: transform_methods/rbasex-coord.py
+    :align: center
+
+This figure also illustrated important relations between the 3D and 2D radii:
+
+.. math::
+    \rho = \sqrt{r^2 + z^2}.
+
+and polar angles:
+
+.. math::
+    \left.\begin{aligned}
+        \cos\theta = y / r \\
+        \cos\theta' = y / \rho
+    \end{aligned}\right\}
+    \quad \Rightarrow \quad
+    \cos\theta' = \frac{r}{\rho} \cos\theta.
+
+
+Basis functions
+---------------
+
+The 3D distribution basis consists of direct products of radial and angular
+basis functions. The radial functions are triangular functions centered at
+integer radii (whole pixels), spanning ±1 pixel:
+
+.. plot:: transform_methods/rbasex-bR.py
+    :align: center
+
+.. math::
+    b_R(\rho) = \begin{cases}
+        \rho - (R - 1), & R - 1 < \rho < R, \\
+        (R + 1) - \rho, & R \leqslant \rho < R + 1, \\
+        0 & \text{otherwise}
+    \end{cases}
+
+(and :math:`b_0(\rho)` does not have the inner part, :math:`R - 1 < \rho < R`,
+since :math:`\rho \geqslant 0`). These functions actually form a basis of the
+piecewise linear approximation with nodes at each pixel.
+
+The angular basis functions are just integer powers of :math:`\cos\theta'` from
+0 up to the highest order expected in the distribution. Hence the overall 3D
+distribution basis functions are
+
+.. math::
+    b_{R,n}(\rho, \theta', \varphi') = b_R(\rho) \cos^n \theta'
+
+(due to cylindrical symmetry, there is no dependence on the azimuthal angle
+:math:`\varphi'`).
+
+The 2D image basis functions are, correspondingly, the projections of these
+distribution basis functions along the :math:`z` axis:
+
+.. math::
+    p_{R,n}(r, \theta) =
+        \int_{-\infty}^\infty b_{R,n}(\rho, \theta', \varphi') \,dz =
+        2 \int_0^\infty b_{R,n}(\rho, \theta', \varphi') \,dz.
+
+
+Basis projections
+-----------------
+
+As mentioned earlier, :math:`\cos\theta' = \tfrac{r}{\rho} \cos\theta`, so we
+can write
+
+.. math::
+    \begin{aligned}
+        p_{R,n}(r, \theta) &= 2 \int_0^\infty b_R(\rho) \cos^n\theta' \,dz = \\
+            &= 2 \int_0^\infty b_R(\rho) \left(\frac{r}{\rho}\right)^n \cos^n\theta \,dz = \\
+            &= 2 \int_0^\infty b_R(\rho) \left(\frac{r}{\rho}\right)^n \,dz \cdot \cos^n\theta.
+    \end{aligned}
+
+In other words, basis projection are also separable into radial and angular
+parts:
+
+.. math::
+    p_{R,n}(r, \theta) = p_{r;n}(r) \cos^n\theta,
+
+with the same angular dependence, but their radial parts are different for
+different angular orders (thus projections of functions with angular dependence
+different from a singe cosine power, for example, :math:`\sin^2\theta'` or
+Legendre polynomials, would be *not* separable).
+
+Since :math:`b_R(\rho)` consists of two segments that are linear functions of
+:math:`\rho`, the integrals above can be expressed in terms of the integrals
+
+.. math::
+    \int\limits_{z_\text{min}}^{z_\text{max}}
+        \rho \left(\frac{r}{\rho}\right)^n \,dz =
+    r \int\limits_{z_\text{min}}^{z_\text{max}}
+        \left(\frac{r}{\rho}\right)^{n-1} \,dz
+
+and
+
+.. math::
+    \int\limits_{z_\text{min}}^{z_\text{max}}
+        R \left(\frac{r}{\rho}\right)^n \,dz =
+    R \int\limits_{z_\text{min}}^{z_\text{max}}
+        \left(\frac{r}{\rho}\right)^n \,dz
+
+with appropriate lower and upper limits. That is, only the antiderivatives of
+the form
+
+.. math::
+    F_n(r, z) = \int \left(\frac{r}{\rho}\right)^n \,dz
+
+with integer :math:`n` from −1 to the highest angular order are needed. They
+all can be computed analytically and are listed in the following table (as a
+reminder, :math:`\rho = \sqrt{r^2 + z^2}`):
+
+.. list-table::
+    :header-rows: 1
+    :widths: auto
+    :align: center
+
+    * - :math:`n`
+      - :math:`F_n(r, z)`
+    * - :math:`-1`
+      - :math:`\frac12 z \left(\frac{r}{\rho}\right)^{-1} +
+        \frac12 r \ln(z + \rho)`
+    * - :math:`\phantom{-}0`
+      - :math:`z`
+    * - :math:`\phantom{-}1`
+      - :math:`r \ln(z + \rho)`
+    * - :math:`\phantom{-}2`
+      - :math:`r \arctan\frac{z}{r}`
+    * - :math:`\phantom{-}3`
+      - :math:`z \left(\frac{r}{\rho}\right)`
+    * - :math:`\phantom{-}4`
+      - :math:`\frac12 z \left(\frac{r}{\rho}\right)^2 +
+        \frac12 r \arctan\frac{z}{r}`
+    * - :math:`\phantom{-}5`
+      - :math:`\frac13 z \left(\frac{r}{\rho}\right)^3 +
+        \frac23 z \left(\frac{r}{\rho}\right)`
+    * - :math:`\phantom{-}6`
+      - :math:`\frac14 z \left(\frac{r}{\rho}\right)^4 +
+        \frac38 z \left(\frac{r}{\rho}\right)^2 +
+        \frac38 r \arctan\frac{z}{r}`
+    * - :math:`\phantom{-}\vdots`
+      - :math:`\vdots`
+    * - :math:`2m \geqslant 2`
+      - :math:`z \sum\limits_{k=1}^{m-1} a_k \left(\frac{r}{\rho}\right)^{2k} +
+        a_1 r \arctan\frac{z}{r}, \quad
+        a_k = \dfrac{\prod_{l=k+1}^{m-1} (2l - 1)}{\prod_{l=k}^{m-1} (2l)}`
+    * - :math:`2m + 1 \geqslant 3`
+      - :math:`z \sum\limits_{k=0}^{m-1} a_k \left(\frac{r}{\rho}\right)^{2k+1},
+        \quad
+        a_k = \dfrac{\prod_{l=k+1}^{m-1} (2l)}{\prod_{l=k}^{m-1} (2l + 1)}`
+
+(The general expression assume the usual convention that an empty product
+equals 1, and an empty sum equals 0.) A simple recurrence relation exists for
+:math:`n \ne 0`:
+
+.. math::
+    F_{n+2}(r, z) = \frac{1}{n} z \left(\frac{r}{\rho}\right)^n +
+                    \frac{n - 1}{n} F_n(r, z).
+
+
+The integration limits have the form
+
+.. math::
+    z_R = \begin{cases}
+        \sqrt{R^2 - r^2}, & r < R, \\
+        0 & \text{otherwise}
+    \end{cases}
+
+and are :math:`[z_{R-1}, z_R]` for the inner part :math:`b_R\big(\rho \in [R -
+1, R]\big) = \rho - (R - 1)` and :math:`[z_R, z_{R+1}]` for the outer part
+:math:`b_R\big(\rho \in [R, R + 1]\big) = (R + 1) - \rho`:
+
+.. plot:: transform_methods/rbasex-limits.py
+    :align: center
+
+The :math:`\rho` values corresponding to the integration limits (for
+substitution in the antiderivatives :math:`F_n`) have an even simpler form:
+
+.. math::
+    \rho|_{z=z_R} = \sqrt{r^2 + z_R^2} = \max(r, R),
+
+and hence
+
+.. math::
+    \left.\left(\frac{r}{\rho}\right)\right|_{z=z_R} =
+        \min\left(\frac{r}{R}, 1\right).
+
+The :math:`\arctan\frac{z_R}{r}` terms can also be “simplified” to
+:math:`\left.\arccos\frac{r}{\rho}\right|_{z=z_R} = \arccos\frac{r}{R}` for
+:math:`r < R` and 0 otherwise, or :math:`\arccos\left[\min\left(\frac{r}{R},
+1\right)\right]`. This seems to be more computationally efficient on modern
+systems, although previously it was the other way around, since :math:`\arccos`
+was implemented in libraries through :math:`\operatorname{arctan2}` (FPATAN),
+square root (FSQRT) and arithmetic operations.
+
+Collecting all the pieces together, we get the following expression for the
+radial parts of the projections:
+
+.. math::
+    \begin{aligned}
+        p_{R;n}(r) &= 4 [r F_{n-1}(r, z_R) - R F_n(r, z_R)] - {} \\
+                   &- 2 [r F_{n-1}(r, z_{R-1}) - (R - 1) F_n(r, z_{R-1})] - {} \\
+                   &- 2 [r F_{n-1}(r, z_{R+1}) - (R + 1) F_n(r, z_{R+1})].
+    \end{aligned}
+
+Like :math:`b_0(\rho)`, the :math:`p_{0;n}(r)` functions do not have the inner
+part, so for them (:math:`R = 0`, :math:`z_R = 0`, :math:`R + 1 = 1`) the expression is
+
+.. math::
+    \begin{aligned}
+        p_{0;n}(r) &= 2 [r F_{n-1}(r, 0) - F_n(r, 0)] -
+                     2 [r F_{n-1}(r, z_1) - F_n(r, z_1)] = \\
+                   &= 2 [F_n(r, z_1) - F_n(r, 0)] -
+                      2 r [F_{n-1}(r, z_1) - F_{n-1}(r, 0)].
+    \end{aligned}
+
+However, in practice :math:`R = 0` corresponds to the single central pixel, and
+at the integer grid we have :math:`p_{0;0}(r) = \delta_{r,0}` and
+:math:`p_{0;n>0}(r) = 0`, that is the intensity at :math:`r = 0` must be
+assumed isotropic.
+
+Here are examples of :math:`p_{R;n}(r)` plotted for :math:`R = 6` and :math:`n
+= 0, 1, 2`, together with the radial part of the distribution basis function
+:math:`b_R(r)`:
+
+.. plot:: transform_methods/rbasex-pRn.py
+    :align: center
+
+The projection functions have a large curvature near :math:`r \approx R` and
+thus are not well represented by piecewise linear approximations at the integer
+grid, as illustrated below (the solid red line is the same :math:`p_{6;2}(r)`
+as above):
+
+.. plot:: transform_methods/rbasex-peak.py
+    :align: center
+
+This was not a problem for the reconstruction method developed in [1]_, since
+it samples these functions at each pixel, with their :math:`r = \sqrt{x^2 +
+y^2}` values not limited to integers. But expanding piecewise linear radial
+distributions over the basis of these curved :math:`p_{R;n}` might be
+problematic. However, as the green curves illustrate, even for a peak with just
+3 nonzero points, its projection is represented by linear segments
+significantly better. Therefore, for real experimental data with adequate
+sampling (peak widths > 2 pixels), the piecewise linear approximation should
+work reasonably well.
+
+
+Transform
+---------
+
+The initial 3D distribution has the form
+
+.. math::
+    I(\rho, \theta') = \sum_n I_n(\rho) \cos^n \theta',
+
+where :math:`I_n(\rho)` are the radial distributions for each angular order.
+They are represented as a linear combination of the radial basis functions:
+
+.. math::
+    I_n(\rho) = \sum_R c_{R,n} b_R(\rho).
+
+The forward Abel transform of this 3D distribution (in other words, its
+projection, or the experimentally recorded image) then has the form
+
+.. math::
+    P(r, \theta) = \sum_n P_n(\rho) \cos^n \theta,
+
+where :math:`P_n(r)` are its radial distributions for each angular order (not
+to be confused with Legendre polynomials) and are represented as linear
+combinations of the radial projected basis functions:
+
+.. math::
+    P_n(r) = \sum_R c_{R,n} p_{R;n}(r)
+
+with the same coefficients :math:`c_{R,n}`.
+
+If the radial distributions of both the initial distribution and its projection
+are sampled at integer radii, these linear combinations can be written in
+vector-matrix notation as
+
+.. math::
+    \begin{aligned}
+        I_n(\boldsymbol \rho) &= \mathbf B^{\rm T} \mathbf c_n,
+        & \mathbf B_{ij} &= b_{R=i}(\rho = j), \\
+        P_n(\mathbf r) &= \mathbf P_n^{\rm T} \mathbf c_n,
+        & (\mathbf P_n)_{ij} &= p_{R=i;n}(r = j)
+    \end{aligned}
+
+for each angular order :math:`n`.
+
+It is obvious from the definition of :math:`b_R(\rho)` that :math:`\mathbf B`
+is an identity matrix, so the expansion coefficients are simply :math:`\mathbf
+c_n = I_n(\boldsymbol \rho)`. Thus the forward and inverse Abel transforms can
+be computed as
+
+.. math::
+    \begin{aligned}
+        P_n(\mathbf r) &= \mathbf P_n^{\rm T} I_n(\boldsymbol \rho), \\
+        I_n(\boldsymbol \rho) &= \big(\mathbf P_n^{\rm T}\big)^{-1} P_n(\mathbf r)
+    \end{aligned}
+
+for each angular order separately. Since all projected basis functions satisfy
+:math:`p_{R;n}(r \geqslant R + 1) = 0` (see the plots above), the matrices
+:math:`\mathbf P_n^{\rm T}` are upper triangular, and their inversions
+:math:`\big(\mathbf P_n^{\rm T}\big)^{-1}` are also upper triangular for all
+:math:`n`, which additionally facilitates the computations. (This triangularity
+makes the inverse Abel transform similar to the “onion peeling” procedure
+written in a matrix form, but based on linear interpolation instead of midpoint
+rectangular approximation.)
+
+Overall, the transforms proceed as follows:
+
+1. Radial distributions for each angular order are extracted from the input
+   data using :class:`abel.tools.vmi.Distributions`. This takes
+   :math:`O(N\,R_\text{max}^2)` time, where :math:`N` is the number of angular
+   terms, and :math:`R_\text{max}` is the largest analyzed radius (assuming
+   :math:`N \ll R_\text{max}`).
+2. Radial projected basis functions are computed to construct the
+   :math:`\mathbf P_n` matrices, also in :math:`O(N\,R_\text{max}^2)` total
+   time.
+3. For the inverse Abel transform, the :math:`\mathbf P_n^{\rm T}` matrices are
+   inverted, in :math:`O(N\,R_\text{max}^3)` total time. This step is not
+   needed for the forward Abel transform.
+4. The radial distributions from step 1 are multiplied by the transform
+   matrices :math:`\mathbf P_n^{\rm T}` or :math:`\big(\mathbf P_n^{\rm
+   T}\big)^{-1}` to obtain the reconstructed radial distributions, in
+   :math:`O(N\,R_\text{max}^2)` total time.
+5. If the transformed image is needed, it is constructed from its radial
+   distributions obtained in step 4 using the first formula in this section.
+   This takes :math:`O(N\,R_\text{max}^2)` time.
+
+That is, only step 3 has time complexity that scales cubically with the image
+size, and all other steps have quadratic complexity. However, for the forward
+Abel transform, step 3 is not needed at all, and for the inverse Abel
+transform, its results can be cached. Thus processing a sequence of images
+takes time linearly proportional to the total number of processed pixels. In
+other words, the throughput is independent on the image size.
+
+
+Regularizations
+---------------
+
+The matrix equation
+
+.. math::
+    \mathbf y = \mathbf A \mathbf x
+
+(in our case the vector :math:`\mathbf x` represents the radial part of the
+sought 3D distribution, the matrix :math:`\mathbf A` represents the forward
+Abel transform, and the vector :math:`\mathbf y` represents the radial part of
+the recorded projection) can be solved as
+
+.. math::
+    \mathbf x = \mathbf A^{-1} \mathbf y
+
+if :math:`\mathbf A` is invertible. However, if the problem is ill-conditioned,
+computing :math:`\mathbf A^{-1}` might be problematic, and the solution might
+have undesirably amplified noise.
+
+Regularization methods try to replace the ill-conditioned problem with a
+related better-conditioned one and use its solution as a well-behaved
+approximation to the solution of the original problem.
+
+
+Tikhonov
+^^^^^^^^
+
+Instead of inverting :math:`\mathbf A` explicitly, the solution of
+:math:`\mathbf y = \mathbf A \mathbf x` can be found as
+
+.. math::
+    \mathbf x = \mathop{\rm arg\,min}\limits_{\mathbf x}
+                (\mathbf y - \mathbf A \mathbf x)^2,
+
+from a quadratic minimization (“least-squares”) problem, which is equivalent to
+the original problem, but makes evident that for ill-conditioned problems the
+minimum is very “flat”, and many different :math:`\mathbf x` can be accepted as
+a solution.
+
+The idea of `Tikhonov regularization
+<https://en.wikipedia.org/wiki/Tikhonov_regularization>`_ is to add some small
+“regularizing” term to this minimization problem:
+
+.. math::
+    \tilde{\mathbf x} = \mathop{\rm arg\,min}\limits_{\mathbf x} \left[
+                            (\mathbf y - \mathbf A \mathbf x)^2 + g[\mathbf x]
+                        \right]
+
+that will help to select the “best” solution by imposing larger penalty on
+undesirable solutions. If this term is also a quadratic form
+
+.. math::
+    g[\mathbf x] = (\mathbf \Gamma \mathbf x)^2
+
+with some matrix :math:`\mathbf \Gamma` (not necessarily square), then the
+quadratic minimization problem is reduced back to a linear matrix equation and
+has the solution
+
+.. math::
+    \tilde{\mathbf x} = \mathbf A^{\rm T}
+                        \left(\mathbf A \mathbf A^{\rm T} +
+                              \mathbf \Gamma \mathbf \Gamma^{\rm T}\right)^{-1}
+                        \mathbf y.
+
+In practice, it is convenient to define :math:`\mathbf \Gamma = \varepsilon
+\mathbf \Gamma_0` with some fixed :math:`\mathbf \Gamma_0` and change the
+“Tikhonov factor” :math:`\varepsilon` to adjust the regularization “strength”.
+The form of :math:`\mathbf \Gamma_0` selects the regularization type:
+
+
+:math:`L_2` norm
+""""""""""""""""
+
+This is the simplest case, with :math:`\mathbf \Gamma_0 = \mathbf I`, the
+identity matrix. That is, the penalty functional :math:`g[\mathbf x] =
+\varepsilon^2 \mathbf x^2` is the quadratic norm of the solution scaled by the
+regularization parameter.
+
+The idea is that, in a continuous limit, if we have a well-behaved function
+:math:`f(r)` and some random noise :math:`\delta(r)`, then
+
+.. math::
+    \begin{aligned}
+        g[f(r) + \delta(r)] &=
+            \int [f(r) + \delta(r)]^2 \,dr = \\
+            &= \underbrace{\int [f(r)]^2 \,dr}_{\textstyle g[f(r)]} +
+               \underbrace{2 \int f(r) \delta(r) \,dr}_{\textstyle \approx 0} +
+               \underbrace{\int [\delta(r)]^2 \,dr}_{\textstyle > 0}.
+    \end{aligned}
+
+In other words, a noisy solution will have a larger penalty than a smooth
+solution, unless the noise is correlated, and a smooth solution will be
+preferred as long as the noise forward transforms is close to zero
+(:math:`\|\mathcal A \delta(r)\| < \|\delta(r)\|`).
+
+Notice, however, that for very large Tikhonov factors the regularization term
+starts to dominate in the minimization problem, which tend to
+
+.. math::
+    \tilde{\mathbf x} = \varepsilon^2
+                        \mathop{\rm arg\,min}\limits_{\mathbf x} \mathbf x^2
+
+and thus has the solution :math:`\tilde{\mathbf x} \to 0`. For reasonable
+regularization strengths this intensity suppression effect is small, but the
+solution is always biased towards zero.
+
+
+Finite differences
+""""""""""""""""""
+
+Here the first-order finite difference operator is used as the Tikhonov matrix:
+
+.. math::
+    \mathbf \Gamma_0 = \begin{pmatrix}
+        -1 &  1 &  0 & 0 & \cdots \\
+         0 & -1 &  1 & 0 & \cdots \\
+         0 &  0 & -1 & 1 & \ddots \\
+        \vdots & \vdots & \ddots & \ddots & \ddots
+    \end{pmatrix}.
+
+It is the discrete analog of the differentiation operator, so in a continuous
+limit this regularization corresponds to using the penalty functional of the
+form
+
+.. math::
+    g[f(r)] = \int \left(\frac{df(r)}{dr}\right)^2 \,dr.
+
+Noisy functions obviously have larger RMS derivatives that smooth functions and
+thus are penalized more.
+
+Unlike the :math:`L_2`-norm regularization, which tends to avoid sign-changing
+functions and oscillating functions in general, this regularization can produce
+noticeably overshoots (including negative) around sharp features in the
+distribution. However, it tends to preserve the overall intensity.
+
+
+Truncated SVD
+^^^^^^^^^^^^^
+
+This is the method used in pBasex. The idea is that since the `condition number
+<https://en.wikipedia.org/wiki/Condition_number>`_ of a matrix equals the ratio
+of its maximal and minimal `singular values
+<https://en.wikipedia.org/wiki/Singular_value>`_, performing the singular value
+decomposition (SVD),
+
+.. math::
+    \mathbf U \mathbf \Sigma \mathbf V^{\rm T} = \mathbf A,
+
+inverting :math:`\mathbf \Sigma` (which is diagonal), then excluding its
+largest values values and assembling the pseudoinverse
+
+.. math::
+    \tilde{\mathbf A}^{-1} = \mathbf V \tilde{\mathbf \Sigma}^{-1}
+                             \mathbf U^{\rm T}
+
+gives a better-conditioned matrix approximation of :math:`\mathbf A^{-1}`,
+which is then used to obtain the approximate solution
+
+.. math::
+    \tilde{\mathbf x} = \tilde{\mathbf A}^{-1} \mathbf y.
+
+This approach can be helpful when the left singular vectors (columns of
+:math:`\mathbf V`, which become linear contributions to :math:`\mathbf x`) are
+physically meaningful and different for the useful signal and the undesirable
+noise. Then removing the singular values corresponding to the undesirable
+vectors excludes them from the solution, while retaining the useful
+contributions. However, this is not the case for our problem. Here are the
+singular values :math:`\sigma_i` of :math:`\mathbf A^{-1}` plotted together
+with some representative left singular vectors :math:`\mathbf v_i`:
+
+.. plot:: transform_methods/rbasex-SVD.py
+    :align: center
+
+As can be seen, all these vectors are oscillatory, with negative values, and
+most of them are delocalized over the whole radial range. That is, they do not
+have a clear physical meaning for practical applications of the Abel transform.
+
+The only potentially useful observation is that the first vectors,
+corresponding to the largest singular values, have the highest spacial
+frequencies and contribute mostly to the lower :math:`r` range. Thus excluding
+them might reduce the high-frequency noise near the center of the transformed
+image. It should be noted, however, that a simple SVD truncation leads to the
+same problems with delocalized oscillations and the `Gibbs phenomenon
+<https://en.wikipedia.org/wiki/Gibbs_phenomenon>`_, as in truncated Fourier
+series. (From this perspective, soft attenuation, like in the Tikhonov
+regularization, is a more appropriate approach.)
+
+So this method is not recommended for practical applications and is provided
+here mostly for completeness.
+
+
+Non-negative components
+^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the simplest *nonlinear* regularization method proposed in [1]_. The
+idea is that the linear matrix equation
+
+.. math::
+    \mathbf y = \mathbf A \mathbf x
+
+is replaced by the minimization problem
+
+.. math::
+    \tilde{\mathbf x} = \mathop{\rm arg\,min}\limits_{\mathbf x\ \geqslant\ 0}
+                        (\mathbf y - \mathbf A \mathbf x)^2
+
+with a physically meaningful constraint that the solution (the intensity
+distribution) must be non-negative everywhere. If the linear solution happens
+to be non-negative, this modified problem has exactly the same solution.
+Otherwise the minimization problem gives the closest (in the least-squares
+sense) non-negative approximation to the original problem.
+
+Unfortunately, applying non-negativity constraint to trigonometric polynomials,
+
+.. math::
+    I(\theta) = \sum a_n \cos^n \theta \geqslant 0\ \text{for all}\ \theta,
+
+generally leads to a system of nonlinear equations on their coefficients, which
+cannot be solved efficiently.
+
+However, if the polynomial has no more that two terms, that is its order is 0,
+1, or 2 with even powers only, the constraints are linear and can be linearly
+transformed into nonnegativity constraints on the coefficients:
+
+.. math::
+    \begin{aligned}
+        I(\theta) &= c_0 \cos^0 \theta \geqslant 0
+        &&\Leftrightarrow& c_0 \geqslant 0; \\
+        I(\theta) &= c_0 \cos^0 \theta + c_1 \cos^1 \theta = \\
+                  &= a_0 (\cos^0 \theta + \cos^1 \theta) + {} \\
+                  &+ a_1 (\cos^0 \theta - \cos^1 \theta) \geqslant 0
+        &&\Leftrightarrow& a_i \geqslant 0; \\
+        I(\theta) &= c_0 \cos^0 \theta + c_2 \cos^2 \theta = \\
+                  &= a_0 (\cos^0 \theta - \cos^2 \theta) + {} \\
+                  &+ a_2 \cos^2 \theta \geqslant 0
+        &&\Leftrightarrow& a_i \geqslant 0.
+    \end{aligned}
+
+Notice that in the last case the term :math:`a_0 (\cos^0 \theta - \cos^2
+\theta) = a_0 \sin^2 \theta` corresponds to perpendicular transitions, whereas
+:math:`a_2 \cos^2 \theta` corresponds to parallel transitions, so the
+inequalities :math:`a_i \geqslant 0` have a direct physical meaning that both
+transition components must be non-negative.
+
+The quadratic minimization problem with linear constraints reduces to a
+sequence of linear problems and is soluble exactly in a finite number of steps.
+
+In some cases the non-negative solution can be positively biased, since it does
+not allow negative noise, but can have some positive noise. Nevertheless, this
+bias is smaller than the positive bias introduced by zeroing negative values in
+solutions obtained by linear methods (*never do this*!).
+
+
+The idea of non-negative transition components can be extended to multiphoton
+processes *without interference between different channels*, so that
+
+.. math::
+    \begin{aligned}
+        I(\theta) &=
+            \left(a_0^{(1)} \sin^2 \theta + a_2^{(1)} \cos^2 \theta\right) \times \\
+        &\times \left(a_0^{(2)} \sin^2 \theta + a_2^{(2)} \cos^2 \theta\right) \times \\
+        &\times \dots \times \\
+        &\times \left(a_0^{(m)} \sin^2 \theta + a_2^{(m)} \cos^2 \theta\right),
+            \quad a_i^{(j)} \geqslant 0,
+    \end{aligned}
+
+which also leads to a linear combination with non-negative coefficients:
+
+.. math::
+    I(\theta) = \sum b_n \sin^m \theta \cdot \cos^n \theta,
+    \quad b_n \geqslant 0.
+
+These constraints, however, are stronger than the intensity non-negativity: for
+example, the angular distribution
+
+.. math::
+    \sin^4 \theta - 2 \sin^2 \theta \cdot \cos^2 \theta + \cos^4 \theta =
+    \left(\sin^2 \theta - \cos^2 \theta\right)^2
+
+is non-negative everywhere, but contains a negative coefficient for the
+:math:`\sin^2 \theta \cdot \cos^2 \theta` term. So even though this
+regularization is not always valid for multiphoton processes, it can be useful
+in some cases and is easy to implement. To remind that it is not “truly
+non-negative”, this regularization is called “positive” here.
+
+
+A general advice applicable to all regularization methods is that when a
+relevant model is available, it is better to fit it directly to non-regularized
+results, thus avoiding additional assumptions and biases introduced by
+regularizations.
+
+
+Examples
+^^^^^^^^
+
+.. warning::
+    Absolute and relative efficiencies of these regularization methods and
+    their optimal parameters depend on the image size, the amount of noise and
+    the distribution itself. Therefore *do not assume* that the examples shown
+    here are directly relevant to *your* data.
+
+Some properties of the regularization methods described above are demonstrated
+here by applying them to a synthetic example. The test distribution from the
+BASEX article is forward Abel-transformed to obtain its projection, and then
+Poissonian noise is added to it to simulate experimental VMI data with
+relatively low signal levels (such that the noise is prominent):
+
+.. comment
+    the only purpose of ":scale: 1" in the plots below is to make them clickable
+
+.. plot:: transform_methods/rbasex-sim.py
+    :scale: 1
+
+In order to characterize the regularization performance, all the methods are
+applied at various strengths to this simulated projection, and the relative
+root-mean-square error :math:`\big\|\tilde I(r) - I_\text{src}(r)\big\| \big/
+\big\|I_\text{src}(r)\big\|`, where :math:`I_\text{src}(r)` is the “true”
+radial intensity distribution, and :math:`\tilde I(r)` is the reconstructed
+distribution, is calculated in each case. The following plot shows how this
+reconstruction error changes with the regularization strength (the
+non-parameterized “pos” method is shown by a dashed line):
+
+.. plot:: transform_methods/rbasex-regRMSE.py
+    :align: center
+
+(Note that the horizontal axis in the left plot is nonlinear, and that the
+vertical axis in the right plot does not start at zero and actually spans a
+very small range.)
+
+These plots demonstrate that the Tikhonov methods have some optimal strength
+value, at which the reconstruction error is minimized. At smaller values the
+noise is not suppressed enough (zero strength corresponds to the
+non-regularized transform), and at larger values the reconstructed distribution
+is smoothed too much.
+
+The SVD plot has steps corresponding to successive removal of singular values.
+The reconstruction error does not decrease monotonically, but exhibits several
+local minima before starting to grow. Notice that even the global minimum is
+only slightly better than no regularization.
+
+The actual reconstructed images for each regularization method at its optimal
+strength are shown below with their radial intensity distributions:
+
+
+Using ``reg=None``
+""""""""""""""""""
+
+.. plot::
+    :scale: 1
+
+    from rbasex_reg import plot
+    plot(None)
+
+The non-regularized transform results are shows as a reference. The image has
+red colors for positive intensities and blue colors for negative intensities.
+The upper plot shows the reconstructed radial intensity distribution in black
+and the “true” distribution in red behind it. The lower plot shows the the
+difference between these two distributions in blue (red is the zero line).
+
+
+Using ``reg=('L2', 100)``
+"""""""""""""""""""""""""
+
+.. plot::
+    :scale: 1
+
+    from rbasex_reg import plot
+    plot('L2', 100)
+
+The noise level is generally reduced, but the peaks near the origin are
+noticeably broadened, which actually increases deviations in this region.
+
+
+Using ``reg=('diff', 115)``
+"""""""""""""""""""""""""""
+
+.. plot::
+    :scale: 1
+
+    from rbasex_reg import plot
+    plot('diff', 115)
+
+The noise is reduced even more, especially its high-frequency components. The
+peaks near the origin also suffer, but somewhat differently.
+
+
+Using ``reg=('SVD', 0.03)``
+"""""""""""""""""""""""""""
+
+.. plot::
+    :scale: 1
+
+    from rbasex_reg import plot
+    plot('SVD', 0.03)
+
+The only noticeable difference from no regularization is some noise reduction
+near the origin.
+
+
+Using ``reg='pos'``
+"""""""""""""""""""
+
+.. plot::
+    :scale: 1
+
+    from rbasex_reg import plot
+    plot('pos')
+
+The most prominent feature is the absence of negative intensities. The noise is
+reduced significantly in the areas of low intensity, where it is constrained
+from attaining negative values, which also reduces its positive amplitudes, as
+the distribution should be reproduced on average. The peaks, being strongly
+positive, do not have noticeable noise reduction. However, in contrast to other
+methods, the peaks near the origin are not broadened, while the off-peak noise
+near them is reduced.
+
+
+References
+----------
+
+.. [1] \ M. Ryazanov,
+       “Development and implementation of methods for sliced velocity map
+       imaging. Studies of overtone-induced dissociation and isomerization
+       dynamics of hydroxymethyl radical (CH\ :sub:`2`\ OH and
+       CD\ :sub:`2`\ OH)”,
+       Ph.D. dissertation, University of Southern California, 2012.
+       (`ProQuest <https://search.proquest.com/docview/1289069738>`_,
+       `USC <http://digitallibrary.usc.edu/cdm/ref/collection/p15799coll3/id/
+       112619>`_).

--- a/doc/transform_methods/rbasex-math.rst
+++ b/doc/transform_methods/rbasex-math.rst
@@ -44,7 +44,7 @@ as shown by the dashed line:
 This figure also illustrates important relations between the 3D and 2D radii:
 
 .. math::
-    \rho = \sqrt{r^2 + z^2}.
+    \rho = \sqrt{r^2 + z^2}
 
 and polar angles:
 
@@ -75,8 +75,10 @@ integer radii (whole pixels), spanning ±1 pixel:
     \end{cases}
 
 (and :math:`b_0(\rho)` does not have the inner part, :math:`R - 1 < \rho < R`,
-since :math:`\rho \geqslant 0`). These functions actually form a basis of the
-piecewise linear approximation with nodes at each pixel.
+since :math:`\rho \geqslant 0`). These functions form a basis of continuous
+piecewise linear approximations with nodes at each pixel. In other words,
+linear combinations of these functions represent any radial distribution as
+pixel values connected by straight lines.
 
 The angular basis functions are just integer powers of :math:`\cos\theta'` from
 0 up to the highest order expected in the distribution. Hence the overall 3D
@@ -342,9 +344,10 @@ for each angular order separately. Since all projected basis functions satisfy
 :math:`\mathbf P_n^{\rm T}` are upper triangular, and their inversions
 :math:`\big(\mathbf P_n^{\rm T}\big)^{-1}` are also upper triangular for all
 :math:`n`, which additionally facilitates the computations. (This triangularity
-makes the inverse Abel transform similar to the “onion peeling” procedure
-written in a matrix form, but based on linear interpolation instead of midpoint
-rectangular approximation.)
+makes the inverse Abel transform similar to the :doc:`“onion peeling”
+<onion_peeling>` procedure written in a matrix form, but based on linear
+interpolation for spherical shells instead of midpoint rectangular
+approximation for cylindrical rings.)
 
 Overall, the transforms proceed as follows:
 
@@ -372,7 +375,7 @@ size, and all other steps have quadratic complexity. However, for the forward
 Abel transform, step 3 is not needed at all, and for the inverse Abel
 transform, its results can be cached. Thus processing a sequence of images
 takes time linearly proportional to the total number of processed pixels. In
-other words, the throughput is independent on the image size.
+other words, the pixel throughput is independent of the image size.
 
 
 .. _rBasexmathreg:
@@ -414,8 +417,8 @@ Instead of inverting :math:`\mathbf A` explicitly, the solution of
 
 from a quadratic minimization (“least-squares”) problem, which is equivalent to
 the original problem, but makes evident that for ill-conditioned problems the
-minimum is very “flat”, and many different :math:`\mathbf x` can be accepted as
-a solution.
+minimum is very “flat”, and many different vectors :math:`\mathbf x` can be
+accepted as a solution.
 
 The idea of `Tikhonov regularization
 <https://en.wikipedia.org/wiki/Tikhonov_regularization>`_ is to add some small
@@ -670,6 +673,8 @@ relevant model is available, it is better to fit it directly to non-regularized
 results, thus avoiding additional assumptions and biases introduced by
 regularizations.
 
+
+.. _rBasexmathregex:
 
 Examples
 ^^^^^^^^

--- a/doc/transform_methods/rbasex-math.rst
+++ b/doc/transform_methods/rbasex-math.rst
@@ -515,9 +515,10 @@ distribution. However, it tends to preserve the overall intensity.
 Truncated SVD
 ^^^^^^^^^^^^^
 
-This is the method used in pBasex. The idea is that since the `condition number
-<https://en.wikipedia.org/wiki/Condition_number>`_ of a matrix equals the ratio
-of its maximal and minimal `singular values
+This is the method mentioned in the pBasex article (but not actually used in
+the original pBasex implementation). The idea is that since the `condition
+number <https://en.wikipedia.org/wiki/Condition_number>`_ of a matrix equals
+the ratio of its maximal and minimal `singular values
 <https://en.wikipedia.org/wiki/Singular_value>`_, performing the singular value
 decomposition (SVD),
 
@@ -593,8 +594,8 @@ Unfortunately, applying non-negativity constraint to trigonometric polynomials,
 .. math::
     I(\theta) = \sum a_n \cos^n \theta \geqslant 0\ \text{for all}\ \theta,
 
-generally leads to a system of nonlinear equations on their coefficients, which
-cannot be solved efficiently.
+generally leads to a system of nonlinear inequalities for their coefficients,
+which cannot be solved efficiently.
 
 However, if the polynomial has no more that two terms, that is its order is 0,
 1, or 2 with even powers only, the constraints are linear and can be linearly

--- a/doc/transform_methods/rbasex-math.rst
+++ b/doc/transform_methods/rbasex-math.rst
@@ -41,7 +41,7 @@ as shown by the dashed line:
 .. plot:: transform_methods/rbasex-coord.py
     :align: center
 
-This figure also illustrated important relations between the 3D and 2D radii:
+This figure also illustrates important relations between the 3D and 2D radii:
 
 .. math::
     \rho = \sqrt{r^2 + z^2}.
@@ -276,7 +276,7 @@ This was not a problem for the reconstruction method developed in [1]_, since
 it samples these functions at each pixel, with their :math:`r = \sqrt{x^2 +
 y^2}` values not limited to integers. But expanding piecewise linear radial
 distributions over the basis of these curved :math:`p_{R;n}` might be
-problematic. However, as the green curves illustrate, even for a peak with just
+problematic. However, as the cyan curves illustrate, even for a peak with just
 3 nonzero points, its projection is represented by linear segments
 significantly better. Therefore, for real experimental data with adequate
 sampling (peak widths > 2 pixels), the piecewise linear approximation should
@@ -374,6 +374,8 @@ transform, its results can be cached. Thus processing a sequence of images
 takes time linearly proportional to the total number of processed pixels. In
 other words, the throughput is independent on the image size.
 
+
+.. _rBasexmathreg:
 
 Regularizations
 ---------------
@@ -515,8 +517,8 @@ distribution. However, it tends to preserve the overall intensity.
 Truncated SVD
 ^^^^^^^^^^^^^
 
-This is the method mentioned in the pBasex article (but not actually used in
-the original pBasex implementation). The idea is that since the `condition
+This is the method mentioned in the pBasex article [2]_ (but not actually used
+in the original pBasex implementation). The idea is that since the `condition
 number <https://en.wikipedia.org/wiki/Condition_number>`_ of a matrix equals
 the ratio of its maximal and minimal `singular values
 <https://en.wikipedia.org/wiki/Singular_value>`_, performing the singular value
@@ -806,3 +808,9 @@ References
        (`ProQuest <https://search.proquest.com/docview/1289069738>`_,
        `USC <http://digitallibrary.usc.edu/cdm/ref/collection/p15799coll3/id/
        112619>`_).
+
+.. [2] \ G. A. Garcia, L. Nahon, I. Powis,
+       “Two-dimensional charged particle image inversion using a polar basis
+       function expansion”,
+       `Rev. Sci. Instrum. 75, 4989–4996 (2004)
+       <https://doi.org/10.1063/1.1807578>`_.

--- a/doc/transform_methods/rbasex-pRn.py
+++ b/doc/transform_methods/rbasex-pRn.py
@@ -1,0 +1,64 @@
+from __future__ import print_function, division
+
+import numpy as np
+from numpy import log, arctan2
+import matplotlib.pyplot as plt
+
+R = 6
+rmax = 8.5
+
+fig = plt.figure(figsize=(6, 3), frameon=False)
+
+ax = plt.gca()
+ax.spines['top'].set_visible(False)
+ax.spines['right'].set_visible(False)
+
+plt.xlim((0, rmax))
+
+r = np.linspace(0, rmax, rmax * 20 + 1)
+r[0] = np.finfo(float).eps  # (to avoid division by 0)
+
+def sqrtp(x):
+    return np.sqrt(x, where=x > 0, out=np.zeros_like(x))
+zRm1 = sqrtp((R - 1)**2 - r**2)
+zR   = sqrtp( R**2      - r**2)
+zRp1 = sqrtp((R + 1)**2 - r**2)
+
+rhoRm1 = np.maximum(r, R - 1)
+rhoR   = np.maximum(r, R    )
+rhoRp1 = np.maximum(r, R + 1)
+
+def F_1(z, rho):
+    return 1/2 * z * rho / r + 1/2 * r * log(z + rho)
+
+def F0(z, rho):
+    return z
+
+def F1(z, rho):
+    return r * log(z + rho)
+
+def F2(z, rho):
+    return r * arctan2(z, r)
+
+F = {-1: F_1, 0: F0, 1: F1, 2: F2}
+
+def p(n):
+    return 4 * (r * F[n - 1](zR, rhoR) - R * F[n](zR, rhoR)) - \
+           2 * (r * F[n - 1](zRm1, rhoRm1) - (R - 1) * F[n](zRm1, rhoRm1)) - \
+           2 * (r * F[n - 1](zRp1, rhoRp1) - (R + 1) * F[n](zRp1, rhoRp1))
+
+plt.plot([0, R - 1, R, R + 1, rmax],
+         [0,     0, 1,     0,    0],
+         'k--', label='$b_{}$'.format(R))
+lpR = '$p_{' + str(R) + ';'
+plt.plot(r, p(0), 'b', label=lpR+'0}$')
+plt.plot(r, p(1), 'g', label=lpR+'1}$')
+plt.plot(r, p(2), 'r', label=lpR+'2}$')
+
+plt.ylim(bottom=0)
+
+plt.legend()
+plt.tight_layout()
+
+#plt.savefig('rbasex-pRn.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-pRn.py
+++ b/doc/transform_methods/rbasex-pRn.py
@@ -14,6 +14,7 @@ ax.spines['top'].set_visible(False)
 ax.spines['right'].set_visible(False)
 
 plt.xlim((0, rmax))
+plt.xlabel('radius')
 
 r = np.linspace(0, rmax, rmax * 20 + 1)
 r[0] = np.finfo(float).eps  # (to avoid division by 0)

--- a/doc/transform_methods/rbasex-peak.py
+++ b/doc/transform_methods/rbasex-peak.py
@@ -1,0 +1,73 @@
+from __future__ import print_function, division
+
+import numpy as np
+from numpy import log, arctan2
+import matplotlib.pyplot as plt
+
+n = 2
+R = 6
+rmax = 8.5
+samp = 20  # samples per 1 px
+
+fig = plt.figure(figsize=(6, 3), frameon=False)
+
+ax = plt.gca()
+ax.spines['top'].set_visible(False)
+ax.spines['right'].set_visible(False)
+
+plt.xlim((0, rmax))
+
+r = np.linspace(0, rmax, rmax * samp + 1)
+r[0] = np.finfo(float).eps  # (to avoid division by 0)
+
+def sqrtp(x):
+    return np.sqrt(x, where=x > 0, out=np.zeros_like(x))
+
+def F_1(z, rho):
+    return 1/2 * z * rho / r + 1/2 * r * log(z + rho)
+
+def F0(z, rho):
+    return z
+
+def F1(z, rho):
+    return r * log(z + rho)
+
+def F2(z, rho):
+    return r * arctan2(z, r)
+
+F = {-1: F_1, 0: F0, 1: F1, 2: F2}
+
+def p(R, n):
+    zRm1 = sqrtp((R - 1)**2 - r**2)
+    zR   = sqrtp( R**2      - r**2)
+    zRp1 = sqrtp((R + 1)**2 - r**2)
+
+    rhoRm1 = np.maximum(r, R - 1)
+    rhoR   = np.maximum(r, R    )
+    rhoRp1 = np.maximum(r, R + 1)
+
+    return 4 * (r * F[n - 1](zR, rhoR) - R * F[n](zR, rhoR)) - \
+           2 * (r * F[n - 1](zRm1, rhoRm1) - (R - 1) * F[n](zRm1, rhoRm1)) - \
+           2 * (r * F[n - 1](zRp1, rhoRp1) - (R + 1) * F[n](zRp1, rhoRp1))
+
+plt.plot([-1, R - 1, R, R + 1, rmax + 1],
+         [ 0,     0, 1,     0,        0],
+         'ro--', label='1 px')
+P = p(R, n)
+plt.plot(r, P, 'r')
+plt.plot(r[::samp], P[::samp], 'ro:')
+
+plt.plot([-1, R - 2, R - 1,   R, R + 1, R + 2, rmax + 1],
+         [ 0,     0,   0.4, 0.6,   0.4,     0,        0],
+         'go--', label='3 px')
+P = 0.4 * p(R - 1, n) + 0.6 * p(R, n) + 0.4 * p(R + 1, n)
+plt.plot(r, P, 'g')
+plt.plot(r[::samp], P[::samp], 'go:')
+
+plt.ylim(bottom=0)
+
+plt.legend(markerscale=0)
+plt.tight_layout()
+
+#plt.savefig('rbasex-peak.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-peak.py
+++ b/doc/transform_methods/rbasex-peak.py
@@ -16,6 +16,7 @@ ax.spines['top'].set_visible(False)
 ax.spines['right'].set_visible(False)
 
 plt.xlim((0, rmax))
+plt.xlabel('radius')
 
 r = np.linspace(0, rmax, rmax * samp + 1)
 r[0] = np.finfo(float).eps  # (to avoid division by 0)
@@ -52,17 +53,17 @@ def p(R, n):
 
 plt.plot([-1, R - 1, R, R + 1, rmax + 1],
          [ 0,     0, 1,     0,        0],
-         'ro--', label='1 px')
+         'ro--', label='1 px peak')
 P = p(R, n)
-plt.plot(r, P, 'r')
+plt.plot(r, P, 'r', label='its projection')
 plt.plot(r[::samp], P[::samp], 'ro:')
 
 plt.plot([-1, R - 2, R - 1,   R, R + 1, R + 2, rmax + 1],
          [ 0,     0,   0.4, 0.6,   0.4,     0,        0],
-         'go--', label='3 px')
+         'co--', label='3 px peak')
 P = 0.4 * p(R - 1, n) + 0.6 * p(R, n) + 0.4 * p(R + 1, n)
-plt.plot(r, P, 'g')
-plt.plot(r[::samp], P[::samp], 'go:')
+plt.plot(r, P, 'c', label='its projection')
+plt.plot(r[::samp], P[::samp], 'co:')
 
 plt.ylim(bottom=0)
 

--- a/doc/transform_methods/rbasex-regRMSE.py
+++ b/doc/transform_methods/rbasex-regRMSE.py
@@ -1,0 +1,83 @@
+from __future__ import division, print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from abel.tools.analytical import SampleImage
+from abel.tools.vmi import Ibeta
+from abel.rbasex import rbasex_transform
+
+# test distribution
+rmax = 200
+scale = 10000
+source = SampleImage(n=2 * rmax - 1).image / scale
+Isrc, _ = Ibeta(source)
+Inorm = (Isrc**2).sum()
+
+# simulated projection fith Poissonian noise
+proj, _ = rbasex_transform(source, direction='forward')
+proj[proj < 0] = 0
+proj = np.random.RandomState(0).poisson(proj)  # (reproducible, see NEP 19)
+
+# calculate relative RMS error for given regularization parameters
+def rmse(method, strengths=None):
+    if strengths is None:
+        _, distr = rbasex_transform(proj, reg=method, out=None)
+        I, _ = distr.Ibeta()
+        return ((I - Isrc)**2).sum() / Inorm
+
+    err = np.empty_like(strengths, dtype=float)
+    for n, strength in enumerate(strengths):
+        _, distr = rbasex_transform(proj, reg=(method, strength), out=None)
+        I, _ = distr.Ibeta()
+        err[n] = ((I - Isrc)**2).sum() / Inorm
+    return err
+
+# get all data
+L2_str = (np.linspace(0, np.sqrt(1000), 51)**2)[:30]
+L2_err = rmse('L2', L2_str)
+
+diff_str = np.linspace(0, np.sqrt(1000), 51)**2
+diff_err = rmse('diff', diff_str)
+
+pos_err = rmse('pos')
+
+SVD_str = np.arange(0, 0.056, 1.0 / rmax)
+SVD_err = rmse('SVD', SVD_str)
+
+# plot...
+fig = plt.figure(figsize=(6, 3), frameon=False)
+
+# L2, diff, pos
+plt.subplot(121)
+
+plt.plot(np.sqrt(L2_str), L2_err, label='L2')
+plt.plot(np.sqrt(diff_str), diff_err, label='diff')
+plt.plot([0, np.sqrt(1000)], [pos_err, pos_err], '--', label='pos')
+
+plt.ylim(bottom=0)
+
+plt.xlim((0, np.sqrt(1000)))
+ticks = [0, 30, 100, 300, 1000]
+plt.xticks(np.sqrt(ticks), map(str, ticks))
+plt.xlabel('strength')
+
+plt.legend()
+
+# SVD
+plt.subplot(122)
+
+plt.step(SVD_str, SVD_err, where='mid', c='C3', label='SVD')
+
+plt.yticks([0.079, 0.080])
+
+plt.xlim((0, 0.055))
+plt.xlabel('strength')
+
+plt.legend()
+
+# finish
+plt.tight_layout()
+
+#plt.savefig('rbasex-regRMSE.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-regRMSE.py
+++ b/doc/transform_methods/rbasex-regRMSE.py
@@ -56,6 +56,7 @@ plt.plot(np.sqrt(diff_str), diff_err, label='diff')
 plt.plot([0, np.sqrt(1000)], [pos_err, pos_err], '--', label='pos')
 
 plt.ylim(bottom=0)
+plt.ylabel('relative RMS error')
 
 plt.xlim((0, np.sqrt(1000)))
 ticks = [0, 30, 100, 300, 1000]
@@ -70,6 +71,7 @@ plt.subplot(122)
 plt.step(SVD_str, SVD_err, where='mid', c='C3', label='SVD')
 
 plt.yticks([0.079, 0.080])
+plt.ylabel('relative RMS error')
 
 plt.xlim((0, 0.055))
 plt.xlabel('strength')

--- a/doc/transform_methods/rbasex-sim.py
+++ b/doc/transform_methods/rbasex-sim.py
@@ -1,0 +1,53 @@
+from __future__ import division, print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from abel.tools.analytical import SampleImage
+from abel.tools.vmi import Ibeta
+from abel.rbasex import rbasex_transform
+
+rmax = 200
+scale = 10000
+
+vlim = 0.5
+pvlim = 0.5 * np.sqrt(rmax)
+
+def rescaleI(im):
+    return np.sqrt(np.abs(im)) * np.sign(im)
+
+# test distribution
+source = SampleImage(n=2 * rmax - 1).image / scale
+Isrc, _ = Ibeta(source)
+Inorm = (Isrc**2).sum()
+
+# simulated projection fith Poissonian noise
+proj, _ = rbasex_transform(source, direction='forward')
+proj[proj < 0] = 0
+proj = np.random.RandomState(0).poisson(proj)  # (reproducible, see NEP 19)
+
+# plot...
+fig = plt.figure(figsize=(7, 3.5), frameon=False)
+
+# test distribution
+plt.subplot(121)
+
+fig = plt.imshow(rescaleI(source), vmin=-vlim, vmax=vlim, cmap='bwr')
+
+plt.axis('off')
+plt.text(0, 2 * rmax, 'test source', va='top')
+
+# simulated projection
+plt.subplot(122)
+
+fig = plt.imshow(rescaleI(proj), vmin=0, vmax=pvlim, cmap='gray_r')
+
+plt.axis('off')
+plt.text(0, 2 * rmax, 'simulated projection', va='top')
+
+# finish
+plt.subplots_adjust(left=0, right=0.97, wspace=0.1,
+                    bottom=0.08, top=0.98, hspace=0.5)
+
+#plt.savefig('rbasex-sim.svg')
+#plt.show()

--- a/doc/transform_methods/rbasex-sim.py
+++ b/doc/transform_methods/rbasex-sim.py
@@ -21,10 +21,12 @@ source = SampleImage(n=2 * rmax - 1).image / scale
 Isrc, _ = Ibeta(source)
 Inorm = (Isrc**2).sum()
 
-# simulated projection fith Poissonian noise
+# simulated projection with Poissonian noise
 proj, _ = rbasex_transform(source, direction='forward')
 proj[proj < 0] = 0
-proj = np.random.RandomState(0).poisson(proj)  # (reproducible, see NEP 19)
+# (reproducible random noise,
+#  see NEP 19: https://numpy.org/neps/nep-0019-rng-policy.html)
+proj = np.random.RandomState(0).poisson(proj)
 
 # plot...
 fig = plt.figure(figsize=(7, 3.5), frameon=False)

--- a/doc/transform_methods/rbasex.rst
+++ b/doc/transform_methods/rbasex.rst
@@ -1,0 +1,185 @@
+.. _rBasex:
+
+rBasex
+======
+
+
+Introduction
+------------
+
+This method resembles the pBasex [1]_ approach of expanding a velocity-map
+image over a 2D basis set in polar coordinates, but uses more convenient basis
+functions with analytical Abel transforms, developed by M. Ryazanov in [2]_.
+
+
+How it works
+------------
+
+In velocity-map imaging with cylindrically symmetric photodissociation (in a
+broad sense, including photoionization and photodetachment) the 3D velocity
+distribution at each speed (3D radius) consists of a finite number of spherical
+harmonics :math:`Y_{nm}(\theta, \varphi)` with :math:`m = 0`, which are also
+representable as Legendre polynomials :math:`P_n(\cos\theta)`. This means that
+an :math:`N \times N` image has only :math:`N_r \times N_a` degrees of freedom,
+where :math:`N_r` is the number of radial samples, usually :math:`N / 2`, and
+:math:`N_a` is the number of angular terms, a small number depending on the
+number of photons. These are the “radial distribution” extracted from the
+transformed image in other, general Abel-inversion methods.
+
+However, if these radial distributions are considered as a basis, the 3D
+distribution can be represented as a linear combination of these basis
+functions with some coefficients. And the corresponding image, being the
+forward Abel transform of the 3D distribution, will be represented as a linear
+combination of basis-function projections, that is, their forward Abel
+transforms, with the same coefficients. The reverse is also true: finding the
+expansion coefficients of an experimental VM image over the projected basis
+directly gives the expansion coefficients of the initial 3D velocity direction
+and thus the sought radial distributions.
+
+Finding the expansion coefficients is a simple linear problem, and the forward
+Abel transforms of the basis functions can be calculated easily if the basis is
+chosen wisely.
+
+See :ref:`rBasexmath` for the complete description.
+
+.. toctree::
+    :hidden:
+
+    rbasex-math
+
+
+Differences from pBasex
+^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Triangular radial basis functions are used instead of Gaussians. They are
+   more compact/orthogonal (only the adjacent functions overlap) and have
+   analytical Abel transforms.
+
+2. Cosine powers are used instead of Legendre polynomials for angular basis
+   functions. This makes the projected basis functions also separable into
+   radial and angular parts.
+
+3. The basis separability allows decomposition of the problem in two steps:
+   first, radial distributions are extracted from the image (without
+   intermediate rebinning to polar grid, what is faster and avoids accumulation
+   of resampling errors); second, these radial distributions are expanded over
+   radial bases for each angular order. This eliminates the necessity to work
+   with large matrices.
+
+4. Custom pixel weighting can be used, for example, to exclude image areas
+   “damaged” in some way (obscured by a beam block, contaminated by parasitic
+   signals, affected by detector imperfections and so on). Partial images (not
+   including the whole angular range) can be reconstructed as well.
+
+5. The forward Abel transform is implemented in addition to the inverse
+   transform.
+
+6. Additional (better) regularization methods are implemented.
+
+
+Differences from the reconstruction method described in [2]_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Instead of working with individual pixels and weighting them according to
+   Poisson statistics, the binned radial distributions (not weighted by
+   default) are transformed. This is less accurate, but much faster, especially
+   in Python.
+
+2. Slicing is not implemented.
+
+3. Only the non-negativity constraints are implemented. However, several
+   linear regularization options are added.
+
+4. Odd angular orders can be included.
+
+
+When to use it
+--------------
+
+Although this method can be applied only to velocity-map images, and not just
+cylindrically symmetric images, it has several benefits in this special case.
+
+1. The reconstructed radial distributions, which are of the primary interest in
+   VMI studies, are obtained directly.
+
+2. Limitations on the angular behavior of the distribution also put strong
+   constraints on the reconstruction noise, making the reconstructed images
+   much cleaner.
+
+3. Unlike general Abel transform methods, which have time complexity with
+   *cubic* dependence on the image size, this method is only *quadratic*, once
+   the transform matrix is computed. Computing the transform matrix is still
+   cubic, but after it is done, transforming a series of images is faster,
+   especially for large images.
+
+4. The optional non-negativity constraints implemented in this method allow
+   obtaining physically meaningful intensity and anisotropy distributions. They
+   can also help in denoising experimental images with very low event counts.
+
+
+How to use it
+-------------
+
+The method can be used by directly calling its transform function::
+
+   recon, distr = abel.rbasex.rbasex_transform(image)
+   r, I, beta = distr.rIbeta()
+
+It returns the transformed image ``recon`` and a :class:`Distributions.Results`
+object ``distr``, from which various radial distributions can be retrieved,
+such as the intensity and anisotropy-parameter distributions in this example.
+
+If only the distributions are needed, but not the transformed image itself, the
+calculations can be accelerated by disabling the creation of the output image::
+
+   _, distr = abel.rbasex.rbasex_transform(image, out=None)
+   r, I, beta = distr.rIbeta()
+
+Note that this method does not require the input image to be centered. Thus
+instead of centering it with :func:`center_image`, which will crop some data or
+fill it with zeros, it is better to pass the image origin directly to the
+transform function, determining it automatically, if needed::
+
+   origin = abel.tools.center.find_origin(image, method='convolution')
+   recon, distr = abel.rbasex.rbasex_transform(image, origin=origin)
+
+See :func:`abel.rbasex.rbasex_transform` documentation for the full description
+of all available transform parameters.
+
+Alternatively, the method can be accessed through the universal
+:class:`abel.Transform` class::
+
+   res = abel.Transform(image, method='rbasex')
+   recon = res.transform
+   distr = res.distr
+
+passing additional rBasex parameters through the ``transform_options``
+argument. However, keep in mind that if you want to use all the data from an
+off-center image, do not use the ``origin`` argument of :class:`Transform`, but
+pass it inside ``transform_options``. This also *must* be done in optional
+pixel weighting is used, since otherwise :class:`Transform` will shift the
+image, but not the weights array.
+
+
+Citation
+--------
+
+This method has not yet been published elsewhere, so cite it as the “rBasex
+method from the PyAbel package”, using the current Zenodo DOI (see :ref:`README
+<READMEcitation>` for details).
+
+.. [1] \ G. A. Garcia, L. Nahon, I. Powis,
+       “Two-dimensional charged particle image inversion using a polar basis
+       function expansion”,
+       `Rev. Sci. Instrum. 75, 4989–4996 (2004)
+       <https://doi.org/10.1063/1.1807578>`_.
+
+.. [2] \ M. Ryazanov,
+       “Development and implementation of methods for sliced velocity map
+       imaging. Studies of overtone-induced dissociation and isomerization
+       dynamics of hydroxymethyl radical (CH\ :sub:`2`\ OH and
+       CD\ :sub:`2`\ OH)”,
+       Ph.D. dissertation, University of Southern California, 2012.
+       (`ProQuest <https://search.proquest.com/docview/1289069738>`_,
+       `USC <https://digitallibrary.usc.edu/cdm/ref/collection/p15799coll3/id/
+       112619>`_).

--- a/doc/transform_methods/rbasex.rst
+++ b/doc/transform_methods/rbasex.rst
@@ -122,43 +122,69 @@ How to use it
 
 The method can be used by directly calling its transform function::
 
-   recon, distr = abel.rbasex.rbasex_transform(image)
-   r, I, beta = distr.rIbeta()
+    recon, distr = abel.rbasex.rbasex_transform(image)
+    r, I, beta = distr.rIbeta()
 
-It returns the transformed image ``recon`` and a :class:`Distributions.Results`
-object ``distr``, from which various radial distributions can be retrieved,
-such as the intensity and anisotropy-parameter distributions in this example.
+It returns the transformed image ``recon`` and a :class:`Distributions.Results
+<abel.tools.vmi.Distributions.Results>` object ``distr``, from which various
+radial distributions can be retrieved, such as the intensity and
+anisotropy-parameter distributions in this example.
 
 If only the distributions are needed, but not the transformed image itself, the
 calculations can be accelerated by disabling the creation of the output image::
 
-   _, distr = abel.rbasex.rbasex_transform(image, out=None)
-   r, I, beta = distr.rIbeta()
+    _, distr = abel.rbasex.rbasex_transform(image, out=None)
+    r, I, beta = distr.rIbeta()
 
 Note that this method does not require the input image to be centered. Thus
-instead of centering it with :func:`center_image`, which will crop some data or
-fill it with zeros, it is better to pass the image origin directly to the
-transform function, determining it automatically, if needed::
+instead of centering it with :func:`~abel.tools.center.center_image`, which
+will crop some data or fill it with zeros, it is better to pass the image
+origin directly to the transform function, determining it automatically, if
+needed::
 
-   origin = abel.tools.center.find_origin(image, method='convolution')
-   recon, distr = abel.rbasex.rbasex_transform(image, origin=origin)
+    origin = abel.tools.center.find_origin(image, method='convolution')
+    recon, distr = abel.rbasex.rbasex_transform(image, origin=origin)
 
 See :func:`abel.rbasex.rbasex_transform` documentation for the full description
 of all available transform parameters.
 
 Alternatively, the method can be accessed through the universal
-:class:`abel.Transform` class::
+:class:`Transform <abel.transform.Transform>` class::
 
-   res = abel.Transform(image, method='rbasex')
-   recon = res.transform
-   distr = res.distr
+    res = abel.Transform(image, method='rbasex')
+    recon = res.transform
+    distr = res.distr
 
 passing additional rBasex parameters through the ``transform_options``
 argument. However, keep in mind that if you want to use all the data from an
-off-center image, do not use the ``origin`` argument of :class:`Transform`, but
-pass it inside ``transform_options``. This also *must* be done in optional
-pixel weighting is used, since otherwise :class:`Transform` will shift the
-image, but not the weights array.
+off-center image, do not use the ``origin`` argument of :class:`Transform
+<abel.transform.Transform>`, but pass it inside ``transform_options``. This
+also *must* be done if optional pixel weighting is used, since otherwise
+:class:`Transform <abel.transform.Transform>` will shift the image, but not the
+weights array.
+
+The weights array can be used as a mask, using zero weights to exclude unwanted
+pixels, as demonstrated in :doc:`../example_rbasex_block`. In practice, instead
+of defining the mask geometry in the code, it might be more convenient to save
+the analyzed data as an image file::
+
+    # save as an RGB image using a chosen colormap
+    plt.imsave('imagemask.png', image, cmap='hot')
+
+then open it in any raster graphics editor, paint the areas to be excluded with
+some distinct color (for example, blue in case of ``cmap='hot'``) and save it.
+This painted image then can be loaded in the program, and the mask is easily
+extracted from it::
+
+    # read as an array with R, G, B (or R, G, B, A) components
+    mask = plt.imread('imagemask.png')
+    # set zero weights for pixels with blue channel (2) > red channel (0)
+    # and unit weights for other pixels
+    weights = 1.0 - (mask[..., 2] > mask[..., 0])
+
+(for other image colormaps and mask colors, adapt the comparison logic
+accordingly). These weights then can be used in the transform of the original
+data, as well as any other data having the same mask geometry.
 
 
 Citation

--- a/doc/transform_methods/rbasex.rst
+++ b/doc/transform_methods/rbasex.rst
@@ -9,7 +9,7 @@ Introduction
 
 This method resembles the pBasex [1]_ approach of expanding a velocity-map
 image over a 2D basis set in polar coordinates, but uses more convenient basis
-functions with analytical Abel transforms, developed by M. Ryazanov in [2]_.
+functions with analytical Abel transforms, developed by M. Ryazanov [2]_.
 
 
 How it works

--- a/doc/transform_methods/rbasex_reg.py
+++ b/doc/transform_methods/rbasex_reg.py
@@ -1,0 +1,76 @@
+from __future__ import division, print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from abel.tools.analytical import SampleImage
+from abel.tools.vmi import Ibeta
+from abel.rbasex import rbasex_transform
+
+rmax = 200
+scale = 10000
+
+vlim = 0.5
+
+Ilim = (-500, 2500)
+dIlim = (-700, 700)
+
+def rescaleI(im):
+    return np.sqrt(np.abs(im)) * np.sign(im)
+
+# calculate relative RMS error for given regularization parameters
+def plot(method, strength=None):
+    # test distribution
+    source = SampleImage(n=2 * rmax - 1).image / scale
+    Isrc, _ = Ibeta(source)
+    Inorm = (Isrc**2).sum()
+
+    # simulated projection fith Poissonian noise
+    proj, _ = rbasex_transform(source, direction='forward')
+    proj[proj < 0] = 0
+    proj = np.random.RandomState(0).poisson(proj)  # (reproducible, see NEP 19)
+
+    # reconstructed image and intensity
+    if strength is None:
+        reg = method
+    else:
+        reg=(method, strength)
+    im, distr = rbasex_transform(proj, reg=reg)
+    I, _ = distr.Ibeta()
+
+    # plot...
+    fig = plt.figure(figsize=(7, 3.5), frameon=False)
+
+    # image
+    plt.subplot(121)
+
+    fig = plt.imshow(rescaleI(im), vmin=-vlim, vmax=vlim, cmap='bwr')
+
+    plt.axis('off')
+    plt.text(0, 2 * rmax, method, va='top')
+
+    # intensity
+    ax = plt.subplot2grid((3, 2), (0, 1), rowspan=2)
+
+    ax.plot(Isrc, c='r', lw=1)
+    ax.plot(I, c='k', lw=1)
+
+    ax.set_xlim((0, rmax))
+    ax.set_ylim(Ilim)
+
+    # error
+    plt.subplot(326)
+
+    plt.axhline(c='r', lw=1)
+    plt.plot(I - Isrc, c='b', lw=1)
+
+    plt.xlim((0, rmax))
+    plt.ylim(dIlim)
+
+    # finish
+    plt.subplots_adjust(left=0, right=0.97, wspace=0.1,
+                        bottom=0.08, top=0.98, hspace=0.5)
+    #plt.savefig('rbasex_reg.svg')
+    #plt.show()
+
+#plot(None)

--- a/examples/example_rbasex_block.py
+++ b/examples/example_rbasex_block.py
@@ -1,0 +1,123 @@
+from __future__ import division, print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import abel
+from abel.tools.analytical import SampleImage
+from abel.tools.vmi import rharmonics
+from abel.rbasex import rbasex_transform
+
+# This example demonstrates analysis of velocity-map images with "damaged"
+# areas, in this case, with some parts obstructed by a beam block (see
+# https://aip.scitation.org/doi/10.1063/1.4921990 for a practical example).
+# First, a general Abel-transform method is used naively to demonstrate
+# artifacts produced in the reconstructed image and the extracted radial
+# distributions.
+# Second, radial distributions are extracted from the same reconstructed image,
+# but with its artifacts masked, showing good agreement with the actual
+# distributions.
+# Third, the rBasex method is used to transform the initial damaged image with
+# the experimental artifacts masked, yielding a correct and cleaner
+# reconstructed image and correct reconstructed distributions.
+
+R = 150  # image radius
+N = 2 * R + 1  # full image width and height
+block_r = 20  # beam-block disk radius
+block_w = 5  # beam-block holder width
+
+vlim = 3.6  # intensity limits for images
+ylim = (-1.3, 2.7)  # limits for plots
+
+# create source distribution and its profiles for reference
+source = SampleImage(N).image / 100
+r_src, P0_src, P2_src = rharmonics(source)
+
+# simulate experimental image:
+# projection
+im, _ = rbasex_transform(source, direction='forward')
+# Poissonian noise
+im[im < 0] = 0
+im = np.random.RandomState(0).poisson(im)
+# image coordinates
+im_x = np.arange(float(N)) - R
+im_y = R - np.arange(float(N))[:, None]
+im_r = np.sqrt(im_x**2 + im_y**2)
+# simulate beam-block shadow
+im = im / (1 + np.exp(-(im_r - block_r)))
+im[:R] *= 1 / (1 + np.exp(-(np.abs(im_x) - block_w)))
+
+# create mask that fully covers beam-block shadow
+mask_r = block_r + 5
+mask_w = block_w + 5
+mask = np.ones_like(im)
+mask[im_r < mask_r] = 0
+mask[:R, R-mask_w:R+mask_w] = 0
+
+# reconstruct "as is" by a general Abel-transform method
+rec_abel = abel.Transform(im, method='two_point',
+                          transform_options=dict(basis_dir='bases')).transform
+# extract profiles "as is"
+r_abel, P0_abel, P2_abel = rharmonics(rec_abel)
+# extract profiles from masked reconstruction
+r_abel_masked, P0_abel_masked, P2_abel_masked = rharmonics(rec_abel, weights=mask)
+
+# reconstruct masked image with rBasex
+rec_rbasex, distr_rbasex = rbasex_transform(im, weights=mask)
+r_rbasex, P0_rbasex, P2_rbasex = distr_rbasex.rharmonics()
+
+# plotting...
+plt.figure(figsize=(7, 7))
+
+plt.cm.hot.set_bad('lightgray', 1.0)
+plt.cm.seismic.set_bad('lightgray', 1.0)
+
+def plots(row,
+          im_title, im, im_mask,
+          tr_title, tr, tr_mask,
+          pr_title, r, P0, P2):
+    # input image
+    if im is not None:
+        plt.subplot(3, 4, 4 * row + 1)
+        plt.title(im_title)
+        im_masked = np.ma.masked_where(im_mask == 0, im)
+        plt.imshow(im_masked, cmap='hot')
+        plt.axis('off')
+
+    # transformed image
+    plt.subplot(3, 4, 4 * row + 2)
+    plt.title(tr_title)
+    tr_masked = np.ma.masked_where(tr_mask == 0, tr)
+    plt.imshow(tr_masked, vmin=-vlim, vmax=vlim, cmap='seismic')
+    plt.axis('off')
+
+    # profiles
+    plt.subplot(3, 2, 2 * row + 2)
+    plt.title(pr_title)
+    plt.axvspan(0, mask_r, color='lightgray')  # shade region without valid data
+    plt.plot(r_src, P0_src, 'C0--', lw=1)
+    plt.plot(r_src, P2_src, 'C3--', lw=1)
+    plt.plot(r, P0, 'C0', lw=1, label='$P_0(r)$')
+    plt.plot(r, P2, 'C3', lw=1, label='$P_2(r)$')
+    plt.xlim((0, R))
+    plt.ylim(ylim)
+    plt.legend()
+
+plots(0,
+      'Raw image', im, None,
+      'Two-point', rec_abel, None,
+      'Profiles', r_abel, P0_abel, P2_abel)
+
+plots(1,
+      None, None, None,
+      'Two-point + mask', rec_abel, mask,
+      'Masked profiles', r_abel_masked, P0_abel_masked, P2_abel_masked)
+
+plots(2,
+      'Masked image', im, mask,
+      'rBasex', rec_rbasex, None,
+      'Profiles', r_rbasex, P0_rbasex, P2_rbasex)
+
+plt.subplots_adjust(left=0.01, right=0.97, wspace=0.1,
+                    bottom=0.04, top=0.96, hspace=0.3)
+plt.show()

--- a/examples/example_rbasex_multimass.py
+++ b/examples/example_rbasex_multimass.py
@@ -1,0 +1,131 @@
+from __future__ import division, print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import abel
+from abel.rbasex import rbasex_transform
+
+# This example demonstrates analysis of partially overlapping velocity-map
+# images, which might be useful for the "multimass imaging" method (see
+# https://pubs.acs.org/doi/10.1021/jp053143m).
+# Reconstruction of each part of the combined image uses zero weights for all
+# pixels not belonging to that part or contaminated by signals from other
+# parts in order to extract distributions pertaining to that part only.
+# Notice that the central image in this example cannot be correctly
+# reconstructed by "usual" Abel-transform methods, since all its quadrants are
+# contaminated. However, the remaining uncontaminated radial and angular ranges
+# are sufficient for rBasex to reconstruct the complete distributions.
+
+# Create an artificial sample image from experimental and synthetic images.
+# central image
+im2 = np.loadtxt('data/O2-ANU1024.txt.bz2')
+from scipy.ndimage import zoom
+im2 = zoom(im2, 0.75)  # (resized for better visibility)
+h2, w2 = im2.shape
+# right image
+im3 = np.loadtxt('data/VMI_art1.txt.bz2')
+im3 *= 2  # (intensified for better visibility)
+h3, w3 = im3.shape
+# left image
+h1 = w1 = min(h3, w3)
+r1 = h1 // 2
+x = np.linspace(-r1, r1, w1)
+im1 = np.random.RandomState(0).poisson(200 * np.exp(-(x**2 + x[:, None]**2) /
+                                       (r1 / 3)**2))
+# assemble the whole image
+h, w = max(h2, h3), w2 + w3
+im = np.zeros((h, w))
+row1, col1 = (h - h1) // 2, 0
+im[row1:row1+h1, col1:col1+w1] += im1
+row2, col2 = (h - h2) // 2, (w - w2) // 2
+im[row2:row2+h2, col2:col2+w2] += im2
+row3, col3 = (h - h3) // 2, w - w3
+im[row3:row3+h3, col3:col3+w3] += im3
+
+# Origins and maximal radii for each part
+# (in reality they will need to be determined from the data somehow; also,
+# in practice it would be better to cut the whole image into parts and work
+# with them separately, which is not done here to simplify the code).
+# for left image
+origin1 = (h // 2 - 1, w1 // 2)
+r1 = min(h1, w1) // 2
+# for central image
+origin2 = (h // 2, w // 2)
+r2 = min(h2, w2) // 2 - 50
+# for right image
+origin3 = (h // 2 - 1, w - w3 // 2 - 1)
+r3 = min(h3, w3) // 2
+
+# Create "masks" for each part with unit weights for "good" pixels and zero
+# weights for "bad" pixels.
+# coordinates relative to each origin
+x1, y1 = abel.tools.polar.index_coords(im, origin=origin1)
+x2, y2 = abel.tools.polar.index_coords(im, origin=origin2)
+x3, y3 = abel.tools.polar.index_coords(im, origin=origin3)
+# for left image (include left, exclude central)
+mask1 = np.array((x1**2 + y1**2 < r1**2) *  # inside radius r1 from origin1 and
+                 (x2**2 + y2**2 > r2**2),   # outside radius r2 from origin2
+                 dtype=float)
+# for central image (include central, exclude left and right)
+mask2 = np.array((x2**2 + y2**2 < r2**2) *  # inside radius r2 from origin2 and
+                 (x1**2 + y1**2 > r1**2) *  # outside radius r1 from origin1 and
+                 (x3**2 + y3**2 > r3**2),   # outside radius r3 from origin3
+                 dtype=float)
+# for right image (include right, exclude central)
+mask3 = np.array((x3**2 + y3**2 < r3**2) *  # inside radius r3 from origin3 and
+                 (x2**2 + y2**2 > r2**2),   # outside radius r2 from origin2
+                 dtype=float)
+
+fig = plt.figure(figsize=(12, 8))
+
+# Show the whole image
+plt.subplot(221)
+plt.title('Partially overlapping images\n'
+          '(with outlined regions for analysis)')
+plt.imshow(im, cmap='hot')
+# overlay with the boundaries of each mask (only for demonstration)
+from scipy.ndimage import binary_erosion
+dmask = 1 * (mask1 - binary_erosion(mask1, iterations=3)) + \
+        2 * (mask2 - binary_erosion(mask2, iterations=3)) + \
+        3 * (mask3 - binary_erosion(mask3, iterations=3))
+dmask[dmask == 0] = np.nan
+from matplotlib.colors import ListedColormap
+rgb = ListedColormap(['#CC0000', '#00AA00', '#0055FF'])
+plt.imshow(dmask, extent=(0, w, 0, h), cmap=rgb)
+
+# Analyze the left part and plot results
+plt.subplot(222)
+plt.title('Distributions: left image')
+# the reconstructed image is not used in this example, so it is not created;
+# also notice that order=0 is enough for this totally isotropic case
+_, distr = rbasex_transform(im, origin=origin1, rmax=r1, order=0, weights=mask1, out=None)
+r, I = distr.rIbeta()
+plt.plot(r, I, c=rgb(0), label='$I(r)$')
+plt.legend()
+plt.autoscale(enable=True, tight=True)
+
+# Analyze the central part and plot results
+plt.subplot(223)
+plt.title('Distributions: central image')
+# here the default order=2 is needed and used
+_, distr = rbasex_transform(im, origin=origin2, rmax=r2, weights=mask2, out=None)
+r, I, beta = distr.rIbeta()
+plt.plot(r, I, c=rgb(1), label='$I(r)$')
+# beta(r) I(r) is the "speed distribution" of P_2(r)
+plt.plot(r, beta * I, c='gray', label='$\\beta(r) \\cdot I(r)$')
+plt.legend()
+plt.autoscale(enable=True, tight=True)
+
+# Analyze the right part and plot results
+plt.subplot(224)
+plt.title('Distributions: right image')
+_, distr = rbasex_transform(im, origin=origin3, rmax=r3, weights=mask3, out=None)
+r, I, beta = distr.rIbeta()
+plt.plot(r, I, c=rgb(2), label='$I(r)$')
+plt.plot(r, I * beta, c='gray', label='$\\beta(r) \\cdot I(r)$')
+plt.legend()
+plt.autoscale(enable=True, tight=True)
+
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
Here is a new method for analyzing velocity-mapping images, similar to pBasex, but implemented more efficiently.

The main idea is that the Abel transform of _f_(_r_) cos<sup>_n_</sup> θ is _F<sub>_n_</sub>_(_r_) cos<sup>_n_</sup> θ, with some other radial part _F_<sub>_n_</sub> (different for different powers _n_) but the same angular dependence. And if a suitable basis is chosen for the radial part, the forward transforms _f_(_r_) → _F_<sub>_n_</sub>(_r_) can be computed analytically for all _n_. The rest is as usual in all “BASEX”-type methods.

That is, to perform a forward or inverse Abel transform of an image, it is sufficient to extract from it the radial profiles of all cos<sup>_n_</sup> θ terms, transform these radial profiles (which is much faster that transforming the whole image) and, if needed, construct the transformed image from the transformed profiles. The transformed radial profiles also directly give various radial distributions needed in VMI studies, thus if the transformed image itself is not needed, the last step can be skipped, making the analysis even faster.

An example of speed comparison with `two_point`, the fastest of current methods:
```
PyAbel benchmark run on AMD64 Family 23 Model 17 Stepping 0, AuthenticAMD

time in milliseconds

=== Basis generation ======================================================

Method              n = 513    n = 1025    n = 2049    n = 4097    n = 8193
---------------------------------------------------------------------------
rbasex                 11.7        34.8       116.7       598.9      3248.7
two_point               2.6        13.7        57.7       234.6      1019.7


=== Forward Abel transform ================================================

Method              n = 513    n = 1025    n = 2049    n = 4097    n = 8193
---------------------------------------------------------------------------
rbasex                  2.7        14.6        62.7       302.2      1167.8
rbasex(None)            1.4         6.5        31.7       132.7       516.2


=== Inverse Abel transform ================================================

Method              n = 513    n = 1025    n = 2049    n = 4097    n = 8193
---------------------------------------------------------------------------
rbasex                  2.7        14.7        63.0       302.6      1170.6
rbasex(None)            1.4         6.6        31.8       132.8       516.8
two_point               1.3         9.9        73.7       561.5      4343.1
```
(here `rbasex(None)` means that the output image is not constructed)
And, for completeness, the time that must be added to the `two_point` transform to extract radial distributions from the image:
```
order = 2, time in milliseconds
=== Full image, cached ======================================================
Method                n = 513    n = 1025    n = 2049    n = 4097    n = 8193
-----------------------------------------------------------------------------
linear
   MIN, none              1.8         7.6        31.0       125.7       498.1
```
So when only the radial distributions are needed, the rBasex transform is almost free. Otherwise, when the transformed image is also constructed, `rbasex` is competitive with `two_point` (and other fast methods) at 1 megapixel (the typical image size) and wins at larger image sizes. The best thing is that the time complexity scales only quadratically with the image radius, in contrast to the cubic scaling in all other methods (except maybe Hansen–Law).

Now let's see how the documentation will be built for this PR...

(More testing, proofreading and fact-checking about pBasex are still neded.)