### PR TITLE
README file for the examples directory + years corrections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Unreleased
   angular_integration() and average_radial_intensity(), which had incorrect or
   nonintuitive behavior (PR #318, PR #319).
 
-v0.8.4 (2020-04-15)
+v0.8.4 (2021-04-15)
 -------------------
 * Added odd angular orders to tools.vmi.Distributions (PR #266).
 * Important! Some "center" functions/parameters are renamed to "origin" or

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,7 +2,7 @@ Contributing to PyAbel
 ======================
 
 
-PyAbel is an open-source project, and we welcome improvements! Please let us know about any issues with the software, even if's just a typo. The easiest way to get started is to open a `new issue <https://github.com/PyAbel/PyAbel/issues>`_.
+PyAbel is an open-source project, and we welcome improvements! Please let us know about any issues with the software, even if's just a typo. The easiest way to get started is to open a `new issue <https://github.com/PyAbel/PyAbel/issues>`__.
 
 If you would like to make a Pull Request, the following information may be useful.
 
@@ -10,7 +10,7 @@ If you would like to make a Pull Request, the following information may be usefu
 Change Log
 ----------
 
-If the change is significant (more than just a typo-fix), please leave a short note about the change in `CHANGELOG.rst <https://github.com/PyAbel/PyAbel/blob/master/CHANGELOG.rst>`_
+If the change is significant (more than just a typo-fix), please leave a short note about the change in `CHANGELOG.rst <https://github.com/PyAbel/PyAbel/blob/master/CHANGELOG.rst>`__
 
 
 Unit tests
@@ -24,7 +24,7 @@ For more detailed information, the following can be used::
 
     pytest abel/  -v  --cov=abel
 
-Note that this requires that you have `pytest <https://docs.pytest.org/en/latest/>`_ and (optionally) `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_ installed. You can install these with ::
+Note that this requires that you have `pytest <https://docs.pytest.org/en/latest/>`__ and (optionally) `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`__ installed. You can install these with ::
 
     pip install pytest pytest-cov
 
@@ -32,7 +32,7 @@ Note that this requires that you have `pytest <https://docs.pytest.org/en/latest
 Documentation
 -------------
 
-PyAbel uses Sphinx and `Napoleon <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html>`_ to process Numpy-style docstrings and is synchronized to `pyabel.readthedocs.io <http://pyabel.readthedocs.io>`_. To build the documentation locally, you will need `Sphinx <http://www.sphinx-doc.org/>`_, the `recommonmark <https://github.com/rtfd/recommonmark>`_ package, and the `sphinx_rtd_theme <https://github.com/snide/sphinx_rtd_theme/>`_. You can install them using ::
+PyAbel uses Sphinx and `Napoleon <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html>`__ to process Numpy-style docstrings and is synchronized to `pyabel.readthedocs.io <http://pyabel.readthedocs.io>`__. To build the documentation locally, you will need `Sphinx <http://www.sphinx-doc.org/>`__, the `recommonmark <https://github.com/rtfd/recommonmark>`__ package, and the `sphinx_rtd_theme <https://github.com/snide/sphinx_rtd_theme/>`__. You can install them using ::
 
     pip install sphinx
     pip install recommonmark
@@ -50,7 +50,7 @@ Then you can open ``doc/_build/hmtl/index.html`` to look at the documentation. S
 
 to clear out the old documentation and get things to re-build properly.
 
-When you get tired of typing ``make html`` every time you make a change to the documentation, it's nice to use use `sphix-autobuild <https://pypi.python.org/pypi/sphinx-autobuild>`_ to automatically update the documentation in your browser for you. So, install sphinx-autobuild using ::
+When you get tired of typing ``make html`` every time you make a change to the documentation, it's nice to use use `sphix-autobuild <https://pypi.python.org/pypi/sphinx-autobuild>`__ to automatically update the documentation in your browser for you. So, install sphinx-autobuild using ::
 
     pip install sphinx-autobuild
 
@@ -61,7 +61,7 @@ Now you should be able to ::
 
 which should launch a browser window displaying the docs. When you save a change to any of the docs, the re-build should happen automatically and the docs should update in a matter of a few seconds.
 
-Alternatively, `restview <https://pypi.python.org/pypi/restview>`_ is a nice way to preview the ``.rst`` files.
+Alternatively, `restview <https://pypi.python.org/pypi/restview>`__ is a nice way to preview the ``.rst`` files.
 
 
 Code Style
@@ -69,13 +69,13 @@ Code Style
 
 We hope that the PyAbel code will be understandable, hackable, and maintainable for many years to come. So, please use good coding style, include plenty of comments, use docstrings for functions, and pick informative variable names.
 
-PyAbel attempts to follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style whenever possible, since the PEP8 recommendations typically produces code that is easier to read. You can check your code using `pycodestyle <https://pypi.org/project/pycodestyle/>`_, which can be called from the command line or incorporated right into most text editors. Also, PyAbel is using automated pycodestyle checking of all Pull Requests using `pep8speaks <https://pep8speaks.com/>`_. However, `producing readable code <https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds>`_ is the primary goal, so please go ahead and break the rules of PEP8 when doing so improves readability. For example, if a section of your code is easier to read with lines slightly longer than 79 characters, then use the longer lines.
+PyAbel attempts to follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`__ style whenever possible, since the PEP8 recommendations typically produces code that is easier to read. You can check your code using `pycodestyle <https://pypi.org/project/pycodestyle/>`__, which can be called from the command line or incorporated right into most text editors. Also, PyAbel is using automated pycodestyle checking of all Pull Requests using `pep8speaks <https://pep8speaks.com/>`__. However, `producing readable code <https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds>`__ is the primary goal, so please go ahead and break the rules of PEP8 when doing so improves readability. For example, if a section of your code is easier to read with lines slightly longer than 79 characters, then use the longer lines.
 
 
 Before merging
 --------------
 
-If possible, before merging your pull request please rebase your fork on the last master on PyAbel. This could be done `as explained in this post <https://stackoverflow.com/questions/7244321/how-to-update-a-github-forked-repository>`_::
+If possible, before merging your pull request please rebase your fork on the last master on PyAbel. This could be done `as explained in this post <https://stackoverflow.com/questions/7244321/how-to-update-a-github-forked-repository>`__::
 
     # Add the remote, call it "upstream" (only the fist time)
     git remote add upstream https://github.com/PyAbel/PyAbel.git
@@ -100,7 +100,7 @@ If possible, before merging your pull request please rebase your fork on the las
 
     git push -f
 
-See `this wiki <https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request>`_ for more information.
+See `this wiki <https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request>`__ for more information.
 
 
 Adding a new forward or inverse Abel implementation
@@ -142,14 +142,14 @@ See ``abel/tests/test_basex.py`` for a concrete example.
 Dependencies
 ------------
 
-The current list of dependencies can be found in `setup.py <https://github.com/PyAbel/PyAbel/blob/master/setup.py>`_. Please refrain from adding new dependencies, unless it cannot be avoided.
+The current list of dependencies can be found in `setup.py <https://github.com/PyAbel/PyAbel/blob/master/setup.py>`__. Please refrain from adding new dependencies, unless it cannot be avoided.
 
 
 
 Releasing on PyPi
 -----------------
 
-PyAbel should be automatically released on PyPi (see `PR #161 <https://github.com/PyAbel/PyAbel/pull/161>`_) whenever a new release is drafted on GitHub via the "Draft New Release" button on the `Releases page <https://github.com/PyAbel/PyAbel/releases>`_. But first, make a Pull Request that does the following:
+PyAbel should be automatically released on PyPi (see `PR #161 <https://github.com/PyAbel/PyAbel/pull/161>`__) whenever a new release is drafted on GitHub via the "Draft New Release" button on the `Releases page <https://github.com/PyAbel/PyAbel/releases>`__. But first, make a Pull Request that does the following:
 
 - Increment the version number in abel/_version.py.
 - Modify CHANGELOG.rst to include the new changes in the new version.

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ The outcome of the numerical Abel transform depends on the exact method used. So
 Installation
 ------------
 
-PyAbel requires Python 3.5-3.9. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://www.numpy.org/>`__ and `SciPy <https://www.scipy.org/>`__ are also required, and `Matplotlib <https://matplotlib.org/>`__ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`__, which is available for free.
+PyAbel requires Python 3.5-3.9. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://www.numpy.org/>`__ and `SciPy <https://www.scipy.org/>`__ are also required, and `Matplotlib <https://matplotlib.org/>`__ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.anaconda.com/products/individual>`__, which is available for free.
 
 With pip
 ~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -6,13 +6,13 @@ PyAbel README
 .. image:: https://ci.appveyor.com/api/projects/status/g1rj5f0g7nohcuuo
     :target: https://ci.appveyor.com/project/PyAbel/PyAbel
 
-**Note:** This readme is best viewed as part of the `PyAbel Documentation <https://pyabel.readthedocs.io/en/latest/readme_link.html>`_.
+**Note:** This readme is best viewed as part of the `PyAbel Documentation <https://pyabel.readthedocs.io/en/latest/readme_link.html>`__.
 
 
 Introduction
 ------------
 
-``PyAbel`` is a Python package that provides functions for the forward and inverse `Abel transforms <https://en.wikipedia.org/wiki/Abel_transform>`_. The forward Abel transform takes a slice of a cylindrically symmetric 3D object and provides the 2D projection of that object. The inverse Abel transform takes a 2D projection and reconstructs a slice of the cylindrically symmetric 3D distribution.
+``PyAbel`` is a Python package that provides functions for the forward and inverse `Abel transforms <https://en.wikipedia.org/wiki/Abel_transform>`__. The forward Abel transform takes a slice of a cylindrically symmetric 3D object and provides the 2D projection of that object. The inverse Abel transform takes a 2D projection and reconstructs a slice of the cylindrically symmetric 3D distribution.
 
 .. image:: https://user-images.githubusercontent.com/1107796/48970223-1b477b80-efc7-11e8-9feb-c614d6cadab6.png
    :width: 500px
@@ -27,7 +27,7 @@ PyAbel provides efficient implementations of several Abel transform algorithms, 
 Transform Methods
 -----------------
 
-The outcome of the numerical Abel transform depends on the exact method used. So far, PyAbel includes the following `transform methods <https://pyabel.readthedocs.io/en/latest/transform_methods.html>`_:
+The outcome of the numerical Abel transform depends on the exact method used. So far, PyAbel includes the following `transform methods <https://pyabel.readthedocs.io/en/latest/transform_methods.html>`__:
 
 1. ``basex`` - Gaussian basis set expansion of Dribinski and co-workers.
 
@@ -51,7 +51,7 @@ The outcome of the numerical Abel transform depends on the exact method used. So
 Installation
 ------------
 
-PyAbel requires Python 3.5-3.9. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://www.numpy.org/>`_ and `SciPy <https://www.scipy.org/>`_ are also required, and `Matplotlib <https://matplotlib.org/>`_ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`_, which is available for free.
+PyAbel requires Python 3.5-3.9. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://www.numpy.org/>`__ and `SciPy <https://www.scipy.org/>`__ are also required, and `Matplotlib <https://matplotlib.org/>`__ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`__, which is available for free.
 
 With pip
 ~~~~~~~~
@@ -112,7 +112,7 @@ Output:
    :width: 400px
    :alt: example abel transform
 
-.. note:: Additional examples can be viewed on the `PyAbel examples <https://pyabel.readthedocs.io/en/latest/examples.html>`_ page and even more are found in the `PyAbel/examples <https://github.com/PyAbel/PyAbel/tree/master/examples>`_ directory.
+.. note:: Additional examples can be viewed on the `PyAbel examples <https://pyabel.readthedocs.io/en/latest/examples.html>`__ page and even more are found in the `PyAbel/examples <https://github.com/PyAbel/PyAbel/tree/master/examples>`__ directory.
 
 
 Documentation
@@ -159,13 +159,13 @@ The PyAbel code adheres to the following conventions:
     **Image origin:** Fundamentally, the forward and inverse Abel transforms in PyAbel consider the origin of the image to be located in the center of a pixel. This means that, for a symmetric image, the image will have a width that is an odd number of pixels. (The central pixel is effectively "shared" between both halves of the image.) In most situations, the image origin is specified using the ``origin`` keyword in ``abel.Transform`` (or directly using ``abel.center.center_image`` to find the origin (the center of symmetry) of your image). This processing step takes care of shifting the origin of the image to the middle of the central pixel. However, if the individual Abel transforms methods are used directly, care must be taken to supply a properly centered image. Some methods also provide low-level functions for transforming only the right half of the image (with the origin located in the middle of a 0th-column pixel).
 
 -
-    **Intensity:** The pixel intensities can have any value (within the floating-point range). However, the intensity scale must be linear. Keep in mind that cameras and common image formats often use `gamma correction <https://en.wikipedia.org/wiki/Gamma_correction>`_ and thus provide data with nonlinear intensity encoding. Thus, if possible, it is recommended to disable the gamma correction on cameras used to record images that will be inverse Abel-transformed. If this is not possible, then it is necessary to apply the appropriate intensity transformations before the analysis. Most PyAbel methods also assume intensities to be floating-point numbers, and when applied to integer types, can return inappropriately rounded results. The ``abel.Transform`` class recasts the input image to ``float64`` by default, but if you wish to call the transform methods directly or use other tools, you might need to perform the conversion yourself (as ``IM.astype(float)``, for example).
+    **Intensity:** The pixel intensities can have any value (within the floating-point range). However, the intensity scale must be linear. Keep in mind that cameras and common image formats often use `gamma correction <https://en.wikipedia.org/wiki/Gamma_correction>`__ and thus provide data with nonlinear intensity encoding. Thus, if possible, it is recommended to disable the gamma correction on cameras used to record images that will be inverse Abel-transformed. If this is not possible, then it is necessary to apply the appropriate intensity transformations before the analysis. Most PyAbel methods also assume intensities to be floating-point numbers, and when applied to integer types, can return inappropriately rounded results. The ``abel.Transform`` class recasts the input image to ``float64`` by default, but if you wish to call the transform methods directly or use other tools, you might need to perform the conversion yourself (as ``IM.astype(float)``, for example).
 
 
 Support
 -------
 
-If you have a question or suggestion about PyAbel, the best way to contact the PyAbel Developers Team is to `open a new issue <https://github.com/PyAbel/PyAbel/issues>`_.
+If you have a question or suggestion about PyAbel, the best way to contact the PyAbel Developers Team is to `open a new issue <https://github.com/PyAbel/PyAbel/issues>`__.
 
 
 Contributing
@@ -173,15 +173,15 @@ Contributing
 
 We welcome suggestions for improvement, together with any interesting images that demonstrate  application of PyAbel.
 
-Either open a new `Issue <https://github.com/PyAbel/PyAbel/issues>`_ or make a `Pull Request <https://github.com/PyAbel/PyAbel/pulls>`_.
+Either open a new `Issue <https://github.com/PyAbel/PyAbel/issues>`__ or make a `Pull Request <https://github.com/PyAbel/PyAbel/pulls>`__.
 
-`CONTRIBUTING.rst <https://github.com/PyAbel/PyAbel/blob/master/CONTRIBUTING.rst>`_ has more information on how to contribute, such as how to run the unit tests and how to build the documentation.
+`CONTRIBUTING.rst <https://github.com/PyAbel/PyAbel/blob/master/CONTRIBUTING.rst>`__ has more information on how to contribute, such as how to run the unit tests and how to build the documentation.
 
 
 License
 -------
 
-PyAble is licensed under the `MIT license <https://github.com/PyAbel/PyAbel/blob/master/LICENSE.txt>`_, so it can be used for pretty much whatever you want! Of course, it is provided "as is" with absolutely no warranty.
+PyAble is licensed under the `MIT license <https://github.com/PyAbel/PyAbel/blob/master/LICENSE.txt>`__, so it can be used for pretty much whatever you want! Of course, it is provided "as is" with absolutely no warranty.
 
 
 .. _READMEcitation:
@@ -191,12 +191,12 @@ Citation
 
 First and foremost, please cite the paper(s) corresponding to the implementation of the Abel transform that you use in your work. The references can be found at the links above.
 
-If you find PyAbel useful in you work, it would bring us great joy if you would cite the project. You can find the DOI for the lastest verison `here <https://dx.doi.org/10.5281/zenodo.594858>`_
+If you find PyAbel useful in you work, it would bring us great joy if you would cite the project. You can find the DOI for the lastest verison `here <https://dx.doi.org/10.5281/zenodo.594858>`__
 
 .. image:: https://zenodo.org/badge/30170345.svg
    :target: https://zenodo.org/badge/latestdoi/30170345
 
-Additionally, we have written a scientific paper comparing various Abel transform methods. You can find the manuscript at the Review of Scientific Instruments (DOI: `doi.org/10.1063/1.5092635 <https://doi.org/10.1063/1.5092635>`_) or on arxiv (`arxiv.org/abs/1902.09007 <https://arxiv.org/abs/1902.09007>`_).
+Additionally, we have written a scientific paper comparing various Abel transform methods. You can find the manuscript at the Review of Scientific Instruments (DOI: `doi.org/10.1063/1.5092635 <https://doi.org/10.1063/1.5092635>`__) or on arxiv (`arxiv.org/abs/1902.09007 <https://arxiv.org/abs/1902.09007>`__).
 
 
 **Have fun!**

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -757,7 +757,7 @@ def is_symmetric(arr, i_sym=True, j_sym=True):
     checked for polar symmetry.
 
     See `issue #34 comment
-    <https://github.com/PyAbel/PyAbel/issues/34#issuecomment-160344809>`_
+    <https://github.com/PyAbel/PyAbel/issues/34#issuecomment-160344809>`__
     for the defintion of a center of the image.
     """
 

--- a/abel/dasch.py
+++ b/abel/dasch.py
@@ -33,7 +33,7 @@ _dasch_parameter_docstring = \
     "One-dimensional tomography: a comparison of Abel, onion-peeling, and
     filtered backprojection methods",
     `Appl. Opt. 31, 1146–1152 (1992)
-    <https://doi.org/10.1364/AO.31.001146>`_.
+    <https://doi.org/10.1364/AO.31.001146>`__.
 
     Parameters
     ----------

--- a/abel/hansenlaw.py
+++ b/abel/hansenlaw.py
@@ -60,14 +60,14 @@ def hansenlaw_transform(image, dr=1, direction='inverse', hold_order=0,
     E. W. Hansen,
     "Fast Hankel transform algorithm",
     `IEEE Trans. Acoust. Speech Signal Proc. 33, 666–671 (1985)
-    <https://dx.doi.org/10.1109/TASSP.1985.1164579>`_
+    <https://dx.doi.org/10.1109/TASSP.1985.1164579>`__
 
     and
 
     E. W. Hansen, P.-L. Law,
     "Recursive methods for computing the Abel transform and its inverse",
     `J. Opt. Soc. Am. A 2, 510–520 (1985)
-    <https://dx.doi.org/10.1364/JOSAA.2.000510>`_.
+    <https://dx.doi.org/10.1364/JOSAA.2.000510>`__.
 
     This function performs the Hansen–Law transform on only one "right-side"
     image::

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -37,7 +37,7 @@ _linbasex_parameter_docstring = \
     "Charged particle velocity map image reconstruction with one-dimensional
     projections of spherical functions",
     `Rev. Sci. Instrum. 84, 033101 (2013)
-    <https://doi.org/10.1063/1.4793404>`_.
+    <https://doi.org/10.1063/1.4793404>`__.
 
     ``linbasex`` models the image using a sum of Legendre polynomials at each
     radial pixel, As such, it should only be applied to situations that can

--- a/abel/onion_bordas.py
+++ b/abel/onion_bordas.py
@@ -72,14 +72,14 @@ def onion_bordas_transform(IM, dr=1, direction="inverse", shift_grid=True,
     "Incorporating real time velocity map image reconstruction into closed-loop
     coherent control",
     `Rev. Sci. Instrum. 85, 113105 (2014)
-    <https://doi.org/10.1063/1.4899267>`_.
+    <https://doi.org/10.1063/1.4899267>`__.
 
     The algorithm actually originates from
 
     C. Bordas, F. Paulig,
     "Photoelectron imaging spectrometry: Principle and inversion method",
     `Rev. Sci. Instrum. 67, 2257–2268 (1996)
-    <https://doi.org/10.1063/1.1147044>`_.
+    <https://doi.org/10.1063/1.1147044>`__.
 
     This function operates on the "right side" of an image. i.e. it works on
     just half of a cylindrically symmetric image. Unlike the other transforms,

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -127,7 +127,7 @@ class Transform(object):
             J. P. Shaffer,
             "Multiple scattering and the density distribution of a Cs MOT",
             `Optics Express 13, 9672–9682 (2005)
-            <https://dx.doi.org/10.1364/OPEX.13.009672>`_.
+            <https://doi.org/10.1364/OPEX.13.009672>`__.
 
     angular_integration : bool
         Integrate the image over angle to give the radial (speed) intensity
@@ -229,7 +229,7 @@ class Transform(object):
         "Reconstruction of Abel-transformable images: The Gaussian basis-set
         expansion Abel transform method",
         `Rev. Sci. Instrum. 73, 2634–2642 (2002)
-        <https://dx.doi.org/10.1063/1.1482156>`_.
+        <https://doi.org/10.1063/1.1482156>`__.
 
     ``direct``
         This method attempts a direct integration of the Abel-transform
@@ -248,7 +248,7 @@ class Transform(object):
         E. W. Hansen, P.-L. Law,
         "Recursive methods for computing the Abel transform and its inverse",
         `J. Opt. Soc. Am. A 2, 510–520 (1985)
-        <https://dx.doi.org/10.1364/JOSAA.2.000510>`_.
+        <https://doi.org/10.1364/JOSAA.2.000510>`__.
 
     ``linbasex`` *
         Velocity-mapping images are composed of projected Newton spheres with
@@ -263,7 +263,7 @@ class Transform(object):
         "Charged particle velocity map image reconstruction with
         one-dimensional projections of spherical functions",
         `Rev. Sci. Instrum. 84, 033101 (2013)
-        <https://doi.org/10.1063/1.4793404>`_.
+        <https://doi.org/10.1063/1.4793404>`__.
 
     ``onion_bordas``
         The onion peeling method, also known as "back projection", originates
@@ -271,7 +271,7 @@ class Transform(object):
         C. Bordas, F. Paulig,
         "Photoelectron imaging spectrometry: Principle and inversion method",
         `Rev. Sci. Instrum. 67, 2257–2268 (1996)
-        <https://doi.org/10.1063/1.1147044>`_.
+        <https://doi.org/10.1063/1.1147044>`__.
 
         The algorithm was subsequently coded in MatLab by
         C. E. Rallis, T. G. Burwitz, P. R. Andrews, M. Zohrabi, R. Averin,
@@ -281,16 +281,16 @@ class Transform(object):
         "Incorporating real time velocity map image reconstruction into
         closed-loop coherent control",
         `Rev. Sci. Instrum. 85, 113105 (2014)
-        <https://doi.org/10.1063/1.4899267>`_,
+        <https://doi.org/10.1063/1.4899267>`__,
         which was used as the basis of this Python port. See `issue #56
-        <https://github.com/PyAbel/PyAbel/issues/56>`_.
+        <https://github.com/PyAbel/PyAbel/issues/56>`__.
 
     ``onion_peeling`` *
         This is one of the most compact and fast algorithms, with the inverse
         Abel transform achieved in one Python code-line, `PR #155
-        <https://github.com/PyAbel/PyAbel/pull/155>`_. See also ``three_point``
-        is the onion peeling algorithm as described by Dasch (1992), reference
-        below.
+        <https://github.com/PyAbel/PyAbel/pull/155>`__. See also
+        ``three_point`` is the onion peeling algorithm as described by Dasch
+        (1992), reference below.
 
     ``rbasex`` *
         The pBasex method by
@@ -298,7 +298,7 @@ class Transform(object):
         “Two-dimensional charged particle image inversion using a polar basis
         function expansion”,
         `Rev. Sci. Instrum. 75, 4989–2996 (2004)
-        <http://dx.doi.org/10.1063/1.1807578>`_
+        <http://doi.org/10.1063/1.1807578>`__
         adapts the BASEX ("basis set expansion") method to the specific case of
         velocity-mapping images by using a basis of 2D functions in polar
         coordinates, such that the reconstructed radial distributions are
@@ -313,9 +313,9 @@ class Transform(object):
         dynamics of hydroxymethyl radical (CH\ :sub:`2`\ OH and
         CD\ :sub:`2`\ OH)”,
         Ph.D. dissertation, University of Southern California, 2012
-        (`ProQuest <https://search.proquest.com/docview/1289069738>`_,
+        (`ProQuest <https://search.proquest.com/docview/1289069738>`__,
         `USC <http://digitallibrary.usc.edu/cdm/ref/collection/p15799coll3/id/
-        112619>`_).
+        112619>`__).
 
     ``three_point`` *
         The "Three Point" Abel transform method exploits the observation that
@@ -328,7 +328,7 @@ class Transform(object):
         "One-dimensional tomography: a comparison of Abel, onion-peeling, and
         filtered backprojection methods",
         `Appl. Opt. 31, 1146–1152 (1992)
-        <https://doi.org/10.1364/AO.31.001146>`_.
+        <https://doi.org/10.1364/AO.31.001146>`__.
 
     ``two_point`` *
         Another Dasch method. Simple, and fast, but not as accurate as the

--- a/doc/circularize_image.rst
+++ b/doc/circularize_image.rst
@@ -29,7 +29,7 @@ J. R. Gascooke, S. T. Gibson, W. D. Lawrance,
 "A 'circularisation' method to repair deformations and determine the centre of
 velocity map images",
 `J. Chem. Phys. 147, 013924 (2017)
-<https://dx.doi.org/10.1063/1.4981024>`_.
+<https://dx.doi.org/10.1063/1.4981024>`__.
 
 
 Implementation

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyAbel'
-copyright = u'2016–2020, PyAbel team'
+copyright = u'2016–2021, PyAbel team'
 author = 'PyAbel team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/transform_methods/rbasex-coord.py
+++ b/doc/transform_methods/rbasex-coord.py
@@ -86,7 +86,7 @@ ax.plot(z_, x_, y_, **sa)
 ax.text(0, x_[anc] + lo / 3, y_[anc] + lo, '$\\theta$', **sl)
 
 
-plt.tight_layout(pad=0, rect=(-0.1, -0.2, 1.1, 1))
+plt.tight_layout(pad=0, rect=(-0.06, -0.1, 1.04, 1))
 
 #plt.savefig('rbasex-coord.svg')
 #plt.show()

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,0 +1,5 @@
+Most example scripts provided here must be run from this directory, since they
+need the "data" subdirectory with the example data files and/or the "bases"
+subdirectory for saving/loading the basis sets. If you wish to copy or run such
+scripts elsewhere, please make sure that these paths are available or modify
+them accordingly.


### PR DESCRIPTION
Addressing #321: a short README.txt file in the `examples` directory to clarify that the scripts should be run _there_.

And minor corrections to the v0.8.4 release information:
* Updating the copyright years.
* Correcting the release date (was 2020 instead of 2021) in the changelog.