### PR TITLE
Circularization improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Unreleased
   loading "from transform", interface enhancements (PR #277).
 * Improved documentation (PR #283, PR #288).
 * Correctly use quadrants in abel.Transform (PR #287).
+* Circularization now uses periodic splines (to avoid discontinuity), with
+  smoothing determined by the RMS tolerance instead of the nonintuitive
+  "smooth" parameter (PR #293).
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,7 +2,7 @@ Contributing to PyAbel
 ======================
 
 
-PyAbel is an open source project and we welcome improvements! Please let us know about any issues with the software, even if's just a typo. The easiest way to get started is to open a `new issue <https://github.com/PyAbel/PyAbel/issues>`_.
+PyAbel is an open-source project, and we welcome improvements! Please let us know about any issues with the software, even if's just a typo. The easiest way to get started is to open a `new issue <https://github.com/PyAbel/PyAbel/issues>`_.
 
 If you would like to make a Pull Request, the following information may be useful.
 
@@ -14,7 +14,7 @@ Before submitting at Pull Request, be sure to run the unit tests. The test suite
     
     pytest
     
-For more detailed information, the following can be used:  ::
+For more detailed information, the following can be used::
 
     pytest abel/  -v  --cov=abel
 
@@ -26,16 +26,16 @@ Note that this requires that you have `pytest <https://docs.pytest.org/en/latest
 Documentation
 -------------
 
-PyAbel uses Sphinx and `Napoleon <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html>`_ to process Numpy style docstrings, and is synchronized to `pyabel.readthedocs.io <http://pyabel.readthedocs.io>`_. To build the documentation locally, you will need `Sphinx <http://www.sphinx-doc.org/>`_, the `recommonmark <https://github.com/rtfd/recommonmark>`_ package, and the `sphinx_rtd_theme <https://github.com/snide/sphinx_rtd_theme/>`_. You can install all this this using ::
+PyAbel uses Sphinx and `Napoleon <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html>`_ to process Numpy-style docstrings and is synchronized to `pyabel.readthedocs.io <http://pyabel.readthedocs.io>`_. To build the documentation locally, you will need `Sphinx <http://www.sphinx-doc.org/>`_, the `recommonmark <https://github.com/rtfd/recommonmark>`_ package, and the `sphinx_rtd_theme <https://github.com/snide/sphinx_rtd_theme/>`_. You can install them using ::
 
     pip install sphinx
     pip install recommonmark
     pip install sphinx_rtd_theme
 
-Once you have that installed, then you can build the documentation using ::
+Once you have these packages installed, you can build the documentation using ::
 
     cd PyAbel/doc/
-     make html
+    make html
 
 Then you can open ``doc/_build/hmtl/index.html`` to look at the documentation. Sometimes you need to use ::
 
@@ -63,13 +63,13 @@ Code Style
 
 We hope that the PyAbel code will be understandable, hackable, and maintainable for many years to come. So, please use good coding style, include plenty of comments, use docstrings for functions, and pick informative variable names.
 
-PyAbel attempts to follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style whenever possible, since the PEP8 recommendations typically produces code that is easier to read. You can check your code using `pycodestyle <https://pypi.org/project/pycodestyle/>`_, which can be called from the command line or incorporated right into most text editors. Also, PyAbel is using automated pycodestyle checking of all Pull Requests using `pep8speaks <https://pep8speaks.com/>`_. However, `producing readable code <https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds>`_ is the primary goal, so please go ahead and break the rules of PEP8 when doing so improves readability. For example, if a section of your code is easier to read with lines slightly longer than 79 characters, then use the longer lines."
+PyAbel attempts to follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style whenever possible, since the PEP8 recommendations typically produces code that is easier to read. You can check your code using `pycodestyle <https://pypi.org/project/pycodestyle/>`_, which can be called from the command line or incorporated right into most text editors. Also, PyAbel is using automated pycodestyle checking of all Pull Requests using `pep8speaks <https://pep8speaks.com/>`_. However, `producing readable code <https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds>`_ is the primary goal, so please go ahead and break the rules of PEP8 when doing so improves readability. For example, if a section of your code is easier to read with lines slightly longer than 79 characters, then use the longer lines.
 
 
 Before merging
 --------------
 
-If possible, before merging your pull request please rebase your fork on the last master on PyAbel. This could be done `as explained in this post <https://stackoverflow.com/questions/7244321/how-to-update-a-github-forked-repository>`_ ::
+If possible, before merging your pull request please rebase your fork on the last master on PyAbel. This could be done `as explained in this post <https://stackoverflow.com/questions/7244321/how-to-update-a-github-forked-repository>`_::
 
     # Add the remote, call it "upstream" (only the fist time)
     git remote add upstream https://github.com/PyAbel/PyAbel.git
@@ -102,29 +102,35 @@ Adding a new forward or inverse Abel implementation
 
 We are always looking for new implementation of forward or inverse Abel transform, therefore if you have an implementation that you would want to contribute to PyAbel, don't hesitate to do so.
 
-In order to allow a consistent user experience between different implementations, and insure an overall code quality, please consider the following points in your pull request.
+In order to allow a consistent user experience between different implementations and insure an overall code quality, please consider the following points in your pull request.
 
 
 Naming conventions
 ~~~~~~~~~~~~~~~~~~
 
-The implementation named `<implementation>`, located under `abel/<implementation>.py` should use the following naming system for top-level functions,
+The implementation named ``<implementation>``, located under ``abel/<implementation>.py``, should use the following naming system for top-level functions:
 
- -  ``<implemenation>_transform`` :  core transform (when defined)
- -  ``_bs_<implementation>`` :  function that generates  the basis sets (if necessary)
+- ``<implemenation>_transform`` :  core transform (when defined)
+- ``_bs_<implementation>`` :  function that generates  the basis sets (if necessary)
 
 
 Unit tests
 ~~~~~~~~~~
-To detect issues early, the submitted implementation should have the following properties and pass the corresponding unit tests,
+To detect issues early, the submitted implementation should have the following properties and pass the corresponding unit tests:
 
 1. The reconstruction has the same shape as the original image. Currently all transform methods operate with odd-width images and should raise an exception if provided with an even-width image.
 
-2. Given an array of 0 elements, the reconstruction should also be a 0 array.
+2. Given an array with all 0 elements, the reconstruction should also be a 0 array.
 
-3. The implementation should be able to calculated the inverse (or forward) transform of a Gaussian function defined by a standard deviation ``sigma``, with better than a ``10 %`` relative error with respect to the analytical solution for ``0 > r > 2*sigma``.
+3. The implementation should be able to calculated the inverse (or forward) transform of a Gaussian function defined by a standard deviation ``sigma``, with better than a 10 % relative error with respect to the analytical solution for ``0 < r < 2*sigma``.
 
-Unit tests for a given implementation are located under ``abel/tests/test_<implemenation>.py``, which should contain at least the following 3 functions ``test_<implementation>_shape``, ``test_<implementation>_zeros``, ``test_<implementation>_gaussian``. See ``abel/tests/test_basex.py`` for a concrete example.
+Unit tests for a given implementation are located under ``abel/tests/test_<implemenation>.py``, which should contain at least the following 3 functions:
+
+- ``test_<implementation>_shape``
+- ``test_<implementation>_zeros``
+- ``test_<implementation>_gaussian``
+
+See ``abel/tests/test_basex.py`` for a concrete example.
 
 
 Dependencies

--- a/abel/tests/test_tools_circularize.py
+++ b/abel/tests/test_tools_circularize.py
@@ -21,7 +21,7 @@ def test_circularize_image():
 
     IMcirc, angle, scalefactor, spline =\
         abel.tools.circularize.circularize_image(IMdist,
-                   method='lsq', dr=0.5, dt=0.1, smooth=0,
+                   method='lsq', dr=0.5, dt=0.1, tol=0,
                    ref_angle=0, return_correction=True)
 
     r, c = IMcirc.shape

--- a/abel/tests/test_tools_circularize.py
+++ b/abel/tests/test_tools_circularize.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import abel
+from abel.tools.circularize import circularize, circularize_image
 
 
 def test_circularize_image():
@@ -14,19 +15,18 @@ def test_circularize_image():
 
     # flower image distortion
     def flower_scaling(theta, freq=2, amp=0.1):
-        return 1 + amp*np.sin(freq*theta)**4
+        return 1 + amp * np.sin(freq * theta)**4
 
-    IMdist = abel.tools.circularize.circularize(IM,
-                                    radial_correction_function=flower_scaling)
+    IMdist = circularize(IM, radial_correction_function=flower_scaling)
 
-    IMcirc, angle, scalefactor, spline =\
-        abel.tools.circularize.circularize_image(IMdist,
-                   method='lsq', dr=0.5, dt=0.1, tol=0,
-                   ref_angle=0, return_correction=True)
+    IMcirc, angle, scalefactor, spline = \
+        circularize_image(IMdist,
+                          method='lsq', dr=0.5, dt=0.1, tol=0,
+                          ref_angle=0, return_correction=True)
 
     r, c = IMcirc.shape
 
-    diff = (IMcirc - IM).sum(axis=1).sum(axis=0)
+    diff = (IMcirc - IM).sum()
 
     assert_allclose(diff, -307.603, atol=0.05)
 

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 import numpy as np
-from scipy import ndimage
+from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import UnivariateSpline, splrep, splev
 from scipy.optimize import leastsq
 
@@ -261,8 +261,7 @@ def circularize(IM, radial_correction_function, ref_angle=None):
 
     # @DanHickstein magic
     # https://github.com/PyAbel/PyAbel/issues/186#issuecomment-275471271
-    IMcirc = ndimage.interpolation.map_coordinates(IM,
-                     (origin[1] - Yactual, Xactual + origin[0]))
+    IMcirc = map_coordinates(IM, (origin[1] - Yactual, Xactual + origin[0]))
 
     return IMcirc
 

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -2,7 +2,7 @@
 from __future__ import division
 import numpy as np
 from scipy import ndimage
-from scipy.interpolate import UnivariateSpline
+from scipy.interpolate import UnivariateSpline, splrep, splev
 from scipy.optimize import leastsq
 
 import abel
@@ -208,9 +208,12 @@ def circularize_image(IM, method="lsq", origin=None, radial_range=None,
     else:
         smooth = len(angles) * tol**2
 
-    # spline radial correction vs angle
-    radial_correction_function = UnivariateSpline(angles, radcorr, s=smooth,
-                                                  ext=3)
+    # periodic spline radial correction vs angle
+    spl = splrep(np.append(angles, angles[0] + 2 * np.pi),
+                 np.append(radcorr, radcorr[0]), s=smooth, per=True)
+
+    def radial_correction_function(angle):
+        return splev(angle, spl)
 
     # apply the correction
     IMcirc = circularize(IM, radial_correction_function, ref_angle=ref_angle)

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -24,8 +24,8 @@ from abel import _deprecated, _deprecate
 
 
 def circularize_image(IM, method="lsq", origin=None, radial_range=None,
-                      dr=0.5, dt=0.5, smooth=0, ref_angle=None,
-                      inverse=False, return_correction=False,
+                      dr=0.5, dt=0.5, smooth=_deprecated, ref_angle=None,
+                      inverse=False, return_correction=False, tol=0,
                       center=_deprecated):
     r"""
     Corrects image distortion on the basis that the structure should be
@@ -109,25 +109,19 @@ def circularize_image(IM, method="lsq", origin=None, radial_range=None,
         Also passed to :func:`abel.tools.polar.reproject_image_into_polar`.
 
     smooth : float
-        This value is passed to the :func:`scipy.interpolate.UnivariateSpline`
-        function and controls how smooth the spline interpolation is. A value
-        of zero corresponds to a spline that runs through all of the points,
-        and higher values correspond to a smoother spline function.
-
-        It is important to examine the relative peak position (scaling factor)
-        data and how well it is represented by the spline function. Use the
-        option ``return_correction=True`` to examine this data. Typically,
-        **smooth** may remain zero, noisy data may require some smoothing.
+        Deprecated, use **tol** instead. The relationship is
+        **smooth** = `N`\ :sub:`angles` × **tol**\ :sup:`2`,
+        where `N`\ :sub:`angles` is the number of slices (see **dt**).
 
     ref_angle : None or float
         Reference angle for which radial coordinate is unchanged.
         Angle varies between :math:`-\pi` and :math:`\pi`, with zero angle
         vertical.
 
-        ``None`` uses :func:`numpy.mean(radial scale factors)`, which attempts
-        to maintain the same average radial scaling. This approximation is
-        likely valid, unless you know for certain that a specific angle of
-        your image corresponds to an undistorted image.
+        ``None`` uses :func:`numpy.mean` of the radial correction function,
+        which attempts to maintain the same average radial scaling. This
+        approximation is likely valid, unless you know for certain that a
+        specific angle of your image corresponds to an undistorted image.
 
     inverse : bool
         Apply an inverse Abel transform to the `polar`-coordinate image, to
@@ -141,6 +135,21 @@ def circularize_image(IM, method="lsq", origin=None, radial_range=None,
 
     return_correction : bool
         Additional outputs, as describe below.
+
+    tol : float
+        Root-mean-square (RMS) fitting tolerance for the spline function. At
+        the default zero value, the spline interpolates between the discrete
+        scaling factors. At larger values, a smoother spline is found such that
+        its RMS deviation from the discrete scaling factors does not exceed
+        this number. For example, ``tol=0.01`` means 1% RMS tolerance for the
+        radial scaling correction. At very large tolerances, the spline
+        degenerates to a constant, the average of the discrete scaling factors.
+
+        Typically, **tol** may remain zero (use interpolation), but noisy data
+        may require some smoothing, since the found discrete scaling factors
+        can have noticeable errors. To examine the relative scaling factors and
+        how well they are represented by the spline function, use the option
+        ``return_correction=True``.
 
     Returns
     -------
@@ -192,6 +201,12 @@ def circularize_image(IM, method="lsq", origin=None, radial_range=None,
 
     # evaluate radial correction factor that aligns each angular slice
     radcorr = correction(polarIM.T, angles, radial, method=method)
+
+    if smooth is not _deprecated:
+        _deprecate('abel.tools.circularize.circularize_image() '
+                   'argument "smooth" is deprecated, use "tol" instead.')
+    else:
+        smooth = len(angles) * tol**2
 
     # spline radial correction vs angle
     radial_correction_function = UnivariateSpline(angles, radcorr, s=smooth,

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -102,7 +102,7 @@ class Transform(object):
     symmetry_axis : None, int or tuple
         Symmetrize the image about the numpy axis
         0 (vertical), 1 (horizontal), (0, 1) (both axes). Note that the
-        abel transform is always performed around the vertical axis.
+        Abel transform is always performed around the vertical axis.
         This parameter only affects how the image is modified before
         (and after) applying the Abel transform. For more information,
         see the "Quadrant combining" note below.

--- a/doc/circularize_image.rst
+++ b/doc/circularize_image.rst
@@ -57,7 +57,7 @@ Other parameters may help better define the radial correction function.
 Warning
 -------
 Ensure the returned radial_correction vs angle data is a well behaved function. 
-See the example, below, bottom left figure. If necessary limit the ``radial_range=(Rmin, Rmax)``, or change the value of the spline smoothing parameter.
+See the example, below, bottom left figure. If necessary limit the ``radial_range=(Rmin, Rmax)``, or change the value of the spline smoothing parameter ``tol``.
 
 Example
 -------

--- a/examples/example_circularize_image.py
+++ b/examples/example_circularize_image.py
@@ -22,15 +22,17 @@ IMf = abel.Transform(IM, method='hansenlaw', direction="forward").transform
 
 # flower image distortion
 def flower_scaling(theta, freq=2, amp=0.1):
-    return 1 + amp*np.sin(freq*theta)**4
+    return 1 + amp * np.sin(freq * theta)**4
 
 # distort the image
 IMdist = abel.tools.circularize.circularize(IMf,
-                                radial_correction_function=flower_scaling)
+                                            radial_correction_function=flower_scaling)
 
 # circularize ------------
-IMcirc, sla, sc, scspl = abel.tools.circularize.circularize_image(IMdist,
-               method='lsq', dr=0.5, dt=0.1, tol=0, return_correction=True)
+IMcirc, sla, sc, scspl = \
+    abel.tools.circularize.circularize_image(IMdist,
+                                             method='lsq', dr=0.5, dt=0.1,
+                                             tol=0, return_correction=True)
 
 # inverse Abel transform for distored and circularized images ---------
 AIMdist = abel.Transform(IMdist, method="three_point",
@@ -42,7 +44,7 @@ AIMcirc = abel.Transform(IMcirc, method="three_point",
 rdist, speeddist = abel.tools.vmi.angular_integration(AIMdist, dr=0.5)
 rcirc, speedcirc = abel.tools.vmi.angular_integration(AIMcirc, dr=0.5)
 
-# note the small image size is responsible for the slight over correction 
+# note the small image size is responsible for the slight over correction
 # of the background near peaks
 
 row, col = IMcirc.shape
@@ -52,12 +54,12 @@ row, col = IMcirc.shape
 fig, axs = plt.subplots(2, 2, figsize=(8, 8))
 fig.subplots_adjust(wspace=0.5, hspace=0.5)
 
-extent = (np.min(-col//2), np.max(col//2), np.min(-row//2), np.max(row//2))
+extent = (np.min(-col // 2), np.max(col // 2),
+          np.min(-row // 2), np.max(row // 2))
 axs[0, 0].imshow(IMdist, aspect='auto', origin='lower', extent=extent)
 axs[0, 0].set_title("Ominus distorted sample image")
 
-axs[0, 1].imshow(AIMcirc, vmin=0, aspect='auto', origin='lower',
-                 extent=extent)
+axs[0, 1].imshow(AIMcirc, vmin=0, aspect='auto', origin='lower', extent=extent)
 axs[0, 1].set_title("circ. + inv. Abel")
 
 axs[1, 0].plot(sla, sc, 'o')

--- a/examples/example_circularize_image.py
+++ b/examples/example_circularize_image.py
@@ -30,7 +30,7 @@ IMdist = abel.tools.circularize.circularize(IMf,
 
 # circularize ------------
 IMcirc, sla, sc, scspl = abel.tools.circularize.circularize_image(IMdist,
-               method='lsq', dr=0.5, dt=0.1, smooth=0, return_correction=True)
+               method='lsq', dr=0.5, dt=0.1, tol=0, return_correction=True)
 
 # inverse Abel transform for distored and circularized images ---------
 AIMdist = abel.Transform(IMdist, method="three_point",


### PR DESCRIPTION
This is to address #276 — switching to periodic splines to avoid possibly discontinuous corrections at ±π, and also switching from the raw `smooth` parameter for spline smoothing to the more meaningful RMS tolerance.