### PR TITLE
Moving numpy import into try block in setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Unreleased
   smoothing determined by the RMS tolerance instead of the nonintuitive
   "smooth" parameter (PR #293).
 * Corrected and improved tools.center (PR #302).
+* Moved numpy import to try block in setup.py. This allows pip to install PyAbel in situations where numpy is not already installed. (PR #310)
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/abel/direct.py
+++ b/abel/direct.py
@@ -64,9 +64,10 @@ def direct_transform(fr, dr=None, r=None, direction='inverse',
     that the function is linear across this pixel. With correction=True, the
     Direct method produces reasonable results.
 
-    The Direct method is implemented in both Python and, if Cython is available
-    during PyAbel's installation, a compiled C version, which is much faster.
-    The implementation can be selected using the backend argument.
+    The Direct method is implemented in both Python and a compiled C version
+    using Cython, which is much faster. The implementation can be selected using
+    the backend argument. If the C-backend is not available, you must re-install
+    PyAbel with Numpy, Cython, and a C-compiler already installed.
 
     By default, integration at all other pixels is performed using the
     Trapezoidal rule.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import os.path
 from setuptools import setup, find_packages, Extension
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
-
 # a define the version string inside the package
 # see 
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
@@ -13,33 +12,19 @@ VERSIONFILE = "abel/_version.py"
 verstrline = open(VERSIONFILE, "rt").read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
 mo = re.search(VSRE, verstrline, re.M)
+
 if mo:
     version = mo.group(1)
 else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
-    
-# change behaviour of the setup.py on readthedocs.org
-# https://read-the-docs.readthedocs.io/en/latest/faq.html#how-do-i-change-behavior-for-read-the-docs
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if on_rtd:
-    np = None
-    install_requires = []
-
-else:
-    install_requires = [
-          "numpy >= 1.6",
-          "setuptools >= 16.0",
-          "scipy >= 0.14",
-          "six >= 1.10.0"]
-
-try:  # try to import numpy and Cython to build Cython extensions
+# try to import numpy and Cython to build Cython extensions:
+try:  
     import numpy as np
     from Cython.Distutils import build_ext
     import Cython.Compiler.Options
     Cython.Compiler.Options.annotate = False
     _cython_installed = True
-
 
 except ImportError:
     _cython_installed = False
@@ -112,7 +97,10 @@ setup(name='PyAbel',
       url='https://github.com/PyAbel/PyAbel',
       license='MIT',
       packages=find_packages(),
-      install_requires=install_requires,
+      install_requires=[ "numpy >= 1.6",
+                         "setuptools >= 16.0",
+                         "scipy >= 0.14",
+                         "six >= 1.10.0"],
       package_data={'abel': ['tests/data/*']},
       long_description=long_description,
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -5,42 +5,40 @@ import os.path
 from setuptools import setup, find_packages, Extension
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
-# change behaviour of the setup.py on readthedocs.io
+# change behaviour of the setup.py on readthedocs.org
 # https://read-the-docs.readthedocs.io/en/latest/faq.html#how-do-i-change-behavior-for-read-the-docs
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:
-    import numpy as np
-    install_requires=[
+
+if on_rtd:  # if we're building on readthedocs.org:
+    np = None
+    install_requires = []
+
+else:
+    install_requires = [
           "numpy >= 1.6",
           "setuptools >= 16.0",
           "scipy >= 0.14",
-          "six >= 1.10.0"
-          ]
-else:
-    np = None
-    install_requires=[]
+          "six >= 1.10.0"]
 
-
-
-try:
+try:  # try to import numpy and Cython to build Cython extensions
+    import numpy as np
     from Cython.Distutils import build_ext
     import Cython.Compiler.Options
     Cython.Compiler.Options.annotate = False
     _cython_installed = True
+
 except ImportError:
     _cython_installed = False
-    build_ext = object # just avoid a syntax error in TryBuildExt, this is not used anyway
+    build_ext = object  # just avoid a syntax error in TryBuildExt, this is not used anyway
     print('='*80)
     print('Warning: Cython extensions will not be built as Cython is not installed!\n'\
           '         This means that the abel.direct C implementation will not be available.')
     print('='*80)
 
 
-
-
-# a define the version sting inside the package
+# a define the version string inside the package
 # see https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
-VERSIONFILE="abel/_version.py"
+VERSIONFILE = "abel/_version.py"
 verstrline = open(VERSIONFILE, "rt").read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
 mo = re.search(VSRE, verstrline, re.M)
@@ -79,8 +77,8 @@ class TryBuildExt(build_ext):
             if os.environ.get('CI'):
                 # running on Travis CI or Appveyor CI
                 if sys.platform == 'win32' and sys.version_info < (3, 0):
-                    pass # Cython extensions are not built on Appveyor (Win) for PY2.7
-                         # see PR #185
+                    pass  # Cython extensions are not built on Appveyor (Win) for PY2.7
+                          # see PR #185
                 else:
                     raise
             else:
@@ -98,14 +96,14 @@ ext_modules=[
 
 if _cython_installed and not on_rtd:
     setup_args = {'cmdclass': {'build_ext': TryBuildExt},
-                  'include_dirs': [ np.get_include() ],
+                  'include_dirs': [ np.get_include()],
                   'ext_modules': ext_modules}
 else:
     setup_args = {}
 
 with open('README.rst') as file:
     long_description = file.read()
-    
+
 setup(name='PyAbel',
       version=version,
       description='A Python package for forward and inverse Abel transforms',
@@ -114,14 +112,14 @@ setup(name='PyAbel',
       license='MIT',
       packages=find_packages(),
       install_requires=install_requires,
-      package_data={'abel': ['tests/data/*' ]},
+      package_data={'abel': ['tests/data/*']},
       long_description=long_description,
       classifiers=[
       # How mature is this project? Common values are
       #   3 - Alpha
       #   4 - Beta
       #   5 - Production/Stable
-      'Development Status :: 3 - Alpha',
+      'Development Status :: 4 - Beta',
 
       # Indicate who your project is intended for
       'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -9,16 +9,22 @@ from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatfo
 # https://read-the-docs.readthedocs.io/en/latest/faq.html#how-do-i-change-behavior-for-read-the-docs
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if on_rtd:  # if we're building on readthedocs.org:
-    np = None
-    install_requires = []
+# if on_rtd:  # if we're building on readthedocs.org:
+#     np = None
+#     install_requires = []
+#
+# else:
+#     install_requires = [
+#           "numpy >= 1.6",
+#           "setuptools >= 16.0",
+#           "scipy >= 0.14",
+#           "six >= 1.10.0"]
 
-else:
-    install_requires = [
-          "numpy >= 1.6",
-          "setuptools >= 16.0",
-          "scipy >= 0.14",
-          "six >= 1.10.0"]
+install_requires = [
+      "numpy >= 1.6",
+      "setuptools >= 16.0",
+      "scipy >= 0.14",
+      "six >= 1.10.0"]
 
 try:  # try to import numpy and Cython to build Cython extensions
     import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,8 @@ setup(name='PyAbel',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
           ],
       **setup_args
       )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
+import os
 import sys
 import re
-import os
 import os.path
 from setuptools import setup, find_packages, Extension
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
@@ -33,72 +33,73 @@ else:
           "scipy >= 0.14",
           "six >= 1.10.0"]
 
-    try:  # try to import numpy and Cython to build Cython extensions
-        import numpy as np
-        from Cython.Distutils import build_ext
-        import Cython.Compiler.Options
-        Cython.Compiler.Options.annotate = False
-        _cython_installed = True
+try:  # try to import numpy and Cython to build Cython extensions
+    import numpy as np
+    from Cython.Distutils import build_ext
+    import Cython.Compiler.Options
+    Cython.Compiler.Options.annotate = False
+    _cython_installed = True
+
+
+except ImportError:
+    _cython_installed = False
+    build_ext = object  # just avoid a syntax error in TryBuildExt, this is not used anyway
+    setup_args = {}
+    print('='*80)
+    print('Warning: Cython extensions will not be built as Cython is not installed!\n'\
+          '         This means that the abel.direct C implementation will not be available.')
+    print('='*80)
+
+
+if _cython_installed: # if Cython is installed, we will try to build direct-C
     
-        if sys.platform != 'win32':
-            compile_args = dict( extra_compile_args=['-O2', '-march=native'],
-                                     extra_link_args=['-O2', '-march=native'])
-            libraries = ["m"]
-        else:
-            compile_args = dict( extra_compile_args=[])
-            libraries = []
+    if sys.platform != 'win32':
+        compile_args = dict( extra_compile_args=['-O2', '-march=native'],
+                                 extra_link_args=['-O2', '-march=native'])
+        libraries = ["m"]
+    else:
+        compile_args = dict( extra_compile_args=[])
+        libraries = []
 
-        # Optional compilation of Cython modules adapted from
-        # https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post
+    # Optional compilation of Cython modules adapted from
+    # https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post
+    
+    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 
-
-        ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-
-        class TryBuildExt(build_ext):
-            def build_extensions(self):
-                try:
-                    build_ext.build_extensions(self)
-                except ext_errors:
-                    print("**************************************************")
-                    print("WARNING: Cython extensions failed to build (used in abel.direct).\n"
-                          "Typical reasons for this problem are:\n"
-                          "  - a C compiler is not installed or not found\n"
-                          "  - issues using mingw compiler on Windows 64bit (experimental support for now)\n"
-                          "This only means that the abel.direct C implementation will not be available.\n")
-                    print("**************************************************")
-                    if os.environ.get('CI'):
-                        # running on Travis CI or Appveyor CI
-                        if sys.platform == 'win32' and sys.version_info < (3, 0):
-                            pass  # Cython extensions are not built on Appveyor (Win) for PY2.7
-                                  # see PR #185
-                        else:
-                            raise
+    class TryBuildExt(build_ext):
+        def build_extensions(self):
+            try:
+                build_ext.build_extensions(self)
+            except ext_errors:
+                print("**************************************************")
+                print("WARNING: Cython extensions failed to build (used in abel.direct).\n"
+                      "Typical reasons for this problem are:\n"
+                      "  - a C compiler is not installed or not found\n"
+                      "  - issues using mingw compiler on Windows 64bit (experimental support for now)\n"
+                      "This only means that the abel.direct C implementation will not be available.\n")
+                print("**************************************************")
+                if os.environ.get('CI'):
+                    # running on Travis CI or Appveyor CI
+                    if sys.platform == 'win32' and sys.version_info < (3, 0):
+                        pass  # Cython extensions are not built on Appveyor (Win) for PY2.7
+                              # see PR #185
                     else:
-                        # regular install, Cython extensions won't be compiled
-                        pass
-                except:
-                    raise
+                        raise
+                else:
+                    # regular install, Cython extensions won't be compiled
+                    pass
+            except:
+                raise
 
-        ext_modules=[
-            Extension("abel.lib.direct",
-                     [os.path.join("abel","lib","direct.pyx")],
-                     libraries=libraries,
-                     **compile_args),
-            ]
+    ext_modules=[
+        Extension("abel.lib.direct",
+                 [os.path.join("abel","lib","direct.pyx")],
+                 libraries=libraries,
+                 **compile_args)]
 
-    
-        setup_args = {'cmdclass': {'build_ext': TryBuildExt},
-                      'include_dirs': [ np.get_include()],
-                      'ext_modules': ext_modules}        
-
-    except ImportError:
-        _cython_installed = False
-        build_ext = object  # just avoid a syntax error in TryBuildExt, this is not used anyway
-        setup_args = {}
-        print('='*80)
-        print('Warning: Cython extensions will not be built as Cython is not installed!\n'\
-              '         This means that the abel.direct C implementation will not be available.')
-        print('='*80)
+    setup_args = {'cmdclass': {'build_ext': TryBuildExt},
+                  'include_dirs': [ np.get_include()],
+                  'ext_modules': ext_modules}        
 
 
 with open('README.rst') as file:

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ import os.path
 from setuptools import setup, find_packages, Extension
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
-# a define the version string inside the package
-# see 
+# a define the version string inside the package, see:
 # https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 VERSIONFILE = "abel/_version.py"
 verstrline = open(VERSIONFILE, "rt").read()
@@ -19,7 +18,7 @@ else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
 
 # try to import numpy and Cython to build Cython extensions:
-try:  
+try:
     import numpy as np
     from Cython.Distutils import build_ext
     import Cython.Compiler.Options
@@ -28,7 +27,7 @@ try:
 
 except ImportError:
     _cython_installed = False
-    build_ext = object  # just avoid a syntax error in TryBuildExt, this is not used anyway
+    build_ext = object  # avoid a syntax error in TryBuildExt
     setup_args = {}
     print('='*80)
     print('Warning: Cython extensions will not be built as Cython is not installed!\n'\
@@ -36,23 +35,27 @@ except ImportError:
     print('='*80)
 
 
-if _cython_installed: # if Cython is installed, we will try to build direct-C
-    
+if _cython_installed:  # if Cython is installed, we will try to build direct-C
+
     if sys.platform != 'win32':
-        compile_args = dict( extra_compile_args=['-O2', '-march=native'],
-                                 extra_link_args=['-O2', '-march=native'])
+        compile_args = dict(extra_compile_args=['-O2', '-march=native'],
+                            extra_link_args=['-O2', '-march=native'])
         libraries = ["m"]
     else:
-        compile_args = dict( extra_compile_args=[])
+        compile_args = dict(extra_compile_args=[])
         libraries = []
 
     # Optional compilation of Cython modules adapted from
-    # https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post
-    
+    # https://github.com/bsmurphy/PyKrige which was itself
+    # adapted from a StackOverflow post
+
     ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 
     class TryBuildExt(build_ext):
+        """Class to  build the direct-C extensions."""
+
         def build_extensions(self):
+            """Try to build the direct-C extension."""
             try:
                 build_ext.build_extensions(self)
             except ext_errors:
@@ -66,8 +69,9 @@ if _cython_installed: # if Cython is installed, we will try to build direct-C
                 if os.environ.get('CI'):
                     # running on Travis CI or Appveyor CI
                     if sys.platform == 'win32' and sys.version_info < (3, 0):
-                        pass  # Cython extensions are not built on Appveyor (Win) for PY2.7
-                              # see PR #185
+                        # Cython extensions are not built on Appveyor (Win)
+                        # for PY2.7. See PR #185
+                        pass
                     else:
                         raise
                 else:
@@ -76,15 +80,15 @@ if _cython_installed: # if Cython is installed, we will try to build direct-C
             except:
                 raise
 
-    ext_modules=[
+    ext_modules = [
         Extension("abel.lib.direct",
-                 [os.path.join("abel","lib","direct.pyx")],
-                 libraries=libraries,
-                 **compile_args)]
+                  [os.path.join("abel", "lib", "direct.pyx")],
+                  libraries=libraries,
+                  **compile_args)]
 
     setup_args = {'cmdclass': {'build_ext': TryBuildExt},
-                  'include_dirs': [ np.get_include()],
-                  'ext_modules': ext_modules}        
+                  'include_dirs': [np.get_include()],
+                  'ext_modules': ext_modules}
 
 
 with open('README.rst') as file:
@@ -97,37 +101,37 @@ setup(name='PyAbel',
       url='https://github.com/PyAbel/PyAbel',
       license='MIT',
       packages=find_packages(),
-      install_requires=[ "numpy >= 1.6",
-                         "setuptools >= 16.0",
-                         "scipy >= 0.14",
-                         "six >= 1.10.0"],
+      install_requires=["numpy >= 1.6",
+                        "setuptools >= 16.0",
+                        "scipy >= 0.14",
+                        "six >= 1.10.0"],
       package_data={'abel': ['tests/data/*']},
       long_description=long_description,
       classifiers=[
-      # How mature is this project? Common values are
-      #   3 - Alpha
-      #   4 - Beta
-      #   5 - Production/Stable
-      'Development Status :: 4 - Beta',
+          # How mature is this project? Common values are
+          #  3 - Alpha
+          #  4 - Beta
+          #  5 - Production/Stable
+          'Development Status :: 4 - Beta',
 
-      # Indicate who your project is intended for
-      'Intended Audience :: Science/Research',
-      'Intended Audience :: Developers',
-      'Topic :: Scientific/Engineering :: Mathematics',
-      'Topic :: Scientific/Engineering :: Physics',
-      'Topic :: Scientific/Engineering :: Medical Science Apps.',
-      'Topic :: Software Development :: Libraries :: Python Modules',
+          # Indicate who your project is intended for
+          'Intended Audience :: Science/Research',
+          'Intended Audience :: Developers',
+          'Topic :: Scientific/Engineering :: Mathematics',
+          'Topic :: Scientific/Engineering :: Physics',
+          'Topic :: Scientific/Engineering :: Medical Science Apps.',
+          'Topic :: Software Development :: Libraries :: Python Modules',
 
-      # Pick your license as you wish (should match "license" above)
-      'License :: OSI Approved :: MIT License',
+          # Pick your license as you wish (should match "license" above)
+          'License :: OSI Approved :: MIT License',
 
-      # Specify the Python versions you support here. In particular, ensure
-      # that you indicate whether you support Python 2, Python 3 or both.
-      'Programming Language :: Python :: 2',
-      'Programming Language :: Python :: 2.7',
-      'Programming Language :: Python :: 3',
-      'Programming Language :: Python :: 3.6',
-      'Programming Language :: Python :: 3.7',
-      ],
+          # Specify the Python versions you support here. In particular, ensure
+          # that you indicate whether you support Python 2, Python 3 or both.
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          ],
       **setup_args
-     )
+      )

--- a/setup.py
+++ b/setup.py
@@ -5,45 +5,10 @@ import os.path
 from setuptools import setup, find_packages, Extension
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
-# change behaviour of the setup.py on readthedocs.org
-# https://read-the-docs.readthedocs.io/en/latest/faq.html#how-do-i-change-behavior-for-read-the-docs
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-# if on_rtd:  # if we're building on readthedocs.org:
-#     np = None
-#     install_requires = []
-#
-# else:
-#     install_requires = [
-#           "numpy >= 1.6",
-#           "setuptools >= 16.0",
-#           "scipy >= 0.14",
-#           "six >= 1.10.0"]
-
-install_requires = [
-      "numpy >= 1.6",
-      "setuptools >= 16.0",
-      "scipy >= 0.14",
-      "six >= 1.10.0"]
-
-try:  # try to import numpy and Cython to build Cython extensions
-    import numpy as np
-    from Cython.Distutils import build_ext
-    import Cython.Compiler.Options
-    Cython.Compiler.Options.annotate = False
-    _cython_installed = True
-
-except ImportError:
-    _cython_installed = False
-    build_ext = object  # just avoid a syntax error in TryBuildExt, this is not used anyway
-    print('='*80)
-    print('Warning: Cython extensions will not be built as Cython is not installed!\n'\
-          '         This means that the abel.direct C implementation will not be available.')
-    print('='*80)
-
 
 # a define the version string inside the package
-# see https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
+# see 
+# https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
 VERSIONFILE = "abel/_version.py"
 verstrline = open(VERSIONFILE, "rt").read()
 VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
@@ -52,60 +17,89 @@ if mo:
     version = mo.group(1)
 else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+    
+# change behaviour of the setup.py on readthedocs.org
+# https://read-the-docs.readthedocs.io/en/latest/faq.html#how-do-i-change-behavior-for-read-the-docs
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
+if on_rtd:
+    np = None
+    install_requires = []
 
-if sys.platform != 'win32':
-    compile_args = dict( extra_compile_args=['-O2', '-march=native'],
-                             extra_link_args=['-O2', '-march=native'])
-    libraries = ["m"]
 else:
-    compile_args = dict( extra_compile_args=[])
-    libraries = []
+    install_requires = [
+          "numpy >= 1.6",
+          "setuptools >= 16.0",
+          "scipy >= 0.14",
+          "six >= 1.10.0"]
 
-# Optional compilation of Cython modules adapted from
-# https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post
+    try:  # try to import numpy and Cython to build Cython extensions
+        import numpy as np
+        from Cython.Distutils import build_ext
+        import Cython.Compiler.Options
+        Cython.Compiler.Options.annotate = False
+        _cython_installed = True
+    
+        if sys.platform != 'win32':
+            compile_args = dict( extra_compile_args=['-O2', '-march=native'],
+                                     extra_link_args=['-O2', '-march=native'])
+            libraries = ["m"]
+        else:
+            compile_args = dict( extra_compile_args=[])
+            libraries = []
+
+        # Optional compilation of Cython modules adapted from
+        # https://github.com/bsmurphy/PyKrige which was itself adapted from a StackOverflow post
 
 
-ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+        ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 
-class TryBuildExt(build_ext):
-    def build_extensions(self):
-        try:
-            build_ext.build_extensions(self)
-        except ext_errors:
-            print("**************************************************")
-            print("WARNING: Cython extensions failed to build (used in abel.direct).\n"
-                  "Typical reasons for this problem are:\n"
-                  "  - a C compiler is not installed or not found\n"
-                  "  - issues using mingw compiler on Windows 64bit (experimental support for now)\n"
-                  "This only means that the abel.direct C implementation will not be available.\n")
-            print("**************************************************")
-            if os.environ.get('CI'):
-                # running on Travis CI or Appveyor CI
-                if sys.platform == 'win32' and sys.version_info < (3, 0):
-                    pass  # Cython extensions are not built on Appveyor (Win) for PY2.7
-                          # see PR #185
-                else:
+        class TryBuildExt(build_ext):
+            def build_extensions(self):
+                try:
+                    build_ext.build_extensions(self)
+                except ext_errors:
+                    print("**************************************************")
+                    print("WARNING: Cython extensions failed to build (used in abel.direct).\n"
+                          "Typical reasons for this problem are:\n"
+                          "  - a C compiler is not installed or not found\n"
+                          "  - issues using mingw compiler on Windows 64bit (experimental support for now)\n"
+                          "This only means that the abel.direct C implementation will not be available.\n")
+                    print("**************************************************")
+                    if os.environ.get('CI'):
+                        # running on Travis CI or Appveyor CI
+                        if sys.platform == 'win32' and sys.version_info < (3, 0):
+                            pass  # Cython extensions are not built on Appveyor (Win) for PY2.7
+                                  # see PR #185
+                        else:
+                            raise
+                    else:
+                        # regular install, Cython extensions won't be compiled
+                        pass
+                except:
                     raise
-            else:
-                # regular install, Cython extensions won't be compiled
-                pass
-        except:
-            raise
 
-ext_modules=[
-    Extension("abel.lib.direct",
-             [os.path.join("abel","lib","direct.pyx")],
-             libraries=libraries,
-             **compile_args),
-    ]
+        ext_modules=[
+            Extension("abel.lib.direct",
+                     [os.path.join("abel","lib","direct.pyx")],
+                     libraries=libraries,
+                     **compile_args),
+            ]
 
-if _cython_installed and not on_rtd:
-    setup_args = {'cmdclass': {'build_ext': TryBuildExt},
-                  'include_dirs': [ np.get_include()],
-                  'ext_modules': ext_modules}
-else:
-    setup_args = {}
+    
+        setup_args = {'cmdclass': {'build_ext': TryBuildExt},
+                      'include_dirs': [ np.get_include()],
+                      'ext_modules': ext_modules}        
+
+    except ImportError:
+        _cython_installed = False
+        build_ext = object  # just avoid a syntax error in TryBuildExt, this is not used anyway
+        setup_args = {}
+        print('='*80)
+        print('Warning: Cython extensions will not be built as Cython is not installed!\n'\
+              '         This means that the abel.direct C implementation will not be available.')
+        print('='*80)
+
 
 with open('README.rst') as file:
     long_description = file.read()


### PR DESCRIPTION
Following the discussion in #308, we decided that we should move the `import numpy as np` line into the `try` block in setup.py. Numy is required for the `np.get_include()` command to build the Cython extensions.

This should allow pip to successfully install PyAbel, even in situations where numpy was not previously installed.

I'll work on adding something to the readme to discuss the Cython+numpy+C-compiler for building the direct-C.