### PR TITLE
State requirements before importing packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "numpy >= 1.6"]

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatfo
 # https://read-the-docs.readthedocs.io/en/latest/faq.html#how-do-i-change-behavior-for-read-the-docs
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if not on_rtd:
-    import numpy as np
     install_requires=[
           "numpy >= 1.6",
           "setuptools >= 16.0",
           "scipy >= 0.14",
           "six >= 1.10.0"
           ]
+    import numpy as np
 else:
     np = None
     install_requires=[]


### PR DESCRIPTION
Hey,
thanks for writing PyAbel - it's very convenient. When using ``tox`` to set up my environment, I get a ``ModuleNotFoundError`` (``No module named 'numpy'``) during the installation of the module. 
Defining the requirements before importing ``numpy`` in ``setup.py`` solves this issue for me.
