### PR TITLE
New set_center() implementation and axes in find_origin()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Unreleased
 * Circularization now uses periodic splines (to avoid discontinuity), with
   smoothing determined by the RMS tolerance instead of the nonintuitive
   "smooth" parameter (PR #293).
+* Corrected and improved tools.center (PR #302).
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -14,6 +14,35 @@ import abel
 from abel.tools.center import find_origin, center_image, set_center
 
 
+def test_find_origin():
+    """
+    Test find_origin methods.
+    """
+    size = [12, 13]
+    row, col = 5.4, 6.6  # origin
+    w = 3.0  # gaussian width parameter (sqrt(2) * sigma)
+    for rows in size:
+        y2 = ((np.arange(rows) - row) / w)**2
+        for cols in size:
+            x2 = ((np.arange(cols) - col) / w)**2
+            data = np.exp(-(x2 + y2[:, None]))
+            axes = (1, 0)
+            # (not testing trivial 'image_center', which does not find origin)
+            for method in ['com', 'convolution', 'gaussian', 'slice']:
+                origin = find_origin(data, method, axes)
+                ref = (row if 0 in axes else rows // 2,
+                       col if 1 in axes else cols // 2)
+                tol = 0.1  # 'convolution' rounds to 0.5
+                # 'slice' has ~0.5 px offset for even sizes
+                if method == 'slice' and not (rows % 2 and cols % 2):
+                    tol = 0.6
+                assert_allclose(origin, ref, atol=tol, verbose=False,
+                                err_msg='-> {} x {}, method = {}, axes = {}: '
+                                        'origin = {} not equal {}'.
+                                        format(rows, cols, method, axes,
+                                               origin, ref))
+
+
 def test_set_center_int():
     """
     Test whole-pixel shifts.
@@ -271,6 +300,7 @@ def test_center_image():
 
 
 if __name__ == "__main__":
+    test_find_origin()
     test_set_center_axes()
     test_set_center_int()
     test_set_center_float()

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -22,10 +22,10 @@ def test_set_center_int():
     size = [4, 5]
     # input size, crop, origin -> output elements
     param = {4: {'maintain_size': [[None, '1234'],
-                                   [0,    '0123'],
-                                   [1,    '1234'],
-                                   [2,    '2340'],
-                                   [3,    '3400']],
+                                   [0,    '0012'],
+                                   [1,    '0123'],
+                                   [2,    '1234'],
+                                   [3,    '2340']],
                  'valid_region':  [[None, '1234'],
                                    [0,    '1'],
                                    [1,    '123'],
@@ -94,19 +94,19 @@ def test_set_center_float():
     param = {10: [(None, {'maintain_size': [10, (0, 10)],
                           'valid_region':  [10, (0, 10)],
                           'maintain_data': [10, (0, 10)]}),
-                  (2.5,  {'maintain_size': [10, (1, 10)],
+                  (2.5,  {'maintain_size': [10, (2, 10)],
                           'valid_region':  [5,  (0,  5)],
                           'maintain_data': [15, (4, 15)]}),
-                  (3.5,  {'maintain_size': [10, (0, 10)],
+                  (3.5,  {'maintain_size': [10, (1, 10)],
                           'valid_region':  [7,  (0,  7)],
                           'maintain_data': [13, (2, 13)]}),
                   (4.5,  {'maintain_size': [10, (0, 10)],
                           'valid_region':  [9,  (0,  9)],
                           'maintain_data': [11, (0, 11)]}),
-                  (5.5,  {'maintain_size': [10, (0,  9)],
+                  (5.5,  {'maintain_size': [10, (0, 10)],
                           'valid_region':  [7,  (0,  7)],
                           'maintain_data': [13, (0, 11)]}),
-                  (6.5,  {'maintain_size': [10, (0,  8)],
+                  (6.5,  {'maintain_size': [10, (0,  9)],
                           'valid_region':  [5,  (0,  5)],
                           'maintain_data': [15, (0, 11)]})],
              11: [(None, {'maintain_size': [11, (0, 11)],
@@ -143,8 +143,8 @@ def test_set_center_float():
                     refcols, crange = cparam[crop]
                     refshape = (refrows, refcols)
                     refrange = (slice(*rrange), slice(*crange))
-                    reforigin = ((refrows - 1) // 2 if row else default,
-                                 (refcols - 1) // 2 if col else default)
+                    reforigin = (refrows // 2 if row else default,
+                                 refcols // 2 if col else default)
                     msg = '-> {} x {}, origin = {}, crop = {}: '.\
                           format(rows, cols, (row, col), crop)
                     # shape
@@ -173,7 +173,7 @@ def test_set_center_axes():
     """
     for N in [4, 5]:
         data = np.arange(N**2).reshape((N, N))
-        c = (N - 1) // 2
+        c = N // 2
         msg = '-> N = {}, '.format(N)
         assert_equal(set_center(data, (None, None)),
                      data,

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -4,12 +4,225 @@ from __future__ import print_function
 
 import os.path
 
+import itertools
+
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_equal, assert_allclose
+from scipy.ndimage.interpolation import shift
 
 import abel
+from abel.tools.center import find_origin, center_image, set_center
 
-from scipy.ndimage.interpolation import shift
+
+def test_set_center_int():
+    """
+    Test whole-pixel shifts.
+    """
+    # input sizes
+    size = [4, 5]
+    # input size, crop, origin -> output elements
+    param = {4: {'maintain_size': [[None, '1234'],
+                                   [0,    '0123'],
+                                   [1,    '1234'],
+                                   [2,    '2340'],
+                                   [3,    '3400']],
+                 'valid_region':  [[None, '1234'],
+                                   [0,    '1'],
+                                   [1,    '123'],
+                                   [2,    '234'],
+                                   [3,    '4']],
+                 'maintain_data': [[None, '1234'],
+                                   [0,    '0001234'],
+                                   [1,    '01234'],
+                                   [2,    '12340'],
+                                   [3,    '1234000']]},
+             5: {'maintain_size': [[None, '12345'],
+                                   [0,    '00123'],
+                                   [1,    '01234'],
+                                   [2,    '12345'],
+                                   [3,    '23450'],
+                                   [4,    '34500']],
+                 'valid_region':  [[None, '12345'],
+                                   [0,    '1'],
+                                   [1,    '123'],
+                                   [2,    '12345'],
+                                   [3,    '345'],
+                                   [4,    '5']],
+                 'maintain_data': [[None, '12345'],
+                                   [0,    '000012345'],
+                                   [1,    '0012345'],
+                                   [2,    '12345'],
+                                   [3,    '1234500'],
+                                   [4,    '123450000']]}}
+    # all size combinations
+    for rows, cols in itertools.product(size, repeat=2):
+        # test data: consecutive numbers from 1, row by row
+        data = (np.arange(rows * cols) + 1).reshape((rows, cols))
+        # all crop options
+        for crop in ['maintain_size', 'valid_region', 'maintain_data']:
+            # all origin rows
+            for row, rref in param[rows][crop]:
+                # vector or reference rows
+                rref = np.array([int(n) for n in rref])
+                # all origin columns
+                for col, cref in param[cols][crop]:
+                    # vector of reference columns
+                    cref = np.array([int(n) for n in cref])
+                    # reference array
+                    ref = (rref[:, None] - 1) * cols + cref
+                    ref[rref == 0] = 0
+                    ref[:, cref == 0] = 0
+                    # check set_center() result
+                    result = set_center(data, (row, col), crop=crop)
+                    assert_equal(result, ref, verbose=False,
+                                 err_msg='-> {} x {}, origin = {}, crop = {}\n'
+                                         'result =\n{}\n'
+                                         'must be =\n{}'.
+                                         format(rows, cols, (row, col), crop,
+                                                result, ref))
+
+
+def test_set_center_float():
+    """
+    Test fractional shifts.
+    """
+    # input sizes
+    size = [10, 11]
+    # default origin coordinate (substituting None)
+    default = 5.0
+    # input size, origin, crop -> output size, non-zero range
+    param = {10: [(None, {'maintain_size': [10, (0, 10)],
+                          'valid_region':  [10, (0, 10)],
+                          'maintain_data': [10, (0, 10)]}),
+                  (2.5,  {'maintain_size': [10, (1, 10)],
+                          'valid_region':  [5,  (0,  5)],
+                          'maintain_data': [15, (4, 15)]}),
+                  (3.5,  {'maintain_size': [10, (0, 10)],
+                          'valid_region':  [7,  (0,  7)],
+                          'maintain_data': [13, (2, 13)]}),
+                  (4.5,  {'maintain_size': [10, (0, 10)],
+                          'valid_region':  [9,  (0,  9)],
+                          'maintain_data': [11, (0, 11)]}),
+                  (5.5,  {'maintain_size': [10, (0,  9)],
+                          'valid_region':  [7,  (0,  7)],
+                          'maintain_data': [13, (0, 11)]}),
+                  (6.5,  {'maintain_size': [10, (0,  8)],
+                          'valid_region':  [5,  (0,  5)],
+                          'maintain_data': [15, (0, 11)]})],
+             11: [(None, {'maintain_size': [11, (0, 11)],
+                          'valid_region':  [11, (0, 11)],
+                          'maintain_data': [11, (0, 11)]}),
+                  (3.5,  {'maintain_size': [11, (1, 11)],
+                          'valid_region':  [7,  (0,  7)],
+                          'maintain_data': [15, (3, 15)]}),
+                  (4.5,  {'maintain_size': [11, (0, 11)],
+                          'valid_region':  [9,  (0,  9)],
+                          'maintain_data': [13, (1, 13)]}),
+                  (5.5,  {'maintain_size': [11, (0, 11)],
+                          'valid_region':  [9,  (0,  9)],
+                          'maintain_data': [13, (0, 12)]}),
+                  (6.5,  {'maintain_size': [11, (0, 10)],
+                          'valid_region':  [7,  (0,  7)],
+                          'maintain_data': [15, (0, 12)]})]}
+    w = 2.0  # gaussian width parameter (sqrt(2) * sigma)
+    # all size combinations
+    for rows, cols in itertools.product(size, repeat=2):
+        # all origin "rows"
+        for row, rparam in param[rows]:
+            y2 = ((np.arange(rows) - (row or default)) / w)**2
+            # all origin "columns"
+            for col, cparam in param[cols]:
+                x2 = ((np.arange(cols) - (col or default)) / w)**2
+                # test data: gaussian centered at (row, col)
+                data = np.exp(-(x2 + y2[:, None]))
+                # all crop options
+                for crop in ['maintain_size', 'valid_region', 'maintain_data']:
+                    # check set_center() result
+                    result = set_center(data, (row, col), crop=crop)
+                    refrows, rrange = rparam[crop]
+                    refcols, crange = cparam[crop]
+                    refshape = (refrows, refcols)
+                    refrange = (slice(*rrange), slice(*crange))
+                    reforigin = ((refrows - 1) // 2 if row else default,
+                                 (refcols - 1) // 2 if col else default)
+                    msg = '-> {} x {}, origin = {}, crop = {}: '.\
+                          format(rows, cols, (row, col), crop)
+                    # shape
+                    assert_equal(result.shape, refshape, verbose=False,
+                                 err_msg=msg + 'shape {} not equal {}'.
+                                               format(result.shape, refshape))
+                    # non-zero data
+                    assert_equal(result[refrange] != 0, True,
+                                 err_msg=msg + 'zeros in non-zero range')
+                    # zero padding
+                    tmp = result.copy()
+                    tmp[refrange] = 0
+                    assert_equal(tmp, 0, err_msg=msg +
+                                 'non-zeros outside non-zero range')
+                    # gaussian center
+                    origin = find_origin(result, 'gaussian')
+                    assert_allclose(origin, reforigin, atol=0.01,
+                                    verbose=False, err_msg=msg +
+                                    'shifted center {} not equal {}'.
+                                    format(origin, reforigin))
+
+
+def test_set_center_axes():
+    """
+    Test "None" origin components and axes selection.
+    """
+    for N in [4, 5]:
+        data = np.arange(N**2).reshape((N, N))
+        c = (N - 1) // 2
+        msg = '-> N = {}, '.format(N)
+        assert_equal(set_center(data, (None, None)),
+                     data,
+                     err_msg=msg + '(None, None)')
+        assert_equal(set_center(data, (0, 0), axes=[]),
+                     data,
+                     err_msg=msg + '(0, 0), axes=[]')
+        assert_equal(set_center(data, (0, None)),
+                     set_center(data, (0, c)),
+                     err_msg=msg + '(0, None)')
+        assert_equal(set_center(data, (None, 0)),
+                     set_center(data, (c, 0)),
+                     err_msg=msg + '(None, 0)')
+        assert_equal(set_center(data, (0, 0), axes=0),
+                     set_center(data, (0, c)),
+                     err_msg=msg + '(0, 0), axes=0')
+        assert_equal(set_center(data, (0, 0), axes=1),
+                     set_center(data, (c, 0)),
+                     err_msg=msg + '(0, 0), axes=1')
+
+
+def test_set_center_order():
+    """
+    Test rounding for order = 0 and exact output for order = 1.
+    """
+    data = data = np.ones((5, 5))
+    origin = np.array([1.9, 2.2])
+    # check origin rounding for order = 0
+    assert_equal(set_center(data, origin, order=0),
+                 set_center(data, origin.round()),
+                 err_msg='-> order = 0 not equal round(origin)')
+    # check output for order = 1:
+    # maintain_size
+    result = set_center(data, origin, 'maintain_size', order=1)
+    ref = np.outer([0.9, 1, 1, 1, 1],
+                   [1, 1, 1, 1, 0.8])
+    assert_allclose(result, ref,
+                    err_msg='-> crop = maintain_size, order = 1')
+    # valid_region
+    result = set_center(data, origin, 'valid_region', order=1)
+    ref = np.ones((3, 3))
+    assert_allclose(result, ref,
+                    err_msg='-> crop = valid_region, order = 1')
+    # maintain_data
+    result = set_center(data, origin, 'maintain_data', order=1)
+    ref = np.outer([0, 0.9, 1, 1, 1, 1, 0.1],
+                   [0.2, 1, 1, 1, 1, 0.8, 0])
+    assert_allclose(result, ref,
+                    err_msg='-> crop = maintain_data, order = 1')
 
 
 def test_center_image():
@@ -23,27 +236,27 @@ def test_center_image():
     true_origin = (179, 182)
 
     # find_origin using 'slice' method
-    origin = abel.tools.center.find_origin(IMx, method="slice")
+    origin = find_origin(IMx, method="slice")
 
     assert_allclose(origin, true_origin, atol=1)
 
     # find_origin using 'com' method
-    origin = abel.tools.center.find_origin(IMx, method="com")
+    origin = find_origin(IMx, method="com")
 
     assert_allclose(origin, true_origin, atol=1)
 
     # check single axis - vertical
     # center shifted image IMx in the vertical direction only
-    IMc = abel.tools.center.center_image(IMx, method="com", axes=1)
+    IMc = center_image(IMx, method="com", axes=1)
     # determine the origin
-    origin = abel.tools.center.find_origin(IMc, method="com")
+    origin = find_origin(IMc, method="com")
 
     assert_allclose(origin, (179, 180), atol=1)
 
     # check single axis - horizontal
     # center shifted image IMx in the horizontal direction only
-    IMc = abel.tools.center.center_image(IMx, method="com", axes=0)
-    origin = abel.tools.center.find_origin(IMc, method="com")
+    IMc = center_image(IMx, method="com", axes=0)
+    origin = find_origin(IMc, method="com")
 
     assert_allclose(origin, (180, 182), atol=1)
 
@@ -52,10 +265,14 @@ def test_center_image():
     IM = IM[:, :-1]
     m, n = IM.shape
 
-    IMy = abel.tools.center.center_image(IM, method="slice", odd_size=True)
+    IMy = center_image(IM, method="slice", odd_size=True)
 
     assert_allclose(IMy.shape, (m, n-1))
 
 
 if __name__ == "__main__":
+    test_set_center_axes()
+    test_set_center_int()
+    test_set_center_float()
+    test_set_center_order()
     test_center_image()

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -32,10 +32,7 @@ def test_find_origin():
                 origin = find_origin(data, method, axes)
                 ref = (row if 0 in axes else rows // 2,
                        col if 1 in axes else cols // 2)
-                tol = 0.1  # 'convolution' rounds to 0.5
-                # 'slice' has ~0.5 px offset for even sizes
-                if method == 'slice' and not (rows % 2 and cols % 2):
-                    tol = 0.6
+                tol = 0.2  # 'convolution' rounds to 0.5 pixels
                 assert_allclose(origin, ref, atol=tol, verbose=False,
                                 err_msg='-> {} x {}, method = {}, axes = {}: '
                                         'origin = {} not equal {}'.

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -7,8 +7,7 @@ from __future__ import unicode_literals
 import numpy as np
 from .math import fit_gaussian
 import warnings
-from scipy.ndimage import center_of_mass
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import center_of_mass, shift
 from scipy.optimize import minimize
 # testing strings with Python 2 and 3 compatibility
 from six import string_types
@@ -108,6 +107,8 @@ def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
             the image will be padded with zeros such that none of the original
             image will be cropped.
 
+        See :func:`set_center` for examples.
+
     axes : int or tuple
         center image with respect to axis ``0`` (vertical), ``1`` (horizontal),
         or both axes ``(0, 1)`` (default).
@@ -190,6 +191,10 @@ def set_center(data, origin, crop='maintain_size', axes=(0, 1), order=3,
             the image will be padded with zeros such that none of the original
             image will be cropped.
 
+        Examples:
+
+        .. plot:: tools/crop_options.py
+
     axes : int or tuple
         center image with respect to axis ``0`` (vertical), ``1`` (horizontal),
         or both axes ``(0, 1)`` (default).
@@ -202,6 +207,11 @@ def set_center(data, origin, crop='maintain_size', axes=(0, 1), order=3,
 
     verbose : bool
         print some information for debugging
+
+    Returns
+    -------
+    out : 2D np.array
+        centered image
     """
     if center is not _deprecated:
         _deprecate('abel.tools.center.set_center() '
@@ -530,7 +540,8 @@ def find_origin_by_slice(IM, slice_width=10, radial_range=(0, -1),
     """
 
     def _align(offset, sliceA, sliceB):
-        """intensity difference between an axial slice and its shifted opposite.
+        """
+        Intensity difference between an axial slice and its shifted opposite.
         """
         # always shift to the left (towards center)
         if offset < 0:

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -532,19 +532,19 @@ def axis_slices(IM, radial_range=(0, -1), slice_width=10):
     """
     rows, cols = IM.shape   # image size
 
-    r2 = rows // 2 + rows % 2
-    c2 = cols // 2 + cols % 2
-    sw2 = slice_width // 2
+    r2 = rows // 2
+    c2 = cols // 2
+    sw2 = min(slice_width // 2, r2, c2)
 
     rmin, rmax = radial_range
 
     # vertical slice
-    top = IM[:r2, c2-sw2:c2+sw2].sum(axis=1)
-    bottom = IM[r2 - rows % 2:, c2-sw2:c2+sw2].sum(axis=1)
+    top = IM[:r2, c2-sw2:c2+sw2+1].sum(axis=1)
+    bottom = IM[r2 + rows % 2:, c2-sw2:c2+sw2+1].sum(axis=1)
 
     # horizontal slice
-    left = IM[r2-sw2:r2+sw2, :c2].sum(axis=0)
-    right = IM[r2-sw2:r2+sw2, c2 - cols % 2:].sum(axis=0)
+    left = IM[r2-sw2:r2+sw2+1, :c2].sum(axis=0)
+    right = IM[r2-sw2:r2+sw2+1, c2 + cols % 2:].sum(axis=0)
 
     return (top[::-1][rmin:rmax], bottom[rmin:rmax],
             left[::-1][rmin:rmax], right[rmin:rmax])
@@ -599,8 +599,8 @@ def find_origin_by_slice(IM, axes=(0, 1), slice_width=10, radial_range=(0, -1),
 
     rows, cols = IM.shape
 
-    r2 = rows // 2
-    c2 = cols // 2
+    r2 = (rows - 1) / 2
+    c2 = (cols - 1) / 2
     top, bottom, left, right = axis_slices(IM, radial_range, slice_width)
 
     xyoffset = [0.0, 0.0]

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -163,10 +163,7 @@ def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
 def set_center(data, origin, crop='maintain_size', axes=(0, 1), order=3,
                verbose=False, center=_deprecated):
     """
-    Move image origin to mid-point of image.
-    (For even-sized images, the mid-point is rounded "down", to the closest
-    smaller index, so removing the last row/column will produce a centered
-    odd-sized image.)
+    Move image origin to mid-point of image (``rows // 2, cols // 2``).
 
     Parameters
     ----------
@@ -213,7 +210,7 @@ def set_center(data, origin, crop='maintain_size', axes=(0, 1), order=3,
 
     def center_of(a):
         """ Indices of array center """
-        return (np.array(a.shape) - 1) // 2
+        return np.array(a.shape) // 2
 
     shape = data.shape
     if verbose:

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -52,8 +52,8 @@ def find_origin(IM, method='image_center', verbose=False, **kwargs):
 
 
 def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
-                 crop='maintain_size', verbose=False, center=_deprecated,
-                 **kwargs):
+                 crop='maintain_size', order=3, verbose=False,
+                 center=_deprecated, **kwargs):
     """
     Center image with the custom value or by several methods provided in
     :func:`find_origin()` function.
@@ -113,6 +113,9 @@ def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
         center image with respect to axis ``0`` (vertical), ``1`` (horizontal),
         or both axes ``(0, 1)`` (default).
 
+    order : int
+        interpolation order, see :func:`set_center` for details.
+
     Returns
     -------
     out : 2D np.array
@@ -157,7 +160,7 @@ def center_image(IM, method='com', odd_size=True, square=False, axes=(0, 1),
         origin = method
 
     centered_data = set_center(IM, origin=origin, crop=crop, axes=axes,
-                               verbose=verbose)
+                               order=order, verbose=verbose)
     return centered_data
 
 

--- a/doc/tools/crop_options.py
+++ b/doc/tools/crop_options.py
@@ -1,0 +1,65 @@
+from __future__ import print_function, division
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle, Circle
+from copy import copy
+
+fig, axes = plt.subplots(1, 4, sharex=True, sharey=True,
+                         figsize=(6, 1.8), frameon=False)
+
+# origin
+x0, y0 = 0.45, 0.4
+
+
+def image(n, title, x1, y1, x2, y2):
+    ax = axes[n]
+    ax.set_title(title)
+    ax.axis('off')
+    ax.set_aspect('equal')
+    patches = (Rectangle((0, 0), 1, 1, fc='gray'),
+               Circle((x0, y0), 0.55, ec='black', fill=False, lw=2),
+               Circle((x0, y0), 0.4,  ec='black', fill=False, lw=2),
+               Circle((x0, y0), 0.25, ec='black', fill=False, lw=2))
+    # background whole image
+    clip = Rectangle((0, 0), 1, 1, visible=False)
+    ax.add_patch(clip)
+    for patch in patches:
+        patch = copy(patch)
+        ax.add_patch(patch)
+        patch.set_alpha(0.2)
+        patch.set_clip_path(clip)
+    # foreground croped image
+    cx1, cy1 = max(0, x1), max(0, y1)
+    cx2, cy2 = min(1, x2), min(1, y2)
+    clip = Rectangle((cx1, cy1), cx2 - cx1, cy2 - cy1, visible=False)
+    ax.add_patch(clip)
+    for patch in patches:
+        patch = copy(patch)
+        ax.add_patch(patch)
+        patch.set_clip_path(clip)
+    # frame
+    ax.add_patch(Rectangle((x1, y1), x2 - x1, y2 - y1, ec='red', fill=False))
+    # origin
+    ax.plot(x0, y0, c='red', marker='+')
+
+
+image(0, 'original data', 0, 0, 1, 1)
+
+image(1, 'maintain_size',
+      x0 - 0.5, y0 - 0.5,
+      x0 + 0.5, y0 + 0.5)
+
+hw, hh = min(x0, 1 - x0), min(y0, 1 - y0)
+image(2, 'valid_region',
+      max(0, x0 - hw), max(0, y0 - hh),
+      min(1, x0 + hw), min(1, y0 + hh))
+
+hw, hh = max(x0, 1 - x0), max(y0, 1 - y0)
+image(3, 'maintain_data',
+      min(0, x0 - hw), min(0, y0 - hh),
+      max(0, x0 + hw), max(0, y0 + hh))
+
+plt.subplots_adjust(left=0, bottom=0, right=1, top=0.88, wspace=0, hspace=0)
+
+# plt.savefig('crop_options.svg')
+plt.show()


### PR DESCRIPTION
OK, here is the `abel.tools.center.set_center()` rewritten completely:
* Should behave correctly for all reasonable parameters.
* Doesn't lose fractional edge pixels (`scipy.ndimage.shift()` is [going](https://github.com/scipy/scipy/issues/12773) to be corrected eventually, but this works with what we have now).
* Allows selecting the interpolation order.
* Includes a much faster implementation without interpolation.
* Allows specifying `None` in the origin for axes that do not need centering.

Also, the `axes` argument is added to `find_origin...()` methods, such that they don't do unnecessary (and potentially unsuccessful) work. Now they return the image center coordinate for unused axis, so passing this to `set_center()` will have no effect.