### PR TITLE
Repairs to basis_dir (amending #327)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Correct behavior of relative basis_dir in basex under Python 2 (PR #336).
+
 v0.8.5 (2022-01-21)
 -------------------
 

--- a/abel/basex.py
+++ b/abel/basex.py
@@ -322,6 +322,7 @@ def get_bs_cached(n, sigma=1.0, reg=0.0, correction=True, basis_dir='', dr=1.0,
                 mask = os.path.join(basis_dir,
                                     'basex_basis_*_{}.npy'.format(sigma))
                 for f in glob(mask):
+                    f = os.path.basename(f)
                     # extract basis image size (sigma was fixed above)
                     f_n = int(f.split('_')[-2])
                     # must be large enough and smaller than previous best


### PR DESCRIPTION
Some changes related to `basis_dir`, overlooked in the previous PR #327:
* The `dasch` unit tests were failing unless ran on a clean system (the disk-cache test tired to delete a temporary file using a wrong path; reported in #335). Now they avoid using disk caching unless absolutely necessary, and when needed, use the local `tests/data` subdirectory for these temporary files, like all other tests do, and also clean-up after themselves.
* There was a strange error in `basex` when using a relative path for `basis_dir` and running Python 2 (in this case `glob()` yields relative paths). I'm surprised how it was working and passing all tests...