### PR TITLE
Minor documentation improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,23 +29,23 @@ Transform Methods
 
 The outcome of the numerical Abel transform depends on the exact method used. So far, PyAbel includes the following `transform methods <https://pyabel.readthedocs.io/en/latest/transform_methods.html>`_:
 
-    1. ``basex`` - Gaussian basis set expansion of Dribinski and co-workers.
+1. ``basex`` - Gaussian basis set expansion of Dribinski and co-workers.
 
-    2. ``hansenlaw`` - recursive method of Hansen and Law.
+2. ``hansenlaw`` - recursive method of Hansen and Law.
 
-    3. ``direct`` - numerical integration of the analytical Abel transform equations.
+3. ``direct`` - numerical integration of the analytical Abel transform equations.
 
-    4. ``two_point`` - the "two point" method of Dasch and co-workers.
+4. ``two_point`` - the "two point" method of Dasch and co-workers.
 
-    5. ``three_point`` - the "three point" method of Dasch and co-workers.
+5. ``three_point`` - the "three point" method of Dasch and co-workers.
 
-    6. ``onion_peeling`` - the "onion peeling" deconvolution method of Dasch and co-workers.
+6. ``onion_peeling`` - the "onion peeling" deconvolution method of Dasch and co-workers.
 
-    7. ``onion_bordas`` - "onion peeling" or "back projection" method of Bordas *et al.* based on the MatLab code by Rallis and Wells *et al.*
+7. ``onion_bordas`` - "onion peeling" or "back projection" method of Bordas *et al.* based on the MatLab code by Rallis and Wells *et al.*
 
-    8. ``linbasex`` - the 1D-spherical basis set expansion of Gerber *et al.*
+8. ``linbasex`` - the 1D-spherical basis set expansion of Gerber *et al.*
 
-    9. ``rbasex`` - a pBasex-like method formulated in terms of radial distributions.
+9. ``rbasex`` - a pBasex-like method formulated in terms of radial distributions.
 
 
 Installation

--- a/abel/rbasex.py
+++ b/abel/rbasex.py
@@ -75,7 +75,9 @@ def rbasex_transform(IM, origin='center', rmax='MIN', order=2, odd=False,
         largest radius to include in the transform (by default, the largest
         radius with at least one full quadrant of data)
     order : int
-        highest angular order present in the data, ≥ 0 (by default, 2)
+        highest angular order present in the data, ≥ 0 (by default, 2). Working
+        with very high orders (≳ 15) can result in excessive noise, especially
+        at small radii and for narrow peaks.
     odd : bool
         include odd angular orders (by default is `False`, but is enabled
         automatically if **order** is odd)

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -482,7 +482,9 @@ class Distributions(object):
             angular dependences must be inferred from very small available
             angular ranges)
     order : int
-        highest order in the angular distributions, ≥ 0 (by default, 2)
+        highest order in the angular distributions, ≥ 0 (by default, 2).
+        Requesting very high orders (≳ 15) can result in excessive noise,
+        especially at small radii and for narrow peaks.
     odd : bool
         include odd angular orders. By default is ``False``, but is enabled
         automatically if **order** is odd. Notice that although odd orders can


### PR DESCRIPTION
While the new release (#292) is still pending, let's do some minor things...
1. Reformat the methods list in README such that GitHub does not render it like a quote (see [here](https://github.com/PyAbel/PyAbel/issues/292#issuecomment-631613447)).
2. Add a warning to `tools.vmi.Distributions` and `rbasex.rbasex_transform` that using high angular orders can lead to poor results (partially addresses #286).