### PR TITLE
Update Travis tests to Py3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 sudo: false
 matrix:
   include:
-  - python: '3.8'
+  - python: '3.9'
     env: DEPS="numpy scipy cython"
     sudo: true
-    dist: xenial
+    dist: focal
   - python: '3.8'
     env: DEPS="numpy scipy cython"
     sudo: true

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ The outcome of the numerical Abel transform depends on the exact method used. So
 Installation
 ------------
 
-PyAbel requires Python 2.7 or 3.5-3.7. `NumPy <https://www.numpy.org/>`_ and `SciPy <https://www.scipy.org/>`_ are also required, and `Matplotlib <https://matplotlib.org/>`_ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`_, which is available for free.
+PyAbel requires Python 3.5-3.9. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://www.numpy.org/>`_ and `SciPy <https://www.scipy.org/>`_ are also required, and `Matplotlib <https://matplotlib.org/>`_ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`_, which is available for free.
 
 With pip
 ~~~~~~~~

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,14 +14,8 @@ environment:
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda-x64
     - PYTHON_VERSION: 3.7
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda3
-    - PYTHON_VERSION: 3.7
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
-    - PYTHON_VERSION: 3.8
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda3
     - PYTHON_VERSION: 3.8
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,8 @@ setup(name='PyAbel',
       'Programming Language :: Python :: 3',
       'Programming Language :: Python :: 3.6',
       'Programming Language :: Python :: 3.7',
+      'Programming Language :: Python :: 3.8',
+      'Programming Language :: Python :: 3.9',
       ],
       **setup_args
      )


### PR DESCRIPTION
Per the discussion on #307, I did the following:

- I updated the Travis tests to Py3.9
- I updated the Ubuntu version to `focal` for the Py3.9 test (leaving the 3.8 test with `xenial`)
- I removed the 32-bit Py3 builds on Appveyor, to speed things up. (Appveyor tests are still completed in serial and take about 2.5 minutes each. So, dropping from 6 to 4 tests speeds up out test time from 15 mins to 10 mins.)
- I left the Appveyor at 3.8, since it seems that Py3.9 isn't available yet: https://docs.conda.io/en/latest/miniconda.html
- I updated the supported versions in the README, and included a note warning that Py2 support may be dropped soon (this one is for you @stggh!). 
- I included py3.8 and py3.9 as supported versions in setup.py so that these will show up on PyPI. 
