### PR TITLE
included python 3.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: python
 sudo: false
 matrix:
   include:
-  - python: '3.7'
+  - python: '3.8'
     env: DEPS="numpy scipy cython"
     sudo: true
     dist: xenial
-  - python: '3.6'
+  - python: '3.8'
     env: DEPS="numpy scipy cython"
+    sudo: true
+    dist: xenial
   - python: '2.7'
     env: DEPS="numpy scipy cython"
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,16 +13,16 @@ environment:
     - PYTHON_VERSION: 2.7
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda-x64
-    - PYTHON_VERSION: 3.6
+    - PYTHON_VERSION: 3.7
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 3.6
+    - PYTHON_VERSION: 3.7
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
-    - PYTHON_VERSION: 3.7
+    - PYTHON_VERSION: 3.8
       PYTHON_ARCH: "32"
       MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 3.7
+    - PYTHON_VERSION: 3.8
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
 


### PR DESCRIPTION
As @MikhailRyazanov pointed out (#271 (comment)), we should be testing with the latest version of Python (3.8). I removed the tests for Python 3.6, since I think that testing on three Python versions is enough (2.7, 3.7, 3.8). 

(I know that @stggh will argue that we drop the Py2.7 test. He's probably right. Maybe we keep Py2 compatibility and testing through 2020 and we can celebrate New Years by going all Py3?) 