### PR TITLE
Spherical polynomials and improved SampleImage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Unreleased
 ----------
 
 * Correct behavior of relative basis_dir in basex under Python 2 (PR #336).
+* Analytical Abel transform of axially symmetric piecewise polynomials in
+  spherical coordinates (PR #339).
+* Improvements in tools.analytical.SampleImage class: more consistent and
+  intuitive interface, accurate Abel transform for existing images, additional
+  sample images with exact Abel transform (PR #339).
 
 v0.8.5 (2022-01-21)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Using PyAbel can be simple. The following Python code imports the PyAbel package
 .. code-block:: python
 
     import abel
-    original     = abel.tools.analytical.SampleImage().image
+    original     = abel.tools.analytical.SampleImage().func
     forward_abel = abel.Transform(original, direction='forward', method='hansenlaw').transform
     inverse_abel = abel.Transform(forward_abel, direction='inverse', method='three_point').transform
 

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -236,8 +236,8 @@ def _linbasex_transform_with_basis(IM, Basis, proj_angles=[0, np.pi/2],
     #     QLz[1] = np.sum(IM, axis=0)
     # else:
     for i in range(proj):
-        Rot_IM = scipy.ndimage.interpolation.rotate(IM,
-                       proj_angles[i]*180/np.pi, axes=(1, 0), reshape=False)
+        Rot_IM = scipy.ndimage.rotate(IM, proj_angles[i]*180/np.pi,
+                                      axes=(1, 0), reshape=False)
         QLz[i, :] = np.sum(Rot_IM, axis=1)
 
     # arrange all projections for input into "lstsq"

--- a/abel/onion_bordas.py
+++ b/abel/onion_bordas.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import shift
 
 ################################################################################
 #

--- a/abel/tests/test_dasch_methods.py
+++ b/abel/tests/test_dasch_methods.py
@@ -37,7 +37,7 @@ def test_dasch_zeros():
 
 
 def test_dasch_deconvolution_array_sources():
-    im = abel.tools.analytical.SampleImage(101).image
+    im = abel.tools.analytical.SampleImage(101).func
     q = abel.tools.symmetry.get_image_quadrants(im)[0]
 
     # clean up any old deconvolution array files

--- a/abel/tests/test_hansenlaw.py
+++ b/abel/tests/test_hansenlaw.py
@@ -94,7 +94,7 @@ def test_hansenlaw_forward_dribinski_image():
     """
 
     # BASEX sample image
-    IM = abel.tools.analytical.SampleImage(n=1001, name="dribinski").image
+    IM = abel.tools.analytical.SampleImage(n=1001, name="dribinski").func
 
     # core transform(s) use top-right quadrant, Q0
     Q0, Q1, Q2, Q3 = abel.tools.symmetry.get_image_quadrants(IM)

--- a/abel/tests/test_linbasex.py
+++ b/abel/tests/test_linbasex.py
@@ -27,7 +27,7 @@ def test_linbasex_forward_dribinski_image():
     """
 
     # BASEX sample image
-    IM = abel.tools.analytical.SampleImage(n=1001, name="dribinski").image
+    IM = abel.tools.analytical.SampleImage(n=1001, name="dribinski").func
 
     # forward Abel transform
     fIM = abel.Transform(IM, method='hansenlaw', direction='forward')

--- a/abel/tests/test_tools_analytical.py
+++ b/abel/tests/test_tools_analytical.py
@@ -28,7 +28,7 @@ def test_sample_Dribinski():
     n = 501
     test1 = SampleImage(n=n, name='Dribinski', sigma=2)
     test2 = SampleImage(n=n // 2 + 1, name='Dribinski', sigma=1)  # halved
-    assert(test2.r_max == test1.r_max / 2)
+    assert test2.r_max == test1.r_max / 2
     assert_allclose(test2.func, test1.func[::2, ::2])
     assert_allclose(test2.abel, test1.abel[::2, ::2] / 2, atol=2e-6)
 
@@ -50,6 +50,19 @@ def test_sample_Gaussian():
                                              'verbose': False}).transform
         assert_allclose(recon, test.func, atol=tol,
                         err_msg='-> abel, {}'.format(kwargs))
+
+    # test even size
+    n = 10
+    r_max = 4.5  # (n - 1) / 2
+    sigma = 2
+    x = np.arange(n) - r_max
+    ref = np.exp(-(x**2 + x[:, None]**2) / sigma**2)
+
+    test = SampleImage(n=n, name='Gaussian', sigma=sigma)
+    assert test.r_max == r_max
+    assert_allclose(test.r, x)
+    assert_allclose(test.func, ref)
+    assert_allclose(test.abel, np.sqrt(np.pi) * sigma * ref)
 
 
 def test_sample_O2():

--- a/abel/tests/test_tools_analytical.py
+++ b/abel/tests/test_tools_analytical.py
@@ -33,6 +33,38 @@ def test_sample_Dribinski():
     assert_allclose(test2.abel, test1.abel[::2, ::2] / 2, atol=2e-6)
 
 
+def test_sample_Gaussian():
+    """
+    Test SampleImage 'Gaussian'.
+    """
+    # SampleImage options, recon tolerance
+    param = [(dict(), 4e-4),
+             (dict(n=501), 5e-4),
+             (dict(n=501, sigma=50), 3e-9)]
+
+    # test transform using Daun with cubic splines (the most accurate)
+    for kwargs, tol in param:
+        test = SampleImage(name='Gaussian', **kwargs)
+        recon = Transform(test.abel, method='daun', symmetry_axis=(0, 1),
+                          transform_options={'degree': 3,
+                                             'verbose': False}).transform
+        assert_allclose(recon, test.func, atol=tol,
+                        err_msg='-> abel, {}'.format(kwargs))
+
+
+def test_sample_O2():
+    """
+    Test SampleImage 'O2'.
+    """
+    # test transform with forward Daun with cubic splines (the most accurate)
+    test = SampleImage(n=1001, name='O2')  # ~high resolution
+    proj = Transform(test.func, method='daun', direction='forward',
+                     symmetry_axis=(0, 1),
+                     transform_options={'degree': 3,
+                                        'verbose': False}).transform
+    assert_allclose(proj, test.abel, atol=9e-4 * np.max(proj))
+
+
 def test_sample_Ominus():
     """
     Test SampleImage 'Ominus'.
@@ -44,14 +76,9 @@ def test_sample_Ominus():
              (dict(n=501, sigma=3), 0.14),
              (dict(temperature=100), 0.2)]
 
+    # test transform using Daun with cubic splines (the most accurate)
     for kwargs, tol in param:
         test = SampleImage(name='Ominus', **kwargs)
-        # test deprecated .image attribute
-        with catch_warnings():
-            simplefilter('ignore', category=DeprecationWarning)
-            assert_equal(test.image, test.func)
-
-        # test transform (Daun with cubic splines is the most accurate)
         recon = Transform(test.abel, method='daun', symmetry_axis=(0, 1),
                           transform_options={'degree': 3,
                                              'verbose': False}).transform
@@ -70,4 +97,6 @@ def test_sample_Ominus():
 
 if __name__ == "__main__":
     test_sample_Dribinski()
+    test_sample_Gaussian()
+    test_sample_O2()
     test_sample_Ominus()

--- a/abel/tests/test_tools_analytical.py
+++ b/abel/tests/test_tools_analytical.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+# to suppress deprecation warnings
+from warnings import catch_warnings, simplefilter
+
+from abel.tools.analytical import SampleImage, SampleImage_
+from abel import Transform
+
+
+def test_sample_Dribinski():
+    """
+    Test SampleImage 'Dribinski'.
+    """
+    opt = [dict(),
+           dict(n=501),
+           dict(sigma=3),
+           dict(n=501, sigma=3)]
+
+    for kwargs in opt:
+        # test against old implementation
+        ref = SampleImage_(name='dribinski', **kwargs).image
+        test = SampleImage(name='dribinski', **kwargs)
+        n2 = ref.shape[0] // 2           # old code has different cosθ at r = 0
+        ref[n2, n2] = test.func[n2, n2]  # so ignore central pixel
+        assert_allclose(test.func, ref, err_msg='-> func, {}'.format(kwargs))
+        # test deprecated attribute
+        with catch_warnings():
+            simplefilter('ignore', category=DeprecationWarning)
+            assert_equal(test.image, test.func)
+
+    # .abel is difficult to test reliably due to the huge dynamic range
+
+
+def test_sample_Ominus():
+    """
+    Test SampleImage 'Ominus'.
+    """
+    # SampleImage options, recon tolerance
+    param = [(dict(), 0.2),
+             (dict(n=501), 0.073),
+             (dict(sigma=3), 0.056),
+             (dict(n=501, sigma=3), 0.14),
+             (dict(temperature=100), 0.2)]
+
+    for kwargs, tol in param:
+        # test against old implementation
+        ref = SampleImage_(name='Ominus', **kwargs).image
+        test = SampleImage(name='Ominus', **kwargs)
+        assert_allclose(test.func, ref, atol=1e-15,
+                        err_msg='-> {}'.format(kwargs))
+        # test deprecated .image attribute
+        with catch_warnings():
+            simplefilter('ignore', category=DeprecationWarning)
+            assert_equal(test.image, test.func)
+
+        # test transform (Daun with cubic splines is the most accurate)
+        recon = Transform(test.abel, method='daun', symmetry_axis=(0, 1),
+                          transform_options={'degree': 3,
+                                             'verbose': False}).transform
+        assert_allclose(recon, test.func, atol=tol,
+                        err_msg='-> abel, {}'.format(kwargs))
+
+    # test transform tol
+    test = SampleImage(name='Ominus')
+    abel = test.abel.copy()  # default, ≲5e-3
+    abel4 = test.transform(1e-4)
+    abel5 = test.transform(1e-5)
+    ampl = np.max(abel5)
+    assert_allclose(abel, abel5, atol=3e-3 * ampl)
+    assert_allclose(abel4, abel5, atol=0.3e-4 * ampl)
+
+
+if __name__ == "__main__":
+    test_sample_Dribinski()
+    test_sample_Ominus()

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -8,7 +8,7 @@ import itertools
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import shift
 
 import abel
 from abel.tools.center import find_origin, center_image, set_center

--- a/abel/tests/test_tools_center.py
+++ b/abel/tests/test_tools_center.py
@@ -255,7 +255,7 @@ def test_center_image():
 
     # BASEX sample image, Gaussians at 10, 15, 20, 70,85, 100, 145, 150, 155
     # image width, height n = 361, origin = (180, 180)
-    IM = abel.tools.analytical.SampleImage(n=361, name="dribinski").image
+    IM = abel.tools.analytical.SampleImage(n=361, name="dribinski").func
 
     # artificially displace origin, now at (179, 182)
     IMx = shift(IM, (-1, 2))

--- a/abel/tests/test_tools_circularize.py
+++ b/abel/tests/test_tools_circularize.py
@@ -11,7 +11,7 @@ from abel.tools.circularize import circularize, circularize_image
 
 def test_circularize_image():
 
-    IM = abel.tools.analytical.SampleImage(n=511, name='Ominus', sigma=2).func
+    IM = abel.tools.analytical.SampleImage(n=511, name='Ominus').func
 
     # flower image distortion
     def flower_scaling(theta, freq=2, amp=0.1):

--- a/abel/tests/test_tools_circularize.py
+++ b/abel/tests/test_tools_circularize.py
@@ -11,7 +11,7 @@ from abel.tools.circularize import circularize, circularize_image
 
 def test_circularize_image():
 
-    IM = abel.tools.analytical.SampleImage(n=511, name='Ominus', sigma=2).image
+    IM = abel.tools.analytical.SampleImage(n=511, name='Ominus', sigma=2).func
 
     # flower image distortion
     def flower_scaling(theta, freq=2, amp=0.1):

--- a/abel/tests/test_tools_polynomial.py
+++ b/abel/tests/test_tools_polynomial.py
@@ -35,6 +35,69 @@ def test_polynomial_zeros():
     assert_allclose(P.abel, 0)
 
 
+def test_polynomial_copy():
+    """
+    Test copy creation.
+    """
+    n = 20
+    r = np.arange(n, dtype=float)
+    P0 = Polynomial(r, 0, n/2, [1, -1], 0, n/2)
+    P0c = P0.copy()
+
+    # should not change P0 and P0c
+    P1 = 2 * P0
+    assert_allclose(P0.func, P0c.func)
+    assert_allclose(P0.abel, P0c.abel)
+    assert_allclose(P1.func, (P0 * 2).func)
+    assert_allclose(P1.abel, (P0 * 2).abel)
+
+    # should change P0, but not P0c
+    P0 *= 2
+    assert_allclose(P0.func, P1.func)
+    assert_allclose(P0.abel, P1.abel)
+    assert_allclose(P0.func, (P0c * 2).func)
+    assert_allclose(P0.abel, (P0c * 2).abel)
+
+
+def test_ppolynomial_copy():
+    """
+    Test copy creation.
+    """
+    n = 20
+    r = np.arange(n, dtype=float)
+    P0 = PiecewisePolynomial(r, [(0, n/2, [0, 1], 0, n/2),
+                                 (n/2, n, [1, -1], n/2, n/2)])
+    assert(len(P0.p) == 2)
+    P0c = P0.copy()
+    assert(len(P0c.p) == len(P0.p))
+
+    # should not change P0 and P0c
+    P1 = 2 * P0
+    assert(len(P1.p) == len(P0.p))
+    assert_allclose(P0.func, P0c.func)
+    assert_allclose(P0.abel, P0c.abel)
+    assert_allclose(P1.func, (P0 * 2).func)
+    assert_allclose(P1.abel, (P0 * 2).abel)
+    for i in range(len(P0.p)):
+        assert_allclose(P0.p[i].func, P0c.p[i].func)
+        assert_allclose(P0.p[i].abel, P0c.p[i].abel)
+        assert_allclose(P1.p[i].func, (P0.p[i] * 2).func)
+        assert_allclose(P1.p[i].abel, (P0.p[i] * 2).abel)
+
+    # should change P0, but not P0c
+    P0 *= 2
+    assert(len(P0.p) == len(P0c.p))
+    assert_allclose(P0.func, P1.func)
+    assert_allclose(P0.abel, P1.abel)
+    assert_allclose(P0.func, (P0c * 2).func)
+    assert_allclose(P0.abel, (P0c * 2).abel)
+    for i in range(len(P0.p)):
+        assert_allclose(P0.p[i].func, P1.p[i].func)
+        assert_allclose(P0.p[i].abel, P1.p[i].abel)
+        assert_allclose(P0.p[i].func, (P0c.p[i] * 2).func)
+        assert_allclose(P0.p[i].abel, (P0c.p[i] * 2).abel)
+
+
 def test_polynomial_step():
     """
     Testing step function (and multiplication).
@@ -67,13 +130,11 @@ def test_polynomial_gaussian():
     sigma = 15
 
     # coefficients of Taylor series around r = 1
-    c = []
-    for k in range(50):
-        c.append(np.exp(-1.0) * hermite(k)(-1.0) / factorial(k))
+    c = [np.exp(-1.0) * hermite(k)(-1.0) / factorial(k) for k in range(50)]
 
     P = Polynomial(r, 0, r[-1] + 2, c, sigma, sigma, reduced=True)
-    # scaling and shifting by sigma should produce exp(-(r/σ)^2),
-    # its Abel transform is √π σ exp(-(r/σ)^2)
+    # scaling and shifting by sigma should produce exp(-(r/σ)²),
+    # its Abel transform is √π σ exp(-(r/σ)²)
 
     func = np.exp(-(r / sigma)**2)
     abel = np.sqrt(np.pi) * sigma * func
@@ -108,6 +169,8 @@ def test_polynomial_smoothstep():
 if __name__ == '__main__':
     test_polynomial_shape()
     test_polynomial_zeros()
+    test_polynomial_copy()
+    test_ppolynomial_copy()
     test_polynomial_step()
     test_polynomial_gaussian()
     test_polynomial_smoothstep()

--- a/abel/tests/test_tools_polynomial.py
+++ b/abel/tests/test_tools_polynomial.py
@@ -8,7 +8,8 @@ from scipy.special import hermite
 from math import factorial
 
 import abel
-from abel.tools.polynomial import Polynomial, PiecewisePolynomial
+from abel.tools.polynomial import Polynomial, PiecewisePolynomial, \
+    ApproxGaussian
 
 
 def test_polynomial_shape():
@@ -166,6 +167,33 @@ def test_polynomial_smoothstep():
     assert_allclose(P.func, recon, atol=2.0e-2)
 
 
+def test_approx_gaussian():
+    """
+    Test Gaussian approximation against exact Gaussian.
+    """
+    # reference Gaussian
+    def g(x):
+        return np.exp(-x**2 / 2)
+
+    # test tolerances
+    r = np.linspace(0, 5, 1000)
+    ref = g(r)
+    for tol in [5e-2, 1e-2, 1e-3, 1e-4, 1e-6]:
+        ag = ApproxGaussian(tol)
+        P = PiecewisePolynomial(r, ag.ranges)
+        assert_allclose(P.func, ref, atol=tol, err_msg='-> tol={}'.format(tol))
+
+    # test scaling
+    r = np.arange(100, dtype=float)
+    A = 2
+    r0 = 30
+    sigma = 20
+    ref = A * g((r - r0) / sigma)
+    ag = ApproxGaussian()
+    P = PiecewisePolynomial(r, ag.scaled(A, r0, sigma))
+    assert_allclose(P.func, ref, atol=A * 5e-3)
+
+
 if __name__ == '__main__':
     test_polynomial_shape()
     test_polynomial_zeros()
@@ -174,3 +202,4 @@ if __name__ == '__main__':
     test_polynomial_step()
     test_polynomial_gaussian()
     test_polynomial_smoothstep()
+    test_approx_gaussian()

--- a/abel/tests/test_tools_vmi.py
+++ b/abel/tests/test_tools_vmi.py
@@ -175,7 +175,7 @@ def test_radial_integration():
     Basic test of radial integration.
     """
     # test image (not projected)
-    IM = SampleImage(name='dribinski').image
+    IM = SampleImage(name='dribinski').func
 
     Beta, Amplitude, Rmidpt, _, _ = \
         vmi.radial_integration(IM, radial_ranges=([(65, 75), (80, 90), (95, 105)]))
@@ -192,7 +192,7 @@ def test_toPES():
     Basic test of toPES conversion.
     """
     # test image (not projected)
-    IM = SampleImage(name='Ominus').image
+    IM = SampleImage(name='Ominus').func
 
     eBE, PES = vmi.toPES(*vmi.angular_integration_3D(IM),
                          energy_cal_factor=1.2e-5,

--- a/abel/tests/test_tools_vmi.py
+++ b/abel/tests/test_tools_vmi.py
@@ -201,7 +201,7 @@ def test_toPES():
 
     assert_allclose(eBE[PES.argmax()], 11780, rtol=0.001,
                     err_msg='-> eBE @ max PES')
-    assert_allclose(PES.max(), 16570, rtol=0.001,
+    assert_allclose(PES.max(), 16620, rtol=0.001,
                     err_msg='-> max PES')
 
 

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -12,34 +12,40 @@ import scipy.interpolate
 
 
 class BaseAnalytical(object):
+    r"""
+    Base class for functions that have a known Abel transform
+    (see :class:`GaussianAnalytical` for a concrete example).
+    Every such class should expose the following public attributes:
+
+    Attributes
+    ----------
+    r : numpy array
+        vector of positions along the :math:`r` axis
+    func : numpy array
+        the values of the original function (same shape as :attr:`r` for 1D
+        functions, or same row size as :attr:`r` for 2D images)
+    abel : numpy array
+        the values of the Abel transform (same shape as :attr:`func`)
+    mask_valid : numpy array
+        mask (same shape as :attr:`func`) where the function is
+        well smoothed/well behaved (no known artefacts in the inverse
+        Abel reconstuction), typically excluding the origin, the domain
+        boundaries, and function discontinuities, that can be used for
+        unit testing.
+
+    Parameters
+    ----------
+    n : int
+        number of points along the :math:`r` axis
+        (saved to attribute :attr:`n`)
+    r_max: float
+        maximum :math:`r` value (saved to attribute :attr:`r_max`)
+    symmetric: boolean
+        if ``True``, the :math:`r` interval is [−\ **r_max**, **r_max**]
+        (and **n** should be odd),
+        otherwise, the :math:`r` interval is [0, **r_max**]
+    """
     def __init__(self, n, r_max, symmetric=True, **args):
-        """
-        This is the base class for functions that have a known Abel transform.
-        Every such class should expose the following public attributes:
-          - self.r: vector of positions along the r axis
-          - self.func: the values of the original function
-                        (same shape as self.r)
-          - self.abel: the values of the Abel transform (same shape as self.r)
-          - self.mask_valid: mask of the r interval where the function is
-            well smoothed/well behaved (no known artefacts in the inverse
-            Abel reconstuction), typically excluding the origin, the domain
-            boundaries, and function discontinuities, that can be used for
-            unit testing.
-
-        See GaussianAnalytical for a concrete example.
-
-        Parameters
-        -------a--
-        n : int
-            number of points along the r axis
-
-        r_max: float
-            maximum r interval
-
-        symmetric: boolean
-            if True, the r interval is [-r_max, r_max] (and n should be odd),
-            otherwise, the r interval is [0, r_max]
-        """
         self.n = n
         self.r_max = r_max
 

--- a/abel/tools/analytical.py
+++ b/abel/tools/analytical.py
@@ -421,7 +421,7 @@ class SampleImage(BaseAnalytical):
         ``'O2'``
             Synthetic image mimicking a velocity-map image of O\ :sup:`+` from
             multiphoton photodissociation/ionization
-            :math:`\ce{O2 ->[4h\nu] O + O+ + e^-}`
+            :math:`{\rm O}_2 \xrightarrow{4h\nu} {\rm O} + {\rm O}^+ + e^-`
             at :math:`44\,444~\text{cm}^{-1}` (225 nm)
 
             Multiple peaks with various intensities and anisotropies; see, for

--- a/abel/tools/circularize.py
+++ b/abel/tools/circularize.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 import numpy as np
-from scipy.ndimage.interpolation import map_coordinates
+from scipy.ndimage import map_coordinates
 from scipy.interpolate import UnivariateSpline, splrep, splev
 from scipy.optimize import leastsq
 

--- a/abel/tools/polar.py
+++ b/abel/tools/polar.py
@@ -6,8 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-from scipy.ndimage import map_coordinates
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import map_coordinates, shift
 from scipy.optimize import curve_fit, minimize
 
 

--- a/abel/tools/polynomial.py
+++ b/abel/tools/polynomial.py
@@ -2,7 +2,20 @@
 from __future__ import division
 
 import numpy as np
-from scipy.linalg import pascal, toeplitz
+from scipy.linalg import pascal, invpascal, toeplitz
+from scipy.special import legendre
+try:
+    from functools import cache
+except ImportError:  # no functools in Python 2
+    def cache(func):
+        res = {}
+
+        def decorated(*args):
+            if args not in res:
+                res[args] = func(*args)
+            return res[args]
+
+        return decorated
 
 __doc__ = """
 See :ref:`Polynomials` for details and examples.
@@ -270,6 +283,412 @@ class PiecewisePolynomial(BasePolynomial):
         for p in self.p:
             p *= num
         return self
+
+
+class SPolynomial(BasePolynomial):
+    r"""
+    Bivariate polynomial function :math:`\sum_{mn} c_{mn} r^m \cos^n\theta` in
+    spherical coordinates and its Abel transform.
+
+    Parameters
+    ----------
+    r, cos : numpy array
+        *r* and cos *θ* values at which the function is generated; *r* must be
+        non-negative. Arrays for generating a 2D image can be conveniently
+        prepared by the :func:`rcos` function. On the other hand, the radial
+        dependence alone (for a *single* cosine power) can be obtained by
+        supplying a 1D **r** array and a **cos** array filled with ones.
+    r_min, r_max : float
+        *r* domain: the function is defined as the polynomial on
+        [**r_min**, **r_max**] and zero outside it;
+        0 ≤ **r_min** < **r_max** ≲ **max r**
+        (**r_max** might exceed maximal **r**, but usually by < 1 pixel;
+        negative **r_min** or **r_max** are allowed for convenience but are
+        interpreted as 0)
+    c: 2D numpy array
+        polynomial coefficients for *r* and cos *θ* powers: ``c[m, n]`` is the
+        coefficient for the :math:`r^m \cos^n\theta` term. This array can be
+        conveniently constructed using :class:`Angular` tools.
+    r_0 : float, optional
+        *r* domain shift: the polynomial is defined in powers of
+        (*r* − **r_0**) instead of *r*
+    s : float, optional
+        *r* stretching factor (around **r_0**): the polynomial is defined in
+        powers of (*r* − **r_0**)/**s** instead of *r*
+    """
+    def __init__(self, r, cos, r_min, r_max, c, r_0=0.0, s=1.0):
+        if r.shape != cos.shape:
+            raise ValueError('Shapes of r and cos arrays must be equal.')
+
+        # trim negative r limits
+        if r_max <= 0:
+            # both func and abel must be zero everywhere
+            self.func = np.zeros_like(r)
+            self.abel = np.zeros_like(r)
+            return
+        if r_min < 0:
+            r_min = 0
+
+        c = np.array(c, dtype=float)  # convert / make copy
+        if np.ndim(c) != 2:
+            raise ValueError('Coefficients array c must be 2-dimensional.')
+        # highest cos power with non-zero coefficient
+        N = c.nonzero()[1].max(initial=-1)
+        if N < 0:  # all coefficients are zero
+            # so both func and abel are also zero everywhere
+            self.func = np.zeros_like(r)
+            self.abel = np.zeros_like(r)
+            return
+        # for each cos power: highest r power with non-zero coefficient
+        M = [a.nonzero()[0].max(initial=-1) for a in c.T]
+
+        if s != 1.0:
+            # apply stretch
+            S = np.cumprod([1.0] + [1.0 / s] * max(M))  # powers of 1/s
+            c *= np.array([S]).T
+        if r_0 != 0.0:
+            # apply shift
+            m = max(M)
+            P = pascal(1 + m, 'upper', False)  # binomial coefficients
+            rm = np.cumprod([1.0] + [-float(r_0)] * m)  # powers of -r_0
+            T = toeplitz([1.0] + [0.0] * m, rm)  # upper-diag. (-r_0)^{i - j}
+            c = (P * T).dot(c)
+
+        rfull, cosfull = r, cos  # (r and cos will be limited below)
+
+        # Generate the polynomial function
+        self.func = np.zeros_like(rfull)
+        # limit calculations to relevant domain (outside it func = 0)
+        dom = (r_min <= rfull) & (rfull < r_max)
+        r = rfull[dom]
+        cos = cosfull[dom]
+
+        # sum all non-zero terms using Horner's method
+        for n in range(N, -1, -1):
+            if n < N:
+                self.func[dom] *= cos
+            if M[n] < 0:
+                continue
+            p = np.full_like(r, c[M[n], n])
+            for m in range(M[n] - 1, -1, -1):
+                p *= r
+                if c[m, n]:
+                    p += c[m, n]
+            self.func[dom] += p
+
+        # Generate its Abel transform
+        self.abel = np.zeros_like(rfull)
+        # relevant domain (outside it abel = 0)
+        # (excluding r = 0 to avoid singularities, see below)
+        dom = (0 < rfull) & (rfull < r_max)
+        r = rfull[dom]
+        cos = cosfull[dom]
+        # values at lower and upper integration limits
+        rho = [np.maximum(r, r_min),
+               r_max]  # = max(r, r_max) within domain
+        z = [np.sqrt(rho[0]**2 - r**2),
+             np.sqrt(rho[1]**2 - r**2)]
+        f = [np.minimum(r / r_min, 1.0) if r_min else 1.0,
+             r / r_max]  # = min(r/r_max, 1) within domain
+
+        # antiderivatives (recursive and used several times, thus cached)
+        @cache
+        def F(k, lim):  # lim: 0 = lower limit, 1 = upper limit
+            if k < 0:
+                return (z[lim] * f[lim]**k - k * F(k + 2, lim)) / (1 - k)
+            if k == 0:
+                return z[lim]
+            if k == 1:
+                return r * np.log(z[lim] + rho[lim])
+            if k == 2:
+                return r * np.arccos(f[lim])
+            if k == 3:  # (using explicit expression for higher efficiency)
+                return z[lim] * f[lim]
+            # k > 3:  (in principle, k > 2)
+            k -= 2
+            return (z[lim] * f[lim]**k + (k - 1) * F(k, lim)) / k
+
+        # sum all non-zero terms using Horner's method
+        for n in range(N, -1, -1):
+            if n < N:
+                self.abel[dom] *= cos
+            if M[n] < 0:
+                continue
+            p = c[M[n], n] * 2 * (F(n - M[n], 1) - F(n - M[n], 0))
+            for m in range(M[n] - 1, -1, -1):
+                p *= r
+                if c[m, n]:
+                    p += c[m, n] * 2 * (F(n - m, 1) - F(n - m, 0))
+            self.abel[dom] += p
+        # value at r = 0 (excluded above), nonzero only for n = 0
+        dom = np.where(rfull == 0)
+        for m in range(M[0] + 1):
+            k = m + 1
+            self.abel[dom] += c[m, 0] * 2 * (r_max**k - r_min**k) / k
+
+        # help garbage collector to release cache memory
+        F = None
+
+
+class PiecewiseSPolynomial(BasePolynomial):
+    r"""
+    Piecewise bivariate polynomial function (sum of :class:`SPolynomial`\ s) in
+    spherical coordinates and its Abel transform.
+
+    Parameters
+    ----------
+    r, cos : numpy array
+        *r* and cos *θ* values at which the function is generated
+    ranges : iterable of unpackable
+        (list of tuples of) polynomial parameters for each piece::
+
+           [(r_min_1st, r_max_1st, c_1st),
+            (r_min_2nd, r_max_2nd, c_2nd),
+            ...
+            (r_min_nth, r_max_nth, c_nth)]
+
+        according to :class:`SPolynomial` conventions.
+        All ranges are independent (may overlap and have gaps, may define
+        polynomials of any degrees) and may include optional
+        :class:`SPolynomial` parameters (``r_0, s``).
+    """
+    def __init__(self, r, cos, ranges):
+        for rng in ranges:
+            p = SPolynomial(r, cos, *rng)
+            try:
+                self.func += p.func
+                self.abel += p.abel
+            except AttributeError:  # first range
+                self.func = p.func
+                self.abel = p.abel
+
+
+def rcos(rows=None, cols=None, shape=None, origin=None):
+    r"""
+    Create arrays with polar coordinates :math:`r` and :math:`\cos\theta`:
+    either from a pair of Cartesian arrays (**rows**, **cols**) with row and
+    column values for each point *or* for a uniform grid with given dimensions
+    and origin (**shape**, **origin**).
+
+    Parameters
+    ----------
+    rows, cols : numpy array
+        arrays with respectively row and column values for each point. Must
+        have identical shapes (the output arrays will have the same shape), but
+        might contain any values. For example, can be 2D arrays with integer
+        pixel coordinates, or with floating-point numbers for sampling at
+        subpixel points or on a distorted grid, or 1D arrays for sampling along
+        some curve.
+    shape : tuple of int
+        (rows, cols) -- create output arrays of given shape, with values
+        corresponding to a uniform pixel grid.
+    origin : tuple of float, optional
+        position of the origin (:math:`r = 0`) in the output array. By default,
+        the center of the array is used (center of the middle pixel for
+        odd-sized dimensions; even-sized dimensions will have a corresponding
+        half-pixel shift).
+
+    Returns
+    -------
+    r : numpy array
+        radii :math:`r = \sqrt{\text{row}^2 + \text{col}^2}` for each point
+    cos : numpy array
+        cosines of the polar angle :math:`\cos\theta = -\text{row}/r` for each
+        point (by convention, :math:`\cos\theta = 0` at :math:`r = 0`)
+    """
+    if rows is not None or cols is not None:  # at least one array given
+        # sanity checks:
+        if rows is None or cols is None or \
+           shape is not None or origin is not None:  # incompatible options
+            raise ValueError('Arguments must be either '
+                             'two arrays rows and cols or '
+                             'shape=<tuple> and optional origin=<tuple>.')
+        if rows.shape != cols.shape:
+            raise ValueError('Shapes of rows and cols arrays must be equal.')
+    else:
+        # create rows and cols arrays for given shape
+        rows, cols = np.mgrid[0.0:shape[0], 0.0:shape[1]]
+        # prepare origin
+        if origin is None:  # default = midpoint
+            row = (shape[0] - 1) / 2
+            col = (shape[1] - 1) / 2
+        else:
+            row, col = origin
+            # to absolute coordinates
+            if row < 0:
+                row += shape[0]
+            if col < 0:
+                col += shape[1]
+        # shift "0" to origin
+        rows -= row
+        cols -= col
+
+    # radius
+    r = np.sqrt(rows**2 + cols**2)
+    # cosine
+    cos = -np.divide(rows, r, where=r != 0, out=np.zeros_like(r))
+
+    return r, cos
+
+
+class Angular(object):
+    r"""
+    Class helping to define angular dependences for :class:`SPolynomial` and
+    :class:`PiecewiseSPolynomial`.
+
+    Supports arithmetic operations (addition, subtraction, multiplication of
+    objects; multiplication and division by numbers) and outer product with
+    radial coefficients (any list-like object). For example::
+
+        [3, 0, -1] * (Angular.cos(4) + Angular.sin(4) / 2)
+
+    represents :math:`(3 - r^2)\big(\cos^4\theta + (\sin^4\theta) / 2\big)`,
+    producing ::
+
+        [[ 1.5  0.  -3.  0.   4.5]
+         [ 0.   0.  -0.  0.   0. ]
+         [-0.5  0.   1.  0.  -1.5]]
+
+    which can be supplied as the coefficient matrix to :class:`SPolynomial`.
+    Likewise, a list of ranges for :class:`PiecewiseSPolynomial` can be
+    prepared as an outer product with a list of ``(r_min, r_max, coeffs)``
+    tuples (with optional other :class:`SPolynomial` parameters), where 1D
+    ``coeffs`` contain radial coefficients for a polynomial segment.
+
+    Parameters
+    ----------
+    c : float or iterable of float
+        list of coefficients: ``Angular([c₀, c₁, c₂, ...])`` means
+        :math:`c_0 \cos^0\theta + c_1 \cos^1\theta + c_2 \cos^2\theta + \dots`;
+        ``Angular(a)`` represents the isotropic distribution a⋅cos⁰ *θ*
+
+    Attributes
+    ----------
+    c : numpy array
+        coefficients for :math:`\cos^n\theta` powers, passed at instantiation
+        directly (see above) or converted from other representations by the
+        methods below.
+    """
+    def __init__(self, c):
+        """
+        Weighted sum of cosine powers.
+        """
+        self.c = np.ravel(c).astype(float)
+
+    @classmethod
+    def cos(cls, n):
+        r"""
+        Cosine power: ``Angular.cos(n)`` means :math:`\cos^n\theta`.
+        """
+        if not isinstance(n, int) or n < 0:
+            raise ValueError('Power must be positive integer.')
+        return cls([0] * n + [1])
+
+    @classmethod
+    def sin(cls, n):
+        r"""
+        Sine power: ``Angular.sin(n)`` means :math:`\sin^n\theta`
+        (*n* must be even).
+        """
+        return cls.cossin(0, n)
+
+    @classmethod
+    def cossin(cls, m, n):
+        r"""
+        Product of cosine and sine powers: ``Angular.cossin(m, n)`` means
+        :math:`\cos^m\theta \cdot \sin^n\theta` (*n* must be even).
+        """
+        if not isinstance(m, int) or m < 0:
+            raise ValueError('Cosine power must be positive integer.')
+        if not isinstance(n, int) or n < 0 or n % 2:
+            raise ValueError('Sine power must be even positive integer.')
+        c = np.zeros(1 + m + n)
+        # binomial coefficients of (1 - cos^2)^(n/2)
+        c[m::2] = invpascal(1 + n // 2, 'lower', False)[-1, ::-1]
+        return cls(c)
+
+    @classmethod
+    def legendre(cls, c):
+        r"""
+        Weighted sum of Legendre polynomials in cos *θ*:
+        ``Angular.legendre([c₀, c₁, c₂, ...])`` means
+        :math:`c_0 P_0(\cos\theta) + c_1 P_1(\cos\theta) + c_2 P_2(\cos\theta)
+        + \dots`
+
+        This method is intended to be called like ::
+
+            Angular.legendre([1, β₁, β₂, ...])
+
+        where :math:`\beta_i` are so-called anisotropy parameters. However, if
+        you really need a single polynomial :math:`P_n(\cos\theta)`, this can
+        be easily achieved by ::
+
+            Angular.legendre([0] * n + [1])
+
+        """
+        C = np.zeros_like(c, dtype=float)
+        for n, a in enumerate(c):
+            C[n::-2] += a * legendre(n).c[::2]
+            # (SciPy's legendre() has backwards order and produces noise in
+            #  coefficients that must be zero, so indexing takes care of this)
+        return cls(C)
+
+    # disable NumPy "ufunc" handling, which makes no sense here
+    # and interferes with the overloaded multiplication operator
+    __array_ufunc__ = None
+
+    def __add__(self, other):
+        """
+        Sum of two objects (might have different sizes).
+        """
+        a, b, = sorted([self.c, other.c], key=len)
+        c = b.copy()  # copy the longer array
+        c[:len(a)] += a  # add the shorter array to the relevant part
+        return Angular(c)
+
+    def __sub__(self, other):
+        """
+        Difference of two objects (might have different orders).
+        """
+        a, b, = sorted([self.c, other.c], key=len)
+        c = b.copy()  # copy the longer array
+        c[:len(a)] -= a  # subtract the shorter array from the relevant part
+        return Angular(c)
+
+    def __mul__(self, obj):
+        """
+        Multiplication by number or another angular dependence: return the
+        resulting angular dependence.
+
+        Outer product of radial and angular coefficients: return 2D array with
+        rows corresponding to powers of *r* and columns to powers of cos *θ*.
+        """
+        if isinstance(obj, Angular):  # by another angular dependence
+            return Angular(np.convolve(self.c, obj.c))
+        if np.isscalar(obj):  # by number
+            return Angular(obj * self.c)
+        try:  # piecewise ranges
+            ranges = []
+            for rng in obj:
+                r_min, r_max, c = rng[:3]
+                c = np.outer(np.ravel(c), self.c)
+                rng = (r_min, r_max, c) + rng[3:]
+                ranges.append(rng)
+            return ranges
+        except TypeError:  # otherwise -- by radial coefficients
+            return np.outer(np.ravel(obj), self.c)
+
+    __rmul__ = __mul__
+    __rmul__.__doc__ = __mul__.__doc__
+
+    def __truediv__(self, num):
+        """
+        Division by number.
+        """
+        return Angular(self.c / num)
+
+    def __repr__(self):
+        return str(self.c) + '.[cos^n]'
 
 
 class ApproxGaussian(object):

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -7,8 +7,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 from abel.tools.polar import reproject_image_into_polar
-from scipy.ndimage import map_coordinates, uniform_filter1d
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import map_coordinates, uniform_filter1d, shift
 from scipy.optimize import curve_fit
 from scipy.linalg import hankel, inv, pascal
 from scipy.special import legendre

--- a/doc/abel.rst
+++ b/doc/abel.rst
@@ -126,6 +126,7 @@ abel.tools.polynomial module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: cache
 
 abel.tools.transform_pairs module
 ----------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,7 +39,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
-# MOCK_MODULES = ['numpy', 'scipy', 'scipy.special', 'numpy.linalg', 'scipy.ndimage', 'scipy.ndimage.interpolation',
+# MOCK_MODULES = ['numpy', 'scipy', 'scipy.special', 'numpy.linalg', 'scipy.ndimage', 'scipy.ndimage',
 #         'scipy.linalg', 'scipy.integrate', 'scipy.optimize']
 #
 MOCK_MODULES = []

--- a/doc/tools/approx_gaussian.py
+++ b/doc/tools/approx_gaussian.py
@@ -1,0 +1,62 @@
+from __future__ import division, print_function
+import numpy as np
+from matplotlib import pyplot as plt
+import abel
+
+from abel.tools.polynomial import ApproxGaussian, PiecewisePolynomial
+
+r = np.arange(201)
+r0 = 100
+sigma = 20
+# actual Gaussian function
+gauss = np.exp(-((r - r0) / sigma)**2 / 2)
+# approximation with default tolerance (~0.5%)
+ranges = ApproxGaussian().scaled(1, r0, sigma)
+approx = PiecewisePolynomial(r, ranges)
+nodes = [rng[0] for rng in ranges] + [ranges[-1][1]]
+# much more accurate approximation as a reference
+ref = PiecewisePolynomial(r, ApproxGaussian(1e-5).scaled(1, r0, sigma))
+
+
+def plot(title, f, g, lim):
+    plt.figure(figsize=(6, 4), frameon=False, dpi=200)
+
+    plt.subplot(3, 1, (1, 2))
+    plt.title(title)
+    for R in nodes:
+        plt.axvline(R, lw=0.5, c='lightgray')
+    plt.axhline(lw=0.5, c='k')
+    plt.plot(r, g, label='Gaussian')
+    plt.plot(r, f, '--', label='approx.')
+    plt.autoscale(axis='x', tight=True)
+    plt.ylabel('Value')
+    plt.legend()
+
+    plt.subplot(3, 1, 3)
+    for R in nodes:
+        plt.axvline(R, lw=0.5, c='lightgray')
+    plt.axhline(lw=0.5, c='k')
+    plt.plot(r, f - g, c='brown')
+    plt.autoscale(axis='x', tight=True)
+    plt.xlabel('Radius, px')
+    plt.ylim(-lim, lim)
+    plt.ylabel('Difference')
+
+    plt.tight_layout(pad=0)
+    plt.show()
+
+
+if __name__ == '__main__':
+    M = ref.func.max()
+    D = (approx.func - gauss).max()
+    print('max func =', M)
+    print('max diff =', D)
+    print('rel diff =', D / M * 100, '%')
+    plot('func', approx.func, gauss, 0.005)
+
+    M = ref.abel.max()
+    D = (approx.abel - ref.abel).max()
+    print('max abel =', M)
+    print('max diff =', D)
+    print('rel diff =', D / M * 100, '%')
+    plot('abel', approx.abel, ref.abel, 0.35)

--- a/doc/transform_methods/comparison.rst
+++ b/doc/transform_methods/comparison.rst
@@ -82,7 +82,7 @@ Generating a sample image, performing a forward Abel transform, and completing a
 .. code-block:: python
 
     import abel
-    im0 = abel.tools.analytical.SampleImage().image
+    im0 = abel.tools.analytical.SampleImage().func
     im1 = abel.Transform(im0,
                          direction='forward',
                          method='hansenlaw').transform

--- a/doc/transform_methods/rbasex-regRMSE.py
+++ b/doc/transform_methods/rbasex-regRMSE.py
@@ -10,7 +10,7 @@ from abel.rbasex import rbasex_transform
 # test distribution
 rmax = 200
 scale = 10000
-source = SampleImage(n=2 * rmax - 1).image / scale
+source = SampleImage(n=2 * rmax - 1).func / scale
 Isrc, _ = Ibeta(source)
 Inorm = (Isrc**2).sum()
 

--- a/doc/transform_methods/rbasex-sim.py
+++ b/doc/transform_methods/rbasex-sim.py
@@ -17,7 +17,7 @@ def rescaleI(im):
     return np.sqrt(np.abs(im)) * np.sign(im)
 
 # test distribution
-source = SampleImage(n=2 * rmax - 1).image / scale
+source = SampleImage(n=2 * rmax - 1).func / scale
 Isrc, _ = Ibeta(source)
 Inorm = (Isrc**2).sum()
 

--- a/doc/transform_methods/rbasex_reg.py
+++ b/doc/transform_methods/rbasex_reg.py
@@ -21,7 +21,7 @@ def rescaleI(im):
 # calculate relative RMS error for given regularization parameters
 def plot(method, strength=None):
     # test distribution
-    source = SampleImage(n=2 * rmax - 1).image / scale
+    source = SampleImage(n=2 * rmax - 1).func / scale
     Isrc, _ = Ibeta(source)
     Inorm = (Isrc**2).sum()
 

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -335,7 +335,7 @@ class PyAbel:  # (tk.Tk):
         else:
             self.fn = self.fn.split(' ')[-1]
             self.IM = abel.tools.analytical.SampleImage(n=1001,
-                                                        name=self.fn).image
+                                                        name=self.fn).func
             if len(self.direction["values"]) > 1:
                 self.direction.current(1)  # raw images require 'forward' transform
             self.text.insert(tk.END, "\nsample image: (1) Abel transform 'forward',\n")

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -13,7 +13,7 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg,\
 from matplotlib.figure import Figure
 from matplotlib import gridspec
 
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import shift
 
 import os.path
 

--- a/examples/example_all_Ominus.py
+++ b/examples/example_all_Ominus.py
@@ -34,7 +34,7 @@ ntrans = np.size(transforms.keys())  # number of transforms
 
 
 # Image:   O2- VMI 1024x1024 pixel ------------------
-IM = abel.tools.analytical.SampleImage(n=501, name="Ominus").image
+IM = abel.tools.analytical.SampleImage(n=501, name="Ominus").func
 
 h, w = IM.shape
 

--- a/examples/example_all_dribinski.py
+++ b/examples/example_all_dribinski.py
@@ -37,7 +37,7 @@ transforms = collections.OrderedDict(sorted(transforms.items()))
 # number of transforms:
 ntrans = np.size(transforms.keys())
   
-IM = abel.tools.analytical.SampleImage(n=301, name="dribinski").image
+IM = abel.tools.analytical.SampleImage(n=301, name="dribinski").func
 
 h, w = IM.shape
 

--- a/examples/example_circularize_image.py
+++ b/examples/example_circularize_image.py
@@ -15,7 +15,7 @@ import scipy.interpolate
 
 
 # sample image -----------
-IM = abel.tools.analytical.SampleImage(n=511, name='Ominus', sigma=2).image
+IM = abel.tools.analytical.SampleImage(n=511, name='Ominus', sigma=2).func
 
 # forward transform == what is measured
 IMf = abel.Transform(IM, method='hansenlaw', direction="forward").transform

--- a/examples/example_dasch_methods.py
+++ b/examples/example_dasch_methods.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 
 # Dribinski sample image size 501x501
 n = 501
-IM = abel.tools.analytical.SampleImage(n).image
+IM = abel.tools.analytical.SampleImage(n).func
 
 # split into quadrants
 origQ = abel.tools.symmetry.get_image_quadrants(IM)

--- a/examples/example_daun_degree.py
+++ b/examples/example_daun_degree.py
@@ -6,7 +6,7 @@ from scipy.interpolate import make_interp_spline, splev
 import abel
 
 # one quadrant of Dribinski sample image, its size and intensity distribution
-im = abel.tools.analytical.SampleImage().image
+im = abel.tools.analytical.SampleImage().func
 q0 = abel.tools.symmetry.get_image_quadrants(im)[0]
 n = q0.shape[0]
 I0, _ = abel.tools.vmi.Ibeta(q0, origin='ll')

--- a/examples/example_daun_reg.py
+++ b/examples/example_daun_reg.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import abel
 
 # one quadrant of Dribinski sample image, its size and intensity distribution
-im = abel.tools.analytical.SampleImage().image
+im = abel.tools.analytical.SampleImage().func
 q0 = abel.tools.symmetry.get_image_quadrants(im)[0]
 n = q0.shape[0]
 I0, _ = abel.tools.vmi.Ibeta(q0, origin='ll')

--- a/examples/example_hansenlaw_basex.py
+++ b/examples/example_hansenlaw_basex.py
@@ -13,8 +13,7 @@ import matplotlib.pyplot as plt
 import abel
 
 import scipy.misc
-from scipy.ndimage.interpolation import shift
-from scipy.ndimage import zoom
+from scipy.ndimage import shift, zoom
 import bz2
 
 # This example demonstrates both Hansen and Law inverse Abel transform

--- a/examples/example_onion_bordas.py
+++ b/examples/example_onion_bordas.py
@@ -8,7 +8,7 @@ import abel
 import matplotlib.pyplot as plt
 
 # Dribinski sample image
-IM = abel.tools.analytical.SampleImage(n=501).image 
+IM = abel.tools.analytical.SampleImage(n=501).func
 
 # split into quadrants
 origQ = abel.tools.symmetry.get_image_quadrants(IM)

--- a/examples/example_rbasex_block.py
+++ b/examples/example_rbasex_block.py
@@ -31,7 +31,7 @@ vlim = 3.6  # intensity limits for images
 ylim = (-1.3, 2.7)  # limits for plots
 
 # create source distribution and its profiles for reference
-source = SampleImage(N).image / 100
+source = SampleImage(N).func / 100
 r_src, P0_src, P2_src = rharmonics(source)
 
 # simulate experimental image:

--- a/examples/example_simple.py
+++ b/examples/example_simple.py
@@ -1,5 +1,5 @@
 import abel
-original     = abel.tools.analytical.SampleImage().image
+original     = abel.tools.analytical.SampleImage().func
 forward_abel = abel.Transform(original, direction='forward', 
                               method='hansenlaw'  ).transform
 inverse_abel = abel.Transform(forward_abel, direction='inverse',

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import abel
 
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import shift
 
 import matplotlib; matplotlib.use('TkAgg')  # avoids crash on OSX
 

--- a/setup.py
+++ b/setup.py
@@ -101,9 +101,9 @@ setup(name='PyAbel',
       url='https://github.com/PyAbel/PyAbel',
       license='MIT',
       packages=find_packages(),
-      install_requires=["numpy >= 1.6",
-                        "setuptools >= 16.0",
-                        "scipy >= 0.14",
+      install_requires=["numpy >= 1.16",       # last for Python 2
+                        "setuptools >= 44.0",  # last for Python 2
+                        "scipy >= 1.2",        # oldest tested
                         "six >= 1.10.0"],
       package_data={'abel': ['tests/data/*']},
       long_description=long_description,


### PR DESCRIPTION
Here is an addition to `abel.tools.polynomial`, now implementing the analytical Abel transform of polynomials in spherical coordinates (bivariate polynomials in *r* and cos *θ*). A special case of them was already used for rBasex basis functions, but here they are generalized to arbitrary *r* powers and arbitrary radial limits.

This can be useful if somebody wants to model smooth VMI-like distributions, for example, by approximating them with cubic splines. But the main goal, also implemented here, was to provide high-accuracy Abel transforms of our sample images (`abel.tools.analytical.SampleImage`). The existing images are composed of Gaussian peaks, which don't have analytical Abel transforms, but they can be approximated by piecewise polynomials with any desired accuracy, and thus an arbitrarily accurate Abel transform can be obtained.

I've also added, for completeness, an isotropic Gaussian “blob” image (2D analog of `abel.tools.analytical.GaussianAnalytical`), which does have an analytical Abel transform. And an image resembling the “classic” calibration image for photofragment VMI (O<sup>+</sup> from O<sub>2</sub> 4-photon photodissociation/ionization), familiar from the Eppink–Parker work. It is composed of polynomials peaks, with maybe less experimentally looking shapes, but having an exact Abel transform.

Partial backward-incompatible changes to `SampleImage` (discussed in #337):
* `.image` attribute is deprecated in favor of `.func` (still works but prints a warning).
* `sigma` parameter is changed to absolute value in pixels instead of something strange. Default values reproduce the old behavior.
* Radial scaling is corrected: `.r_max` is now in pixels according to `n`, and all peaks radii scale proportionally to it (previously it was also doing something strange; see 8fb9b96e for old–new comparison, 39e39636 for the change). `'dribinski'` at its default `n=361` is not affected, `'Ominus'` at its intended `n=501` is also not affected but is slightly changed at other `n` values (I had to adjust the PES unit test slightly to account for this).
