### PR TITLE
Enabling OSX testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       python: 2.7
       env: TOXENV=py27, DEPS="numpy scipy cython"
     - os: osx
-      language: generic
+      python: 3.9
       env: TOXENV=py39, DEPS="numpy scipy cython"
     - os: windows
       python: 3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ jobs:
       python: 2.7
       env: TOXENV=py27, DEPS="numpy scipy cython"
     - os: osx
-      python: 3.9
+      language: generic
+      osx_image: xcode12.5
       env: TOXENV=py39, DEPS="numpy scipy cython"
     # - os: windows
     #   language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ jobs:
     - os: osx
       language: generic
       env: TOXENV=py39, DEPS="numpy scipy cython"
+    - os: windows
+      python: 3.9
+      env: TOXENV=py39, DEPS="numpy scipy cython"      
 install:
   - pip install --upgrade pip setuptools wheel
   - "pip install ${DEPS}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ jobs:
     - os: osx
       language: generic
       env: TOXENV=py39, DEPS="numpy scipy cython"
-    - os: windows
-      language: generic
-      env: TOXENV=py39, DEPS="numpy scipy cython"      
+    # - os: windows
+    #   language: generic
+    #   env: TOXENV=py39, DEPS="numpy scipy cython"    
 install:
   - pip install --upgrade pip setuptools wheel
   - "pip install ${DEPS}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ jobs:
       python: 2.7
       env: TOXENV=py27, DEPS="numpy scipy cython"
     - os: osx
-      python: 3.9
+      language: generic
       env: TOXENV=py39, DEPS="numpy scipy cython"
     - os: windows
-      python: 3.9
+      language: generic
       env: TOXENV=py39, DEPS="numpy scipy cython"      
 install:
   - pip install --upgrade pip setuptools wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       env: TOXENV=py27, DEPS="numpy scipy cython"
     - os: osx
       language: generic
-      osx_image: xcode12.5
+      osx_image: xcode10.1
       env: TOXENV=py39, DEPS="numpy scipy cython"
     # - os: windows
     #   language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       python: 2.7
       env: TOXENV=py27, DEPS="numpy scipy cython"
     - os: osx
-      language: generic
+      python: 3.9
       env: TOXENV=py39, DEPS="numpy scipy cython"
     # - os: windows
     #   language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: python
 sudo: false
-matrix:
+jobs:
   include:
-  - python: '3.9'
-    env: DEPS="numpy scipy cython"
-    sudo: true
-    dist: focal
-  - python: '3.8'
-    env: DEPS="numpy scipy cython"
-    sudo: true
-    dist: xenial
-  - python: '2.7'
-    env: DEPS="numpy scipy cython"
+    - os: linux
+      python: 3.9
+      env: TOXENV=py39, DEPS="numpy scipy cython"
+    - os: linux
+      python: 3.8
+      env: TOXENV=py38, DEPS="numpy scipy cython"
+    - os: linux
+      python: 2.7
+      env: TOXENV=py27, DEPS="numpy scipy cython"
+    - os: osx
+      language: generic
+      env: TOXENV=py39, DEPS="numpy scipy cython"
 install:
   - pip install --upgrade pip setuptools wheel
   - "pip install ${DEPS}"

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ if _cython_installed:  # if Cython is installed, we will try to build direct-C
     ext_modules = [
         Extension("abel.lib.direct",
                   [os.path.join("abel", "lib", "direct.pyx")],
-                  'include_dirs': [np.get_include()],
+                  include_dirs=[np.get_include()],
                   libraries=libraries, 
                   **compile_args)]
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ if _cython_installed:  # if Cython is installed, we will try to build direct-C
     ext_modules = [
         Extension("abel.lib.direct",
                   [os.path.join("abel", "lib", "direct.pyx")],
-                  libraries=libraries,
+                  'include_dirs': [np.get_include()],
+                  libraries=libraries, 
                   **compile_args)]
 
     setup_args = {'cmdclass': {'build_ext': TryBuildExt},


### PR DESCRIPTION
Following https://github.com/PyAbel/PyAbel/issues/323, we should enable testing on MacOS is possible. TravisCI seems to support this. 

I think that we just need to edit the `.travis.yml` file. This is my first attempt. Will probably take a few iterations. 