### PR TITLE
New functions for angular integration and average

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+* New functions in tools.vmi for angular integration and averaging, replacing
+  angular_integration() and average_radial_intensity(), which had incorrect or
+  nonintuitive behavior (PR #318, PR #319).
 
 v0.8.4 (2020-04-15)
 -------------------
@@ -29,8 +32,8 @@ v0.8.4 (2020-04-15)
   smoothing determined by the RMS tolerance instead of the nonintuitive
   "smooth" parameter (PR #293).
 * Corrected and improved tools.center (PR #302).
-* Moved numpy import to try block in setup.py. This allows pip to install PyAbel
-  in situations where numpy is not already installed. (PR #310)
+* Moved numpy import to try block in setup.py. This allows pip to install
+  PyAbel in situations where numpy is not already installed (PR #310).
 
 v0.8.3 (2019-08-16)
 -------------------

--- a/abel/__init__.py
+++ b/abel/__init__.py
@@ -20,7 +20,7 @@ def _deprecate(msg):
     # level 0   level 1         level 2      level 3
     # warn() <- _deprecate() <- abel...() <- user code
 # enable deprecation warnings (ignored by default since Python 2.7) for abel
-filterwarnings('default', '^abel\.', category=DeprecationWarning)
+filterwarnings('default', r'^abel\.', category=DeprecationWarning)
 
 from . import basex
 from . import benchmark

--- a/abel/tests/test_dasch_methods.py
+++ b/abel/tests/test_dasch_methods.py
@@ -100,7 +100,7 @@ def test_dasch_cyl_gaussian(n=101):
     IM = gauss(X, 0, sigma)  # cylindrical Gaussian located at pixel R=0
     Q0 = IM[:r2, c2:]  # quadrant, top-right
     Q0_copy = Q0.copy()
-    ospeed = abel.tools.vmi.angular_integration(Q0_copy, origin=(0, 0))
+    ospeed = abel.tools.vmi.angular_integration_3D(Q0_copy, origin=(0, 0))
 
     # dasch method inverse Abel transform
     for method in dasch_transforms.keys():

--- a/abel/tests/test_hansenlaw.py
+++ b/abel/tests/test_hansenlaw.py
@@ -106,11 +106,11 @@ def test_hansenlaw_forward_dribinski_image():
     ifQ0 = abel.hansenlaw.hansenlaw_transform(fQ0, direction='inverse')
 
     # speed distribution
-    orig_speed, orig_radial = abel.tools.vmi.angular_integration(Q0,
-                              origin=(0, 0), Jacobian=True)
+    orig_speed, orig_radial = abel.tools.vmi.angular_integration_3D(Q0,
+                              origin=(0, 0))
 
-    speed, radial_coords = abel.tools.vmi.angular_integration(ifQ0,
-                           origin=(0, 0), Jacobian=True)
+    speed, radial_coords = abel.tools.vmi.angular_integration_3D(ifQ0,
+                           origin=(0, 0))
 
     orig_speed /= orig_speed[50:125].max()
     speed /= speed[50:125].max()

--- a/abel/tests/test_linbasex.py
+++ b/abel/tests/test_linbasex.py
@@ -39,7 +39,7 @@ def test_linbasex_forward_dribinski_image():
                                             return_Beta=True))
 
     # speed distribution
-    orig_radial, orig_speed = abel.tools.vmi.angular_integration(IM)
+    orig_radial, orig_speed = abel.tools.vmi.angular_integration_3D(IM)
 
 
     radial = ifIM.radial

--- a/abel/tests/test_tools_vmi.py
+++ b/abel/tests/test_tools_vmi.py
@@ -4,6 +4,9 @@ from __future__ import division
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
+# to suppress deprecation warnings
+from warnings import catch_warnings, simplefilter
+
 from abel.tools.analytical import SampleImage
 import abel.tools.vmi as vmi
 
@@ -96,7 +99,9 @@ def test_angular_integration():
     n, ones, cos2, sin2 = make_images(R)
 
     def check(name, ref, rtol, IM, **kwargs):
-        r, speeds = vmi.angular_integration(IM, **kwargs)
+        with catch_warnings():
+            simplefilter('ignore', category=DeprecationWarning)
+            r, speeds = vmi.angular_integration(IM, **kwargs)
         # (ignoring pixels at r = 0 and 1, which can be poor)
         assert_allclose(speeds[2:R], ref(r[2:R]), rtol=rtol,
                         err_msg='-> {}, {}'.format(name, kwargs))
@@ -130,7 +135,9 @@ def test_average_radial_intensity():
     n, ones, cos2, sin2 = make_images(R)
 
     def check(name, ref, atol, IM, **kwargs):
-        r, intensity = vmi.average_radial_intensity(IM, **kwargs)
+        with catch_warnings():
+            simplefilter('ignore', category=DeprecationWarning)
+            r, intensity = vmi.average_radial_intensity(IM, **kwargs)
         assert_allclose(intensity[2:R], ref, atol=atol,
                         err_msg='-> {}, {}'.format(name, kwargs))
 
@@ -187,7 +194,10 @@ def test_toPES():
     # test image (not projected)
     IM = SampleImage(name='Ominus').image
 
-    eBE, PES = vmi.toPES(*vmi.angular_integration(IM),
+    with catch_warnings():
+        simplefilter('ignore', category=DeprecationWarning)
+        r, speeds = vmi.angular_integration(IM)
+    eBE, PES = vmi.toPES(r, speeds,
                          energy_cal_factor=1.2e-5,
                          photon_energy=1.0e7/808.6, Vrep=-100,
                          zoom=IM.shape[-1]/2048)

--- a/abel/tests/test_tools_vmi.py
+++ b/abel/tests/test_tools_vmi.py
@@ -194,17 +194,14 @@ def test_toPES():
     # test image (not projected)
     IM = SampleImage(name='Ominus').image
 
-    with catch_warnings():
-        simplefilter('ignore', category=DeprecationWarning)
-        r, speeds = vmi.angular_integration(IM)
-    eBE, PES = vmi.toPES(r, speeds,
+    eBE, PES = vmi.toPES(*vmi.angular_integration_3D(IM),
                          energy_cal_factor=1.2e-5,
                          photon_energy=1.0e7/808.6, Vrep=-100,
                          zoom=IM.shape[-1]/2048)
 
     assert_allclose(eBE[PES.argmax()], 11780, rtol=0.001,
                     err_msg='-> eBE @ max PES')
-    assert_allclose(PES.max(), 5270, rtol=0.001,
+    assert_allclose(PES.max(), 16570, rtol=0.001,
                     err_msg='-> max PES')
 
 

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -161,7 +161,7 @@ class StepAnalytical(BaseAnalytical):
 
 
 class Polynomial(BaseAnalytical):
-    """
+    r"""
     Define a polynomial function and calculate its analytical
     Abel transform.
 
@@ -219,7 +219,7 @@ class Polynomial(BaseAnalytical):
 
 
 class PiecewisePolynomial(BaseAnalytical):
-    """
+    r"""
     Define a piecewise polynomial function (sum of ``Polynomial``\ s)
     and calculate its analytical Abel transform.
 

--- a/abel/tools/math.py
+++ b/abel/tools/math.py
@@ -37,7 +37,7 @@ def gradient(f, x=None, dx=1, axis=-1):
     To-Do: implement smooth noise-robust differentiators for use on experimental data.
     http://www.holoborodko.com/pavel/numerical-methods/numerical-derivative/smooth-low-noise-differentiators/
     """
-    
+
     if x is None:
         x = np.arange(f.shape[axis]) * dx
     else:
@@ -61,10 +61,10 @@ def gradient(f, x=None, dx=1, axis=-1):
 
 
 def gaussian(x, a, mu, sigma, c):
-    """
+    r"""
     `Gaussian function <https://en.wikipedia.org/wiki/Gaussian_function>`_
 
-    :math:`f(x)=a e^{-(x - \mu)^2 / (2 \\sigma^2)} + c`
+    :math:`f(x)=a e^{-(x - \mu)^2 / (2 \sigma^2)} + c`
 
     Parameters
     ----------

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -88,7 +88,9 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
     coli = (X + origin[1]).flatten()
     coords = np.vstack((rowi, coli))
 
-    zi = map_coordinates(data, coords)
+    # Remap with interpolation
+    # (making an array of floats even if the data has an integer type)
+    zi = map_coordinates(data, coords, output=float)
     output = zi.reshape((nr, nt))
 
     if Jacobian:

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -68,13 +68,13 @@ def reproject_image_into_polar(data, origin=None, Jacobian=False,
     x, y = index_coords(data, origin=origin)  # (x,y) coordinates of each pixel
     r, theta = cart2polar(x, y)  # convert (x,y) -> (r,θ), note θ=0 is vertical
 
-    nr = np.int(np.ceil((r.max() - r.min()) / dr))
+    nr = int(np.ceil((r.max() - r.min()) / dr))
 
     if dt is None:
         nt = max(nx, ny)
     else:
         # dt in radians
-        nt = np.int(np.ceil((theta.max() - theta.min()) / dt))
+        nt = int(np.ceil((theta.max() - theta.min()) / dt))
 
     # Make a regular (in polar space) grid based on the min and max r & theta
     r_i = np.linspace(r.min(), r.max(), nr, endpoint=False)

--- a/abel/tools/polynomial.py
+++ b/abel/tools/polynomial.py
@@ -15,7 +15,7 @@ See :ref:`Polynomials` for details and examples.
 
 
 class Polynomial(object):
-    """
+    r"""
     Polynomial function and its Abel transform.
 
     Supports multiplication and division by numbers.
@@ -190,7 +190,7 @@ class Polynomial(object):
 
 
 class PiecewisePolynomial(Polynomial):
-    """
+    r"""
     Piecewise polynomial function (sum of ``Polynomial``\ s)
     and its Abel transform.
 

--- a/abel/tools/transform_pairs.py
+++ b/abel/tools/transform_pairs.py
@@ -53,7 +53,7 @@ source, projection : tuple of 1D numpy arrays of shape `r`
 
 
 def a(n, r):
-    """ coefficient
+    r""" coefficient
 
         .. math:: a_n = \sqrt{n^2 - r^2}
 
@@ -63,7 +63,7 @@ def a(n, r):
 
 
 def profile1(r):
-    """**profile1**:
+    r"""**profile1**:
     C. J. Cremers, R. C. Birkebak,
     "Application of the Abel Integral Equation to Spectrographic Data",
     `Appl. Opt. 5, 1057–1064 (1966)
@@ -73,17 +73,17 @@ def profile1(r):
 
         \epsilon(r) &= 0.75 + 12r^2 - 32r^3  & 0 \le r \le 0.25
 
-        \epsilon(r) &= \\frac{16}{27}(1 + 6r - 15r^2 + 8r^3)
+        \epsilon(r) &= \frac{16}{27}(1 + 6r - 15r^2 + 8r^3)
                     & 0.25 \lt r \le 1
 
-        I(r) &= \\frac{1}{108}(128a_1 +a_{0.25}) + \\frac{2}{27}r^2
-                  (283a_{0.25} - 112a_1) +
+        I(r) &= \frac{1}{108}(128a_1 + a_{0.25}) + \frac{2}{27}r^2
+                  (283a_{0.25} - 112a_1) + {}
 
-        & \,\,\,\, \\frac{8}{9}r^2\left[4(1+r^2)\ln\\frac{1+a_1}{r} -
-          (4+31r^2)\ln\\frac{0.25+a_{0.25}}{r}\\right] &  0 \le r \le 0.25
+        & \quad \frac{8}{9}r^2\left[4(1 + r^2)\ln\frac{1 + a_1}{r} -
+          (4 + 31r^2)\ln\frac{0.25 + a_{0.25}}{r}\right] &  0 \le r \le 0.25
 
-        I(r) &= \\frac{32}{27}\left[a_1 - 7a_1 r + 3r^2(1+r^2)
-                \ln\\frac{1+a_1}{r}\\right]  & 0.25 \lt r \le 1
+        I(r) &= \frac{32}{27}\left[a_1 - 7a_1 r + 3r^2(1 + r^2)
+                \ln\frac{1 + a_1}{r}\right]  & 0.25 \lt r \le 1
 
     ..
               source                projection
@@ -146,7 +146,7 @@ def profile1(r):
 
 
 def profile2(r):
-    """**profile2**:
+    r"""**profile2**:
     C. J. Cremers, R. C. Birkebak,
     "Application of the Abel Integral Equation to Spectrographic Data",
     `Appl. Opt. 5, 1057–1064 (1966)
@@ -156,8 +156,8 @@ def profile2(r):
 
         \epsilon(r) &= 1 - 3r^2 + 2r^3 & 0 \le r \le 1
 
-        I(r) &= a_1\left(1-\\frac{5}{2}r^2\\right) +
-                \\frac{3}{2}r^4\ln\\frac{1+a_1}{r} & 0 \le r \le 1
+        I(r) &= a_1\left(1 - \frac{5}{2}r^2\right) +
+                \frac{3}{2}r^4\ln\frac{1 + a_1}{r} & 0 \le r \le 1
 
     ..
               source                projection
@@ -195,7 +195,7 @@ def profile2(r):
 
 
 def profile3(r):
-    """**profile3**:
+    r"""**profile3**:
     C. J. Cremers, R. C. Birkebak,
     "Application of the Abel Integral Equation to Spectrographic Data",
     `Appl. Opt. 5, 1057–1064 (1966)
@@ -203,14 +203,14 @@ def profile3(r):
 
     .. math::
 
-        \epsilon(r) &= 1-2r^2  & 0 \le r \le 0.5
+        \epsilon(r) &= 1 - 2r^2  & 0 \le r \le 0.5
 
-        \epsilon(r) &= 2(1-r^2)^2 & 0.5 \lt r \le 1
+        \epsilon(r) &= 2(1 - r^2)^2 & 0.5 \lt r \le 1
 
-        I(r) &= \\frac{4a_1}{3}(1+2r^2)-\\frac{2 a_{0.5}}{3}(1+8r^2) -
-                4r^2\ln\\frac{1-a_1}{0.5+a_{0.5}} & 0 \le r \le 0.5
+        I(r) &= \frac{4a_1}{3}(1 + 2r^2) - \frac{2 a_{0.5}}{3}(1 + 8r^2) -
+                4r^2\ln\frac{1 - a_1}{0.5 + a_{0.5}} & 0 \le r \le 0.5
 
-        I(r) &= \\frac{4a_1}{3}(1+2r^2)-4r^2\ln\\frac{1-a_1}{r} &
+        I(r) &= \frac{4a_1}{3}(1 + 2r^2) - 4r^2\ln\frac{1 - a_1}{r} &
                 0.5 \lt r \le 1
 
     ..
@@ -265,7 +265,7 @@ def profile3(r):
 
 
 def profile4(r):
-    """**profile4**:
+    r"""**profile4**:
     R. Álvarez, A. Rodero, M. C. Quintero,
     "An Abel inversion method for radially resolved measurements in the axial
     injection torch",
@@ -283,15 +283,18 @@ def profile4(r):
         \epsilon(r) &= -40.74 + 155.56r - 188.89r^2 + 74.07r^3
                     & 0.7 \lt r \le1
 
-        I(r) &= 22.68862a_{0.7} - 14.811667a_1 + (217.557a_{0.7} -
-        196.30083a_1)r^2 +
+        I(r) &= 22.68862a_{0.7} - 14.811667a_1 + {}
 
-          & \,\,\, 155.56r^2\ln\\frac{1 + a_1}{0.7 + a_{0.7}} +
-            r^4\left(55.5525\ln\\frac{1 + a_1}{r} - 59.49\ln\\frac{0.7 +
-            a_{0.7}}{r}\\right)  & 0 \le r \le 0.7
+             &\quad (217.557a_{0.7} - 196.30083a_1)r^2 +
+             155.56r^2\ln\frac{1 + a_1}{0.7 + a_{0.7}} + {}
 
-        I(r) &= -14.811667a_1 - 196.30083a_1 r^2 + r^2(155.56 + 55.5525r^2)
-                \ln\\frac{1 + a_1}{r} & 0.7 \lt r \le 1
+             &\quad r^4\left(55.5525\ln\frac{1 + a_1}{r} - 59.49\ln\frac{0.7 +
+             a_{0.7}}{r}\right) & 0 \le r \le 0.7
+
+        I(r) &= -14.811667a_1 - 196.30083a_1 r^2 + {}
+
+             &\quad r^2(155.56 + 55.5525r^2) \ln\frac{1 + a_1}{r}
+             & 0.7 \lt r \le 1
 
     ..
               source                projection
@@ -373,7 +376,7 @@ def profile4(r):
 
 
 def profile5(r):
-    """**profile5**:
+    r"""**profile5**:
     M. J. Buie, J. T. P. Pender, J. P. Holloway, T. Vincent, P. L. G. Ventzek,
     M. L. Brake,
     `J. Quant. Spectrosc. Radiat. Transf. 55, 231–243 (1996)
@@ -419,7 +422,7 @@ def profile5(r):
 
 
 def profile6(r):
-    """**profile6**:
+    r"""**profile6**:
     M. J. Buie, J. T. P. Pender, J. P. Holloway, T. Vincent, P. L. G. Ventzek,
     M. L. Brake,
     `J. Quant. Spectrosc. Radiat. Transf. 55, 231–243 (1996)
@@ -427,11 +430,11 @@ def profile6(r):
 
     .. math::
 
-        \epsilon(r) &= (1-r^2)^{-\\frac{3}{2}} \exp\left[1.1^2\left(
-                        1 - \\frac{1}{1-r^2}\\right)\\right] & 0 \le r \le 1
+        \epsilon(r) &= (1 - r^2)^{-\frac{3}{2}} \exp\left[1.1^2\left(
+                        1 - \frac{1}{1 - r^2}\right)\right] & 0 \le r \le 1
 
-        I(r) &= \\frac{\sqrt{\pi}}{1.1a_1} \exp\left[1.1^2\left(
-                        1 - \\frac{1}{1-r^2}\\right)\\right] & 0 \le r \le 1
+        I(r) &= \frac{\sqrt{\pi}}{1.1a_1} \exp\left[1.1^2\left(
+                        1 - \frac{1}{1 - r^2}\right)\right] & 0 \le r \le 1
 
     ..
               source                projection
@@ -467,7 +470,7 @@ def profile6(r):
 
 
 def profile7(r):
-    """**profile7**:
+    r"""**profile7**:
     M. J. Buie, J. T. P. Pender, J. P. Holloway, T. Vincent, P. L. G. Ventzek,
     M. L. Brake,
     `J. Quant. Spectrosc. Radiat. Transf. 55, 231–243 (1996)
@@ -476,9 +479,9 @@ def profile7(r):
 
     .. math::
 
-        \epsilon(r) &= \\frac{1}{2}(1+10r^2-23r^4+12r^6) & 0 \le r \le 1
+        \epsilon(r) &= \frac{1}{2}(1 + 10r^2 - 23r^4 + 12r^6) & 0 \le r \le 1
 
-        I(r) &= \\frac{8}{105}a_1(19 + 34r^2 - 125r^4 + 72r^6) & 0 \le r \le 1
+        I(r) &= \frac{8}{105}a_1(19 + 34r^2 - 125r^4 + 72r^6) & 0 \le r \le 1
 
     ..
               source                projection

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -140,6 +140,16 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     Note: the use of ``Jacobian=True`` applies the correct Jacobian for the
     integration of a 3D object in spherical coordinates.
 
+    .. warning::
+        This function behaves incorrectly: misses a factor of π for 3D
+        integration, with ``Jacobian=True``, and for ``Jacobian=False`` returns
+        the *average* (over polar angles) multiplied by 2π instead of
+        integrating. It is currently deprecated and is provided only for
+        backward compatibility, but will be removed in the future.
+
+        Please use :func:`radial_intensity`, :func:`angular_integration_2D` or
+        :func:`angular_integration_3D`.
+
     Parameters
     ----------
     IM : 2D numpy.array
@@ -175,6 +185,8 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
         integrated intensity array (vs radius).
 
     """
+    _deprecate('angular_integration() is deprecated, '
+               'please see the documentation for appropriate alternatives.')
 
     polarIM, R, T = reproject_image_into_polar(
         IM, origin, Jacobian=Jacobian, dr=dr, dt=dt)
@@ -199,6 +211,14 @@ def average_radial_intensity(IM, **kwargs):
     :func:`abel.tools.vmi.angular_integration` with
     ``Jacobian=True`` and then dividing the result by 2π.
 
+    .. warning::
+        This function is currently deprecated and is provided only for backward
+        compatibility, but will be removed in the future.
+
+        Please use :func:`radial_intensity`,
+        :func:`average_radial_intensity_2D` or
+        :func:`average_radial_intensity_3D`.
+
     Parameters
     ----------
     IM : 2D numpy.array
@@ -215,8 +235,10 @@ def average_radial_intensity(IM, **kwargs):
 
     intensity : 1D numpy.array
         intensity profile as a function of the radial coordinate
-
     """
+    _deprecate('average_radial_intensity() is deprecated, '
+               'please see the documentation for appropriate alternatives.')
+
     R, intensity = angular_integration(IM, Jacobian=False, **kwargs)
     intensity /= 2 * np.pi
     return R, intensity

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -16,6 +16,121 @@ from scipy.special import legendre
 from abel import _deprecate
 
 
+def radial_intensity(kind, IM, origin=None, dr=1, dt=None):
+    """
+    Calculate the one-dimensional radial intensity profile by angular
+    integration or averaging of the image, treated either as a two-dimensional
+    distribution or as a central slice of a cylindrically symmetric
+    three-dimensional distribution.
+
+    Parameters
+    ----------
+    kind : str
+        operation to perform:
+
+        ``'int2D'``:
+            integration in 2D over polar angles
+        ``'int3D'``:
+            integration in 3D over solid angles
+        ``'avg2D'``:
+            averaging in 2D over polar angles
+        ``'avg3D'``:
+            averaging in 3D over solid angles
+
+    IM : 2D numpy.array
+        the image data
+
+    origin : tuple of float or None
+        image origin in the (row, column) format. If ``None``, the geometric
+        center of the image (``rows // 2, cols // 2``) is used.
+
+    dr : float
+        radial grid spacing in pixels (default 1). ``dr=0.5`` may reduce pixel
+        granularity of the radial profile.
+
+    dt : float or None
+        angular grid spacing in radians.
+        If ``None``, the number of theta values will be set to largest
+        dimension (the height or the width) of the image, which should
+        typically ensure good sampling.
+
+    Returns
+    -------
+    r : 1D numpy.array
+        radial coordinates
+
+    intensity : 1D numpy.array
+        intensity profile as a function of the radial coordinate
+    """
+    polarIM, R, T = reproject_image_into_polar(IM, origin, dr=dr, dt=dt)
+
+    # apply necessary Jacobian/normalization
+    if kind == 'int2D':
+        polarIM *= R
+    elif kind == 'int3D':
+        polarIM *= np.pi * R**2 * np.abs(np.sin(T))
+    elif kind == 'avg2D':
+        polarIM /= 2 * np.pi
+    elif kind == 'avg3D':
+        polarIM *= np.abs(np.sin(T)) / 4
+    else:
+        raise ValueError('Incorrect kind={}'.format(kind))
+
+    # integrate over theta
+    dt = T[0, 1] - T[0, 0]  # get the actual number, if dt=None was passed
+    intensity = polarIM.sum(axis=1) * dt
+    # (np.trapz() doesn't know about periodic functions and thus underuses
+    # boundary points; direct Riemann sum is more accurate here)
+
+    return R[:, 0], intensity
+
+
+def angular_integration_2D(IM, origin=None, dr=1, dt=None):
+    """
+    Angular integration of the image as a two-dimensional object.
+
+    Equivalent to :func:`radial_intensity('int2D', IM, origin, dr, dt)
+    <radial_intensity>`.
+    """
+    return radial_intensity('int2D', IM, origin=origin, dr=dr, dt=dt)
+
+
+def angular_integration_3D(IM, origin=None, dr=1, dt=None):
+    """
+    Angular integration of the three-dimensional cylindrically symmetric object
+    represented by the image as its central slice. When applied to the inverse
+    Abel transform of a velocity-mapping image, this yield the speed
+    distribution.
+
+    Equivalent to :func:`radial_intensity('int3D', IM, origin, dr, dt)
+    <radial_intensity>`.
+    """
+    return radial_intensity('int3D', IM, origin=origin, dr=dr, dt=dt)
+
+
+def average_radial_intensity_2D(IM, origin=None, dr=1, dt=None):
+    """
+    Calculate the average radial intensity of the image as a two-dimensional
+    object.
+
+    Equivalent to :func:`radial_intensity('avg2D', IM, origin, dr, dt)
+    <radial_intensity>`.
+    """
+    return radial_intensity('avg2D', IM, origin=origin, dr=dr, dt=dt)
+
+
+def average_radial_intensity_3D(IM, origin=None, dr=1, dt=None):
+    """
+    Calculate the average radial intensity of the three-dimensional
+    cylindrically symmetric object represented by the image as its central
+    slice.
+
+    Equivalent to :func:`radial_intensity('avg3D', IM, origin, dr, dt)
+    <radial_intensity>`.
+    """
+    return radial_intensity('avg3D', IM, origin=origin, dr=dr, dt=dt)
+
+
 def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     r"""Angular integration of the image.
 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -99,7 +99,7 @@ def angular_integration_3D(IM, origin=None, dr=1, dt=None):
     """
     Angular integration of the three-dimensional cylindrically symmetric object
     represented by the image as its central slice. When applied to the inverse
-    Abel transform of a velocity-mapping image, this yield the speed
+    Abel transform of a velocity-mapping image, this yields the speed
     distribution.
 
     Equivalent to :func:`radial_intensity('int3D', IM, origin, dr, dt)
@@ -185,8 +185,10 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
         integrated intensity array (vs radius).
 
     """
-    _deprecate('angular_integration() is deprecated, '
-               'please see the documentation for appropriate alternatives.')
+    _deprecate('angular_integration() is deprecated, please see the '
+               'documentation for details. '
+               'Use radial_intensity(), angular_integration_2D() or '
+               'angular_integration_3D() instead.')
 
     polarIM, R, T = reproject_image_into_polar(
         IM, origin, Jacobian=Jacobian, dr=dr, dt=dt)
@@ -237,7 +239,8 @@ def average_radial_intensity(IM, **kwargs):
         intensity profile as a function of the radial coordinate
     """
     _deprecate('average_radial_intensity() is deprecated, '
-               'please see the documentation for appropriate alternatives.')
+               'use average_radial_intensity_2D(), '
+               'average_radial_intensity_3D() or radial_intensity() instead.')
 
     R, intensity = angular_integration(IM, Jacobian=False, **kwargs)
     intensity /= 2 * np.pi
@@ -442,7 +445,7 @@ def toPES(radial, intensity, energy_cal_factor, per_energy_scaling=True,
 
         sets the intensity Jacobian.
         If ``True``, the returned intensities correspond to an "intensity per
-        eV" or "intensity per cm\ :sup:`-1` ". If ``False``, the returned
+        eV" or "intensity per cm\ :sup:`−1`". If ``False``, the returned
         intensities correspond to an "intensity per pixel".
 
     photon_energy : None or float

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -133,6 +133,9 @@ class Transform(object):
         Integrate the image over angle to give the radial (speed) intensity
         distribution.
 
+        *Note: in PyAbel ≤0.8.4 the intensity distribution was off by a factor
+        of π, please keep this in mind when comparing absolute intensities.*
+
     transform_options : tuple
         Additional arguments passed to the individual transform functions.
         See the documentation for the individual transform method for options.

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -143,7 +143,7 @@ class Transform(object):
 
     angular_integration_options : tuple (or dict)
         Additional arguments passed to the angular integration functions,
-        see :func:`abel.tools.vmi.angular_integration()`.
+        see :func:`abel.tools.vmi.angular_integration_3D()`.
 
     recast_as_float64 : bool
         determines whether the input image should be recast to
@@ -341,7 +341,7 @@ class Transform(object):
     angular_integration : tuple
         (radial-grid, radial-intensity)
         radial coordinates and the radial intensity (speed) distribution,
-        evaluated using :func:`abel.tools.vmi.angular_integration()`.
+        evaluated using :func:`abel.tools.vmi.angular_integration_3D()`.
 
     residual : numpy 2D array
         residual image (not currently implemented).
@@ -563,6 +563,6 @@ class Transform(object):
                 # assume user forgot to pass grid size
                 angular_integration_options['dr'] = transform_options['dr']
 
-            self.angular_integration = tools.vmi.angular_integration(
+            self.angular_integration = tools.vmi.angular_integration_3D(
                                              self.transform,
                                              **angular_integration_options)

--- a/doc/transform_methods/basex-basis.py
+++ b/doc/transform_methods/basex-basis.py
@@ -29,7 +29,7 @@ for k, c in enumerate(colors):
 plt.plot(x, sum([rho(x, k) for k in range(n)]),
          color='black', label=r'$\sum\rho_k$')
 
-plt.xlabel('$u = r/\sigma$')
+plt.xlabel(r'$u = r/\sigma$')
 plt.xlim((0, n - 1))
 plt.grid(axis='x')
 

--- a/doc/transform_methods/comparison/fig_experiment/experiment.py
+++ b/doc/transform_methods/comparison/fig_experiment/experiment.py
@@ -51,9 +51,9 @@ for num, (ax, (label, transFunc, color), letter) in enumerate(zip(axs.ravel(),
     if label == 'linbasex':  # bugfix smoothing=0 transform offset by 1 pixel
         trans[:, 1:] = trans[:, :-1]
 
-    r, inten = abel.tools.vmi.angular_integration(trans[::-1],
-                                                  origin=(0, 0),
-                                                  dr=0.1)
+    r, inten = abel.tools.vmi.angular_integration_3D(trans[::-1],
+                                                     origin=(0, 0),
+                                                     dr=0.1)
 
     inten /= 1e6
 
@@ -111,7 +111,7 @@ axs1[1].set_xticks(np.arange(355, 385), minor=True)
 
 axs1[2].set_xlim(80, 160)
 axs1[2].set_xticks(np.arange(80, 160, 10), minor=True)
-axs1[2].set_ylim(-0.004, 0.02)
+axs1[2].set_ylim(-0.01, 0.065)
 
 
 def place_letter(letter, ax, color='k', offset=(0, 0)):

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -464,8 +464,8 @@ class PyAbel:  # (tk.Tk):
             self.radial, self.speed_dist, _ = self.AIM.distr.rIbeta()
         else:
             # speed distribution
-            self.radial, self.speed_dist = abel.tools.vmi.angular_integration(
-                                           self.AIM.transform)
+            self.radial, self.speed_dist = \
+                abel.tools.vmi.angular_integration_3D(self.AIM.transform)
 
         self.plt[1].axis("on")
         self.plt[1].plot(

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -39,7 +39,7 @@ AIM = abel.Transform(IM, method="hansenlaw", direction="inverse",
 # PES - photoelectron speed distribution  -------------
 print('Calculating speed distribution:')
 
-r, speed  = abel.tools.vmi.angular_integration_3D(AIM)
+r, speed = abel.tools.vmi.angular_integration_3D(AIM)
 
 # normalize to max intensity peak
 speed /= speed[200:].max()  # exclude transform noise near centerline of image

--- a/examples/example_O2_PES_PAD.py
+++ b/examples/example_O2_PES_PAD.py
@@ -39,7 +39,7 @@ AIM = abel.Transform(IM, method="hansenlaw", direction="inverse",
 # PES - photoelectron speed distribution  -------------
 print('Calculating speed distribution:')
 
-r, speed  = abel.tools.vmi.angular_integration(AIM)
+r, speed  = abel.tools.vmi.angular_integration_3D(AIM)
 
 # normalize to max intensity peak
 speed /= speed[200:].max()  # exclude transform noise near centerline of image

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -79,8 +79,8 @@ for q, method in enumerate(transforms.keys()):
     print ("                    {:.1f} s".format(time()-t0))
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(-1, 0),
-                                                       dr=0.1)
+    radial, speed = abel.tools.vmi.angular_integration_3D(IAQ0, origin=(-1, 0),
+                                                          dr=0.1)
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0[mask].max()

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -69,7 +69,7 @@ for q, method in enumerate(transforms.keys()):
     iabelQ.append(IAQ0)  # store for plot
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(-1, 0))
+    radial, speed = abel.tools.vmi.angular_integration_3D(IAQ0, origin=(-1, 0))
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0.max()  

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -68,7 +68,7 @@ for q, method in enumerate(transforms.keys()):
     iabelQ.append(IAQ0)  # store for plot
 
     # polar projection and speed profile
-    radial, speed = abel.tools.vmi.angular_integration(IAQ0, origin=(-1, 0), Jacobian=False)
+    radial, speed = abel.tools.vmi.angular_integration_3D(IAQ0, origin=(-1, 0))
 
     # normalize image intensity and speed distribution
     IAQ0 /= IAQ0.max()  

--- a/examples/example_basex_photoelectron.py
+++ b/examples/example_basex_photoelectron.py
@@ -48,7 +48,7 @@ recon = abel.Transform(raw_data, direction='inverse', method='basex',
                        origin=origin, transform_options=dict(basis_dir='bases'),
                        verbose=True).transform
                       
-speeds = abel.tools.vmi.angular_integration(recon)
+speeds = abel.tools.vmi.angular_integration_3D(recon)
 
 # Set up some axes
 fig = plt.figure(figsize=(15,4))

--- a/examples/example_circularize_image.py
+++ b/examples/example_circularize_image.py
@@ -41,8 +41,8 @@ AIMcirc = abel.Transform(IMcirc, method="three_point",
                          transform_options=dict(basis_dir='bases')).transform
 
 # respective speed distributions
-rdist, speeddist = abel.tools.vmi.angular_integration(AIMdist, dr=0.5)
-rcirc, speedcirc = abel.tools.vmi.angular_integration(AIMcirc, dr=0.5)
+rdist, speeddist = abel.tools.vmi.angular_integration_3D(AIMdist, dr=0.5)
+rcirc, speedcirc = abel.tools.vmi.angular_integration_3D(AIMcirc, dr=0.5)
 
 # note the small image size is responsible for the slight over correction
 # of the background near peaks

--- a/examples/example_dasch_methods.py
+++ b/examples/example_dasch_methods.py
@@ -18,7 +18,7 @@ IM = abel.tools.analytical.SampleImage(n).image
 origQ = abel.tools.symmetry.get_image_quadrants(IM)
 
 # speed distribution of original image
-orig_speed = abel.tools.vmi.angular_integration(origQ[0], origin=(-1, 0))
+orig_speed = abel.tools.vmi.angular_integration_3D(origQ[0], origin=(-1, 0))
 scale_factor = orig_speed[1].max()
 
 plt.plot(orig_speed[0], orig_speed[1]/scale_factor, linestyle='dashed', 
@@ -41,7 +41,7 @@ for method in dasch_transform.keys():
 # method inverse Abel transform
     AQ0 = dasch_transform[method](Q0, basis_dir='bases')
 # speed distribution
-    speed = abel.tools.vmi.angular_integration(AQ0, origin=(-1, 0))
+    speed = abel.tools.vmi.angular_integration_3D(AQ0, origin=(-1, 0))
 
     plt.plot(speed[0], speed[1]*orig_speed[1][14]/speed[1][14]/scale_factor, 
              label=method)

--- a/examples/example_hansenlaw_Xe.py
+++ b/examples/example_hansenlaw_Xe.py
@@ -41,7 +41,7 @@ recon = abel.Transform(im, method="hansenlaw", direction="inverse",
                        symmetry_axis=None, verbose=True, 
                        origin=(240,340)).transform
                        
-r, speeds = abel.tools.vmi.angular_integration(recon)
+r, speeds = abel.tools.vmi.angular_integration_3D(recon)
 
 # Set up some axes
 fig = plt.figure(figsize=(15,4))

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -64,14 +64,14 @@ print('Performing Hansen and Law inverse Abel transform:')
 # quad = (True ... => combine the 4 quadrants into one
 reconH = abel.Transform(im, method="hansenlaw", direction="inverse",
                         verbose=True, symmetry_axis=None).transform
-rH, speedsH = abel.tools.vmi.angular_integration(reconH)
+rH, speedsH = abel.tools.vmi.angular_integration_3D(reconH)
 
 # Basex inverse Abel transform
 print('Performing basex inverse Abel transform:')
 reconB = abel.Transform(im, method="basex", direction="inverse",
                         verbose=True, symmetry_axis=None,
                         transform_options=dict(basis_dir='bases')).transform
-rB, speedsB = abel.tools.vmi.angular_integration(reconB)
+rB, speedsB = abel.tools.vmi.angular_integration_3D(reconB)
 
 # plot the results - VMI, inverse Abel transformed image, speed profiles
 # Set up some axes

--- a/examples/example_onion_bordas.py
+++ b/examples/example_onion_bordas.py
@@ -14,7 +14,7 @@ IM = abel.tools.analytical.SampleImage(n=501).image
 origQ = abel.tools.symmetry.get_image_quadrants(IM)
 
 # speed distribution
-orig_speed = abel.tools.vmi.angular_integration(origQ[0], origin=(-1, 0))
+orig_speed = abel.tools.vmi.angular_integration_3D(origQ[0], origin=(-1, 0))
 
 # forward Abel projection
 fIM = abel.Transform(IM, direction="forward", method="hansenlaw").transform
@@ -26,7 +26,7 @@ Q0 = Q[0].copy()
 # onion_bordas inverse Abel transform
 borQ0 = abel.onion_bordas.onion_bordas_transform(Q0)
 # speed distribution
-bor_speed = abel.tools.vmi.angular_integration(borQ0, origin=(-1, 0))
+bor_speed = abel.tools.vmi.angular_integration_3D(borQ0, origin=(-1, 0))
 
 plt.plot(*orig_speed, linestyle='dashed', label="Dribinski sample")
 plt.plot(bor_speed[0], bor_speed[1], label="onion_bordas")

--- a/examples/example_rbasex_block.py
+++ b/examples/example_rbasex_block.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function
 
 import numpy as np
 import matplotlib.pyplot as plt
+from copy import copy
 
 import abel
 from abel.tools.analytical import SampleImage
@@ -69,8 +70,10 @@ r_rbasex, P0_rbasex, P2_rbasex = distr_rbasex.rharmonics()
 # plotting...
 plt.figure(figsize=(7, 7))
 
-plt.cm.hot.set_bad('lightgray', 1.0)
-plt.cm.seismic.set_bad('lightgray', 1.0)
+cmap_hot = copy(plt.cm.hot)
+cmap_hot.set_bad('lightgray')
+cmap_seismic = copy(plt.cm.seismic)
+cmap_seismic.set_bad('lightgray')
 
 def plots(row,
           im_title, im, im_mask,
@@ -81,14 +84,14 @@ def plots(row,
         plt.subplot(3, 4, 4 * row + 1)
         plt.title(im_title)
         im_masked = np.ma.masked_where(im_mask == 0, im)
-        plt.imshow(im_masked, cmap='hot')
+        plt.imshow(im_masked, cmap=cmap_hot)
         plt.axis('off')
 
     # transformed image
     plt.subplot(3, 4, 4 * row + 2)
     plt.title(tr_title)
     tr_masked = np.ma.masked_where(tr_mask == 0, tr)
-    plt.imshow(tr_masked, vmin=-vlim, vmax=vlim, cmap='seismic')
+    plt.imshow(tr_masked, vmin=-vlim, vmax=vlim, cmap=cmap_seismic)
     plt.axis('off')
 
     # profiles

--- a/examples/example_rbasex_multimass.py
+++ b/examples/example_rbasex_multimass.py
@@ -86,13 +86,14 @@ plt.title('Partially overlapping images\n'
 plt.imshow(im, cmap='hot')
 # overlay with the boundaries of each mask (only for demonstration)
 from scipy.ndimage import binary_erosion
-dmask = 1 * (mask1 - binary_erosion(mask1, iterations=3)) + \
-        2 * (mask2 - binary_erosion(mask2, iterations=3)) + \
-        3 * (mask3 - binary_erosion(mask3, iterations=3))
+brush = np.ones((11, 11))
+dmask = 1 * (mask1 - binary_erosion(mask1, structure=brush)) + \
+        2 * (mask2 - binary_erosion(mask2, structure=brush)) + \
+        3 * (mask3 - binary_erosion(mask3, structure=brush))
 dmask[dmask == 0] = np.nan
 from matplotlib.colors import ListedColormap
 rgb = ListedColormap(['#CC0000', '#00AA00', '#0055FF'])
-plt.imshow(dmask, extent=(0, w, 0, h), cmap=rgb)
+plt.imshow(dmask, extent=(0, w, 0, h), cmap=rgb, interpolation='nearest')
 
 # Analyze the left part and plot results
 plt.subplot(222)

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -139,7 +139,7 @@ def _speed():
     elif transform.get() == 'rbasex':
         radial, speed, _ = AIM.distr.rIbeta()
     else:
-        radial, speed = abel.tools.vmi.angular_integration(AIM.transform)
+        radial, speed = abel.tools.vmi.angular_integration_3D(AIM.transform)
 
     f.clf()
     a = f.add_subplot(111)


### PR DESCRIPTION
Here are the new functions:
* `angular_integration_2D()` and `angular_integration_3D()` to replace `angular_integration()`,
* `average_radial_intensity_2D()` and `average_radial_intensity_3D()` to replace `average_radial_intensity()`.
They are in fact implemented through a new function `radial_intensity()`, which can do all of this.

The old functions are declared deprecated and removed from the rest of the code. Hopefully, completely... This took most of the effort. :–) In this process, I've discovered one **problem**: the `angular_integration` option in `transform.Transform()` was using that incorrect `angular_integration()` function and thus also produced incorrect results. I've [mentioned this in the docstring](https://github.com/MikhailRyazanov/PyAbel/blob/d8173987ac044649216788482be8c34f93150bfa/abel/transform.py#L132-L137), but nothing can be done for backward compatibility in this case... Except renaming this option (and the `angular_integration` attribute, which hold the results), like we did with the `center` → `origin` transition. Any ideas?

P.S. Various minor things that produced warnings (due to incorrectly formatted docstrings and changes in Matplotlib and NumPy) are also corrected. Now  AppVeyor and Read the Docs build without warnings.