### PR TITLE
Corrections to example GUI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Unreleased
 * Added "orders", "sinpowers" and "valid" to tools.vmi.Distributions results,
   reordered cossin() powers for consistency (PR #270).
 * Improved tools.vmi.Distributions performance on Windows (PR #270).
+* More corrections to the GUI example: working without the "bases" directory,
+  loading "from transform", interface enhancements (PR #277).
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -323,9 +323,9 @@ class PyAbel:  # (tk.Tk):
             self.IM = abel.tools.analytical.SampleImage(n=1001,
                                                         name=self.fn).image
             self.direction.current(1)  # raw images require 'forward' transform
-            self.text.insert(tk.END, "\nsample image: (1) Abel transform 'forward', ")
-            self.text.insert(tk.END, "              (2) load 'from transform', ")
-            self.text.insert(tk.END, "              (3) Abel transform 'inverse', ")
+            self.text.insert(tk.END, "\nsample image: (1) Abel transform 'forward',\n")
+            self.text.insert(tk.END, "              (2) load 'from transform',\n")
+            self.text.insert(tk.END, "              (3) Abel transform 'inverse',\n")
             self.text.insert(tk.END, "              (4) Speed")
             self.text.see(tk.END)
 
@@ -379,17 +379,25 @@ class PyAbel:  # (tk.Tk):
                 self.text.insert(
                    tk.END,
                    "\ndirect: calculation is slowed if Cython unavailable ...")
+            self.text.see(tk.END)
             self.canvas.draw()
 
-            if self.method == 'linbasex':
-                self.AIM = abel.Transform(
-                    self.IM, method=self.method, direction=self.fi,
-                    transform_options=dict(return_Beta=True))
-            else:
-                self.AIM = abel.Transform(
-                    self.IM, method=self.method, direction=self.fi,
-                    transform_options=dict(basis_dir='bases'),
-                    symmetry_axis=None)
+            try:
+                if self.method == 'linbasex':
+                    self.AIM = abel.Transform(
+                        self.IM, method=self.method, direction=self.fi,
+                        transform_options=dict(return_Beta=True))
+                else:
+                    self.AIM = abel.Transform(
+                        self.IM, method=self.method, direction=self.fi,
+                        transform_options=dict(basis_dir='bases'),
+                        symmetry_axis=None)
+            except Exception as e:
+                self.text.insert(tk.END, "\nAn error occured:\n")
+                self.text.insert(tk.END, e)
+                self.text.see(tk.END)
+                self.canvas.draw()
+
             self.rmin.delete(0, tk.END)
             self.rmin.insert(0, self.rmx[0])
             self.rmax.delete(0, tk.END)

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -165,7 +165,7 @@ class PyAbel:  # (tk.Tk):
             master=self.button_frame, font=self.font,
             values=["from file", "from transform",
                     "sample dribinski", "sample Ominus"],
-            width=14, height=4)
+            state="readonly", width=14, height=4)
         self.sample_image.current(0)
         self.sample_image.grid(row=1, column=0, padx=(5, 10))
 
@@ -184,7 +184,7 @@ class PyAbel:  # (tk.Tk):
         self.center.grid(row=0, column=1, padx=(0, 20), pady=(5, 0))
         self.center_method = ttk.Combobox(
             master=self.button_frame, font=self.font, values=center_methods,
-            width=11, height=4)
+            state="readonly", width=11, height=4)
         self.center_method.current(1)
         self.center_method.grid(row=1, column=1, padx=(0, 20))
 
@@ -197,14 +197,15 @@ class PyAbel:  # (tk.Tk):
         self.recond.grid(row=0, column=2, padx=(0, 10), pady=(5, 0))
 
         self.transform = ttk.Combobox(
-            master=self.button_frame, values=Abel_methods, font=self.font,
-            width=10, height=len(Abel_methods))
+            master=self.button_frame, font=self.font, values=Abel_methods,
+            state="readonly", width=10, height=len(Abel_methods))
         self.transform.current(2)  # hansenlaw
         self.transform.grid(row=1, column=2, padx=(0, 20))
 
         self.direction = ttk.Combobox(
-            master=self.button_frame, values=["inverse", "forward"],
-            font=self.font, width=8, height=2)
+            master=self.button_frame, font=self.font,
+            values=["inverse", "forward"],
+            state="readonly", width=8, height=2)
         self.direction.current(0)
         self.direction.grid(row=2, column=2, padx=(0, 20))
 

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -15,6 +15,8 @@ from matplotlib import gridspec
 
 from scipy.ndimage.interpolation import shift
 
+import os.path
+
 from six.moves import tkinter as tk
 from six.moves import tkinter_ttk as ttk
 from six.moves import tkinter_font as tkFont
@@ -388,9 +390,18 @@ class PyAbel:  # (tk.Tk):
                         self.IM, method=self.method, direction=self.fi,
                         transform_options=dict(return_Beta=True))
                 else:
+                    basis_dir = 'bases'
+                    if not os.path.isdir(basis_dir):
+                        self.text.insert(tk.END,
+                            "\n(No '" + basis_dir + "' directory;"
+                            " bases sets will not be loaded/saved.)")
+                        self.text.see(tk.END)
+                        self.canvas.draw()
+                        basis_dir = None
+
                     self.AIM = abel.Transform(
                         self.IM, method=self.method, direction=self.fi,
-                        transform_options=dict(basis_dir='bases'),
+                        transform_options=dict(basis_dir=basis_dir),
                         symmetry_axis=None)
             except Exception as e:
                 self.text.insert(tk.END, "\nAn error occured:\n")

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -302,7 +302,7 @@ class PyAbel:  # (tk.Tk):
 
         self.fn = self.sample_image.get()
         # update what is occurring text box
-        self.text.insert(tk.END, "\nloading image file {:s}".format(self.fn))
+        self.text.insert(tk.END, "\nloading image {:s}".format(self.fn))
         self.text.see(tk.END)
         self.canvas.draw()
 
@@ -314,7 +314,7 @@ class PyAbel:  # (tk.Tk):
             else:
                 self.IM = plt.imread(self.fn)
         elif self.fn == "from transform":
-            self.IM = self.AIM
+            self.IM = self.AIM.transform
             self.AIM = None
             for i in range(1, 4):
                 self._clr_plt(i)


### PR DESCRIPTION
Here is the correction to `example_GUI.py` that lets it run without the `'bases'` directory, as discussed in #275. Moreover, now it catches all exceptions occurring in `Transform()` and shows them in the GUI messages pane, so that if something wrong happens, the user will surely notice that.

Another problem was that loading "from transform" in fact did not work, since the code assigned the `Transform` object instead of its transformed image (`.transform`). This is also corrected (and seems to work).

Please test.