### PR TITLE
Offline HTML (2nd iteration)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Introduction
 
 .. begin-github-only2
 
-.. image:: doc/overview.svg
+.. image:: https://raw.githubusercontent.com/PyAbel/PyAbel/master/doc/overview.svg
 
 .. end-github-only2
 
@@ -131,7 +131,7 @@ Output:
 
 .. begin-github-only3
 
-.. image:: https://user-images.githubusercontent.com/12854133/159737698-30ee69d1-e12d-438a-a9ea-7d7bb0c97f9a.svg
+.. image:: https://pyabel.readthedocs.io/en/latest/_images/readme_link-1.svg
     :alt: example Abel transform
 
 .. note:: Additional examples can be viewed on the `PyAbel examples <https://pyabel.readthedocs.io/en/latest/examples.html>`__ page and even more are found in the `PyAbel/examples <https://github.com/PyAbel/PyAbel/tree/master/examples>`__ directory.

--- a/doc/overview.svg
+++ b/doc/overview.svg
@@ -92,7 +92,7 @@ Convert to PDF:
     </radialGradient>
   </defs>
 
-  <g font-family='sans' font-size='16'>
+  <g font-family='DejaVu Sans, Verdana, sans-serif' font-size='16'>
     <!-- Object -->
     <g transform='translate(90 290)'>
       <!-- origin -->


### PR DESCRIPTION
OK, offline HTML at RTD seems to be working (although not without surprises, see https://github.com/readthedocs/readthedocs.org/issues/9068).

This is the second part of #348, replacing README image links with absolute URLs such that they can be used on PyPI (hopefully).