### PR TITLE
Linbasex changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - pip install --upgrade coveralls pytest pytest-cov
   - pip install . -v
 script:
-  - cd tmp/; pytest -v --cov=abel --pyargs abel
+  - cd /tmp; pytest -v --cov=abel --pyargs abel
 deploy:
   provider: pypi
   user: DanHickstein

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,14 +4,14 @@ Changelog
 Unreleased
 ----------
 
-* Offline HTML and PDF documentation is now available at Read the Docs and can
-  be built locally (PR #343, #348, #349).
 * Correct behavior of relative basis_dir in basex under Python 2 (PR #336).
-* Analytical Abel transform of axially symmetric piecewise polynomials in
-  spherical coordinates (PR #339).
 * Improvements in tools.analytical.SampleImage class: more consistent and
   intuitive interface, accurate Abel transform for existing images, additional
   sample images with exact Abel transform (PR #339, #352).
+* Analytical Abel transform of axially symmetric piecewise polynomials in
+  spherical coordinates (PR #339).
+* Offline HTML and PDF documentation is now available at Read the Docs and can
+  be built locally (PR #343, #348, #349).
 
 v0.8.5 (2022-01-21)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,18 @@ Unreleased
   spherical coordinates (PR #339).
 * Offline HTML and PDF documentation is now available at Read the Docs and can
   be built locally (PR #343, #348, #349).
+* **Important** changes in the **lin-BASEX** implementation (PR #357):
+
+  - It was erroneously producing even-sized images with offset origin. Now the
+    output is odd-sized and properly centered.
+  - Output images for radial_step > 1 were scaled down by the same factor. Now
+    they have the save size as the input.
+  - The sign of Beta for odd Legendre orders is reversed to be consistent with
+    PyAbel conventions (zero angle is upwards, towards smaller row indices).
+
+* Transform() with method='linbasex' now always stores the radial, Beta and
+  projection attributes, so there is no need to pass return_Beta=True
+  in transform_options (PR #357).
 
 v0.8.5 (2022-01-21)
 -------------------

--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -465,12 +465,10 @@ class AbelTiming(object):
         self._benchmark('bs', 'linbasex',
                         gen_basis)
 
-        # get the basis (is already cached)
-        basis = linbasex.get_bs_cached(self.h, basis_dir=None)
-        # benchmark the transform
+        # benchmark the transform (basis is already cached)
         self._benchmark('inverse', 'linbasex',
-                        linbasex._linbasex_transform_with_basis,
-                        self.whole_image, basis)
+                        linbasex.linbasex_transform_full,
+                        self.whole_image)
 
         # discard all caches
         linbasex.cache_cleanup()

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -256,7 +256,7 @@ def linbasex_transform_full(IM, basis_dir=None, proj_angles=[0, np.pi/2],
         if legendre_orders[i] % 2:
             Beta[i] = -Beta[i]
 
-    radial = np.linspace(clip, cols // 2, len(Beta[0]))
+    radial = np.linspace(clip * radial_step, cols // 2, len(Beta[0]))
 
     inv_IM, Beta_convol = _Slices(radial, Beta, legendre_orders,
                                   smoothing=smoothing)

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -251,6 +251,11 @@ def linbasex_transform_full(IM, basis_dir=None, proj_angles=[0, np.pi/2],
 
     Beta = _beta_solve(Basis, bb, pol, rcond=rcond)
 
+    # reverse the sign for odd orders (the basis is historically upside down)
+    for i in range(pol):
+        if legendre_orders[i] % 2:
+            Beta[i] = -Beta[i]
+
     radial = np.linspace(clip, cols // 2, len(Beta[0]))
 
     inv_IM, Beta_convol = _Slices(radial, Beta, legendre_orders,
@@ -309,8 +314,8 @@ def _Slices(radial, Beta, legendre_orders, smoothing=0):
     for i in range(pol):
         # interpolated β(r), where r=radius
         BB = np.interp(r, radial, Beta_convol[i, :], left=0)
-        # multiplied by angular part, row / r = cos θ
-        Slice += BB * eval_legendre(legendre_orders[i], row / r)
+        # multiplied by angular part, -row / r = cos θ
+        Slice += BB * eval_legendre(legendre_orders[i], -row / r)
 
     # normalize: division by sphere area
     Slice /= 4 * np.pi * r**2

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -256,7 +256,8 @@ def linbasex_transform_full(IM, basis_dir=None, proj_angles=[0, np.pi/2],
         if legendre_orders[i] % 2:
             Beta[i] = -Beta[i]
 
-    radial = np.linspace(clip * radial_step, cols // 2, len(Beta[0]))
+    R = cols // 2  # outer radius: cols = 2R + 1
+    radial = np.linspace(clip * radial_step + R % radial_step, R, len(Beta[0]))
 
     inv_IM, Beta_convol = _Slices(radial, Beta, legendre_orders,
                                   smoothing=smoothing)

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -9,7 +9,7 @@ from glob import glob
 import numpy as np
 import scipy
 from scipy.special import eval_legendre
-from scipy import ndimage
+from scipy.ndimage import rotate, gaussian_filter1d
 
 import abel
 from abel import _deprecated, _deprecate
@@ -242,8 +242,7 @@ def linbasex_transform_full(IM, basis_dir=None, proj_angles=[0, np.pi/2],
     #     QLz[1] = np.sum(IM, axis=0)
     # else:
     for i in range(proj):
-        Rot_IM = scipy.ndimage.rotate(IM, proj_angles[i]*180/np.pi,
-                                      axes=(1, 0), reshape=False)
+        Rot_IM = rotate(IM, proj_angles[i] * 180 / np.pi, reshape=False)
         QLz[i, :] = np.sum(Rot_IM, axis=1)
 
     # arrange all projections for input into "lstsq"
@@ -291,15 +290,10 @@ def _Slices(radial, Beta, legendre_orders, smoothing=0):
     pol = len(legendre_orders)
     NP = len(Beta[0])  # number of Newton spheres
 
-    Beta_convol = np.zeros((pol, NP))
-
-    # Convolve Beta's with smoothing function
+    # Convolve Beta with Gaussian smoothing function
     if smoothing > 0:
-        # smoothing function
-        Basis_s = np.fromfunction(lambda i: np.exp(-(i - (NP)/2)**2 /
-                                  (2*smoothing**2))/(smoothing*2.5), (NP,))
-        for i in range(pol):
-            Beta_convol[i] = np.convolve(Basis_s, Beta[i], mode='same')
+        Beta_convol = gaussian_filter1d(Beta, smoothing, axis=1,
+                                        mode='constant', cval=0)
     else:
         Beta_convol = Beta
 

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -296,7 +296,7 @@ def _Slices(Beta, legendre_orders, smoothing=0):
     index = range(NP)
 
     Beta_convol = np.zeros((pol, NP))
-    Slice_3D = np.zeros((pol, 2*NP, 2*NP))
+    Slice_3D = np.zeros((pol, 2 * NP - 1, 2 * NP - 1))
 
     # Convolve Beta's with smoothing function
     if smoothing > 0:
@@ -309,9 +309,11 @@ def _Slices(Beta, legendre_orders, smoothing=0):
         Beta_convol = Beta
 
     # Calculate ordered slices:
+    col = np.arange(-NP + 1, NP)
+    row = col[:, None]
     for i in range(pol):
-        Slice_3D[i] = np.fromfunction(lambda k, l: _SL(i, (k-NP), (l-NP),
-                       Beta_convol, index, legendre_orders), (2*NP, 2*NP))
+        Slice_3D[i] = _SL(i, row, col, Beta_convol, index, legendre_orders)
+
     # Sum ordered slices up
     Slice = np.sum(Slice_3D, axis=0)
 

--- a/abel/linbasex.py
+++ b/abel/linbasex.py
@@ -180,7 +180,7 @@ def linbasex_transform_full(IM, basis_dir=None, proj_angles=[0, np.pi/2],
         Note: **Beta[0, i]**, the total number of counts integrated over sphere
         i, becomes 1.
     direction : str
-        Abel transform direction. Only "inverse" is supported for this method.
+        Abel transform direction. Only "inverse" is implemented.
     verbose : bool
         print information about processing (normally used for debugging)
 

--- a/abel/tests/test_benchmarks.py
+++ b/abel/tests/test_benchmarks.py
@@ -2,21 +2,29 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
+from abel.benchmark import AbelTiming, DistributionsTiming, \
+                           absolute_ratio_benchmark, is_symmetric
 from abel.tools.analytical import StepAnalytical, GaussianAnalytical
-from abel.benchmark import absolute_ratio_benchmark, is_symmetric
 
 
-def assert_allclose_msg(x, y, message):
-    assert np.allclose(x, y), message
+def test_AbelTiming():
+    """ Sanity check that AbelTiming works for all methods
+    """
+    AbelTiming(n=11, t_min=0.01, verbose=False)
+
+
+def test_DistributionsTiming():
+    """ Sanity check that DistributionsTiming works for all methods
+    """
+    DistributionsTiming(n=11, t_min=0.01)
 
 
 def test_symmetry_function():
-    # Check the consistency of abel.benchmark.is_symmetric
-
+    """ Check the consistency of abel.benchmark.is_symmetric
+    """
     # checking all combination of odd and even images
     for n, m in [(11, 11),
                  (10, 10),
@@ -30,38 +38,40 @@ def test_symmetry_function():
 
         XX, YY = np.meshgrid(x, y)
 
-
         f1 = np.cos(XX)*np.cos(YY)
-        assert_equal( is_symmetric(f1, i_sym=True, j_sym=True), True,
-              'Checking f1 function for polar symmetry n={},m={}'.format(n,m))
+        assert_equal(is_symmetric(f1, i_sym=True, j_sym=True), True,
+                     'cos(x)*cos(y) polar symmetry: n={}, m={}'.format(n, m))
 
         f2 = np.cos(XX)*np.sin(YY)
-        assert_equal( is_symmetric(f2, i_sym=True, j_sym=False), True,
-              'Checking f2 function for i symmetry n={},m={}'.format(n,m))
+        assert_equal(is_symmetric(f2, i_sym=True, j_sym=False), True,
+                     'cos(x)*sin(y) i symmetry: n={}, m={}'.format(n, m))
 
         f3 = np.sin(XX)*np.cos(YY)
-        assert_equal( is_symmetric(f3, i_sym=False, j_sym=True), True,
-              'Checking f3 function for j symmetry n={},m={}'.format(n,m))
+        assert_equal(is_symmetric(f3, i_sym=False, j_sym=True), True,
+                     'sin(x)*cos(y) j symmetry: n={}, m={}'.format(n, m))
 
-        assert_equal( is_symmetric(f3, i_sym=True, j_sym=False), False,
-              'Checking that f3 function does not have i symmetry n={},m={}'.format(n,m))
+        assert_equal(is_symmetric(f3, i_sym=True, j_sym=False), False,
+                     'sin(x)*cos(y) must not have i symmetry: n={}, m={}'.
+                     format(n, m))
 
     for n in [10, 11]:
         x = np.linspace(-np.pi, np.pi, n)
         f1 = np.cos(x)
-        assert_equal( is_symmetric(f1, i_sym=True, j_sym=False), True,\
-              'Checking f1 function for symmetry in 1D n={},m={}'.format(n,m))
+        assert_equal(is_symmetric(f1, i_sym=True, j_sym=False), True,
+                     'cos(x) symmetry in 1D: n={}, m={}'.format(n, m))
 
 
 def test_absolute_ratio_benchmark():
-    # Mostly sanity to check that Analytical functions don't have typos
-    # or syntax errors
+    """ Mostly sanity check that Analytical functions don't have typos
+        or syntax errors
+    """
     n = 501
     r_max = 50
 
     for symmetric in [True, False]:
-        for Backend, options in [(StepAnalytical, dict(A0=10.0, r1=6.0,
-                                            r2=14.0, ratio_valid_step=1.0)),
+        for Backend, options in [(StepAnalytical,
+                                  dict(A0=10.0, r1=6.0, r2=14.0,
+                                       ratio_valid_step=1.0)),
                                  (GaussianAnalytical, dict(sigma=2))]:
 
             ref = Backend(n, r_max, symmetric=symmetric, **options)
@@ -69,8 +79,16 @@ def test_absolute_ratio_benchmark():
 
             backend_name = type(ref).__name__
 
+            assert_allclose(ratio.mean(), 1.0,
+                            err_msg='Sanity test, sym={}: {}: ratio == 1.0'.
+                                    format(symmetric, backend_name))
+            assert_allclose(ratio.std(), 0.0,
+                            err_msg='Sanity test, sym={}: {}: std == 0.0'.
+                                    format(symmetric, backend_name))
 
-            assert_allclose_msg(ratio.mean(), 1.0,
-                    "Sanity test, sym={}: {}: ratio == 1.0".format(symmetric, backend_name))
-            assert_allclose_msg(ratio.std(), 0.0,
-                    "Sanity test, sym={}: {}: std == 0.0".format(symmetric, backend_name))
+
+if __name__ == '__main__':
+    test_AbelTiming()
+    test_DistributionsTiming()
+    test_symmetry_function()
+    test_absolute_ratio_benchmark()

--- a/abel/tests/test_linbasex.py
+++ b/abel/tests/test_linbasex.py
@@ -58,6 +58,20 @@ def test_linbasex_shape_clip():
     assert proj.shape == (2, n)
 
 
+def test_linbasex_zeros():
+    """ Check that zero input produces zero output
+    """
+    R = 10
+    n = 2 * R + 1
+    x = np.zeros((n, n), dtype='float32')
+
+    recon, radial, beta, proj = linbasex_transform_full(x)
+
+    assert_allclose(recon, 0)
+    assert_allclose(beta, 0)
+    assert_allclose(proj, 0)
+
+
 def test_linbasex_forward_dribinski_image():
     """ Check hansenlaw forward/inverse transform
         using BASEX sample image, comparing speed distributions
@@ -100,9 +114,8 @@ def test_linbasex_odd_sign():
     recon, radial, beta, proj = linbasex_transform_full(im, legendre_orders=[0, 1])
 
     assert np.all(recon[0] > recon[-1]), 'incorrect output orientation'
-    # ignoring r = 0:
-    assert_array_less(0, beta[0][1:], err_msg='beta[0] must be positive')
-    assert_array_less(0, beta[1][1:], err_msg='beta[1] must be positive')
+    assert_array_less(-1e-9, beta[0][1:], err_msg='beta[0] must be positive')
+    assert_array_less(-1e-9, beta[1][1:], err_msg='beta[1] must be positive')
 
 
 def test_linbasex_mean_beta():
@@ -145,21 +158,22 @@ def test_linbasex_mean_beta():
         beta_mean = abel.linbasex.mean_beta(radial, beta, regions)
 
         param = 'radial_step={}, clip={}'.format(radial_step, clip)
-        assert_allclose(beta_mean[0], ref[0], atol=I_tol,
+        assert_allclose(beta_mean[0], ref[0], rtol=I_tol,
                         err_msg=param + ': I')
         assert_allclose(beta_mean[1:], ref[1:], atol=beta_tol,
                         err_msg=param + ': beta')
 
     # default parameters:
-    check(0.07, 0.03)
+    check(0.02, 0.03)
     # sparse, without center:
-    check(0.2, 0.03, radial_step=2, clip=10)
+    check(0.03, 0.03, radial_step=2, clip=10)
 
 
 if __name__ == "__main__":
     test_linbasex_shape()
     test_linbasex_shape_radial_step()
     test_linbasex_shape_clip()
+    test_linbasex_zeros()
     test_linbasex_forward_dribinski_image()
     test_linbasex_odd_sign()
     test_linbasex_mean_beta()

--- a/abel/tests/test_linbasex.py
+++ b/abel/tests/test_linbasex.py
@@ -35,8 +35,7 @@ def test_linbasex_forward_dribinski_image():
     # inverse Abel transform
     ifIM = abel.Transform(fIM.transform, method='linbasex',
                           transform_options=dict(legendre_orders=[0, 2], 
-                                            proj_angles=[0, np.pi/2],
-                                            return_Beta=True))
+                                            proj_angles=[0, np.pi/2]))
 
     # speed distribution
     orig_radial, orig_speed = abel.tools.vmi.angular_integration_3D(IM)

--- a/abel/tests/test_linbasex.py
+++ b/abel/tests/test_linbasex.py
@@ -3,22 +3,53 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os.path
-
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_less
 import abel
-from abel.benchmark import absolute_ratio_benchmark
+from abel.linbasex import linbasex_transform_full
 
-DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
 
 def test_linbasex_shape():
-    n = 21
+    R = 10
+    n = 2 * R + 1
     x = np.ones((n, n), dtype='float32')
 
-    recon = abel.linbasex.linbasex_transform_full(x, basis_dir=None)
+    recon, radial, beta, proj = linbasex_transform_full(x)
 
-    assert recon[0].shape == (n, n)
+    assert recon.shape == (n, n)
+    assert radial.shape == (R + 1,)
+    assert beta.shape == (2, R + 1)
+    assert proj.shape == (2, n)
+
+
+def test_linbasex_shape_radial_step():
+    R = 10
+    dR = 2
+    n = 2 * R + 1
+    x = np.ones((n, n), dtype='float32')
+
+    recon, radial, beta, proj = linbasex_transform_full(x, radial_step=dR)
+
+    assert recon.shape == (n, n)
+    assert radial.shape == (R // dR + 1,)
+    assert beta.shape == (2, R // dR + 1)
+    assert proj.shape == (2, n)
+
+
+def test_linbasex_shape_clip():
+    R = 10
+    clip = 3
+    n = 2 * R + 1
+    x = np.ones((n, n), dtype='float32')
+
+    recon, radial, beta, proj = linbasex_transform_full(x, clip=clip)
+
+    assert recon.shape == (n, n)
+    assert radial.shape == (R + 1 - clip,)
+    assert radial[0] == clip
+    assert radial[-1] == R
+    assert beta.shape == (2, R + 1 - clip)
+    assert proj.shape == (2, n)
 
 
 def test_linbasex_forward_dribinski_image():
@@ -34,12 +65,11 @@ def test_linbasex_forward_dribinski_image():
 
     # inverse Abel transform
     ifIM = abel.Transform(fIM.transform, method='linbasex',
-                          transform_options=dict(legendre_orders=[0, 2], 
-                                            proj_angles=[0, np.pi/2]))
+                          transform_options=dict(legendre_orders=[0, 2],
+                                                 proj_angles=[0, np.pi/2]))
 
     # speed distribution
     orig_radial, orig_speed = abel.tools.vmi.angular_integration_3D(IM)
-
 
     radial = ifIM.radial
     speed = ifIM.Beta[0]
@@ -47,9 +77,29 @@ def test_linbasex_forward_dribinski_image():
     orig_speed /= orig_speed[1:60].max()
     speed /= speed[1:60].max()
 
-    assert np.allclose(orig_speed[1:60], speed[1:60], rtol=0, atol=0.1)
+    assert_allclose(orig_speed[1:60], speed[1:60], rtol=0, atol=0.1)
+
+
+def test_linbasex_odd_sign():
+    R = 10
+    x = np.arange(-R, R + 1)
+    y = x[:, None]
+    r = np.sqrt(x**2 + y**2 + 0.1)  # + 0.1 to avoid division by zero
+    # gaussian(r) × (1 + cos θ):
+    im = np.exp(-(r / R * 2)**2) * (1 - y / r)
+    assert np.all(im[0] > im[-1])  # upper part of cos θ is positive
+
+    recon, radial, beta, proj = linbasex_transform_full(im, legendre_orders=[0, 1])
+
+    assert np.all(recon[0] > recon[-1]), 'incorrect output orientation'
+    # ignoring r = 0:
+    assert_array_less(0, beta[0][1:], err_msg='beta[0] must be positive')
+    assert_array_less(0, beta[1][1:], err_msg='beta[1] must be positive')
 
 
 if __name__ == "__main__":
     test_linbasex_shape()
+    test_linbasex_shape_radial_step()
+    test_linbasex_shape_clip()
     test_linbasex_forward_dribinski_image()
+    test_linbasex_odd_sign()

--- a/abel/tests/test_linbasex.py
+++ b/abel/tests/test_linbasex.py
@@ -18,7 +18,7 @@ def test_linbasex_shape():
 
     recon = abel.linbasex.linbasex_transform_full(x, basis_dir=None)
 
-    assert recon[0].shape == (n+1, n+1)   # NB shape+1
+    assert recon[0].shape == (n, n)
 
 
 def test_linbasex_forward_dribinski_image():

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -497,7 +497,7 @@ class Transform(object):
                           '\n    image size: {:d}x{:d}'.format(*self.IM.shape))
         t0 = time.time()
 
-        if self.method == "linbasex" and self._symmetry_axis is not None:
+        if self.method == "linbasex":
             self._abel_transform_image_full_linbasex(**transform_options)
         elif self.method == "rbasex":
             self._abel_transform_image_full_rbasex(**transform_options)
@@ -522,7 +522,6 @@ class Transform(object):
             "daun": daun.daun_transform,
             "direct": direct.direct_transform,
             "hansenlaw": hansenlaw.hansenlaw_transform,
-            "linbasex": linbasex.linbasex_transform,
             "onion_bordas": onion_bordas.onion_bordas_transform,
             "onion_peeling": dasch.onion_peeling_transform,
             "two_point": dasch.two_point_transform,
@@ -559,26 +558,6 @@ class Transform(object):
 
         if None in self._symmetry_axis:
             AQ3 = selected_transform(Q3)
-
-        if self.method == "linbasex" and\
-           "return_Beta" in transform_options.keys():
-            # linbasex evaluates speed and anisotropy parameters
-            # AQi == AIM, R, Beta, QLz
-            Beta0 = AQ0[2]
-            Beta1 = AQ1[2]
-            Beta2 = AQ2[2]
-            Beta3 = AQ3[2]
-            # rconstructed images of each quadrant
-            AQ0 = AQ0[0]
-            AQ1 = AQ1[0]
-            AQ2 = AQ2[0]
-            AQ3 = AQ3[0]
-            # speed
-            self.linbasex_angular_integration = self.Beta[0]\
-                 (Beta0[0] + Beta1[0] + Beta2[0] + Beta3[0])/4
-            # anisotropy
-            self.linbasex_anisotropy_parameter = self.Beta[1]\
-                 (Beta0[1] + Beta1[1] + Beta2[1] + Beta3[1])/4
 
         # reassemble image
         self.transform = tools.symmetry.put_image_quadrants(

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -412,9 +412,6 @@ class Transform(object):
         with ``method=rbasex``: the object from which various radial
         distributions can be retrieved
     """
-
-    _verbose = False
-
     def __init__(self, IM,
                  direction='inverse', method='three_point', origin='none',
                  symmetry_axis=None, use_quadrants=(True, True, True, True),
@@ -442,7 +439,8 @@ class Transform(object):
         self._use_quadrants = use_quadrants
         self._transform_options = transform_options
         self._recast_as_float64 = recast_as_float64
-        _verbose = verbose
+
+        self._verboseprint = print if verbose else lambda *a, **k: None
 
         # image processing
         self._verify_some_inputs()
@@ -455,8 +453,6 @@ class Transform(object):
                           **angular_integration_options)
 
     # end of class instance
-
-    _verboseprint = print if _verbose else lambda *a, **k: None
 
     def _verify_some_inputs(self):
         if self.IM.ndim == 1 or np.shape(self.IM)[0] <= 2:

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -390,26 +390,27 @@ class Transform(object):
     direction : str
         transform direction, as specified by the input option.
 
-    Beta : numpy 2D array
-        with ``method=linbasex, transform_options=dict(return_Beta=True)``:
-        Beta array coefficients of Newton-sphere spherical harmonics
-
-            Beta[0] - the radial intensity variation
-
-            Beta[1] - the anisotropy parameter variation
-
-            ...Beta[n] - higher-order terms up to ``legedre_orders=[0, ..., n]``
-
     radial : numpy 1D array
-        with ``method=linbasex, transform_options=dict(return_Beta=True)``:
-        radial grid for Beta array
+        with ``method='linbasex'``:
+        radial grid for **Beta** array
+
+    Beta : numpy 2D array
+        with ``method='linbasex'``:
+        coefficients of Newton-sphere spherical harmonics
+
+            **Beta[0]** — the radial intensity variation
+
+            **Beta[1]** — the anisotropy parameter variation
+
+            ... **Beta[n]** — higher-order terms up to **legedre_orders** =
+            [0, ..., n]
 
     projection : numpy 2D array
-        with ``method=linbasex, transform_options=dict(return_Beta=True)``:
+        with ``method='linbasex'``:
         radial projection profiles at angles **proj_angles**
 
     distr : Distributions.Results object
-        with ``method=rbasex``: the object from which various radial
+        with ``method='rbasex'``: the object from which various radial
         distributions can be retrieved
     """
     def __init__(self, IM,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,8 @@ install:
   - activate abel-env
   - pip install coverage pytest pytest-cov
   - dir 
-  - "cd C:\\projects\\PyAbel"
   - pip install . -v
 
 test_script:
-  - "cd C:\\projects\\PyAbel"
+  - cd "%TMP%"
   - pytest -v --cov=abel --pyargs abel

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -291,10 +291,13 @@ latex_elements = {
         \DeclareUnicodeCharacter{2264}{\ensuremath{\le}} % ≤
         \DeclareUnicodeCharacter{2265}{\ensuremath{\ge}} % ≥
         \DeclareUnicodeCharacter{226A}{\ensuremath{\ll}} % ≪
+        \DeclareUnicodeCharacter{226B}{\ensuremath{\gg}} % ≫
         \DeclareUnicodeCharacter{2272}{\ensuremath{\lesssim}} % ≲
         \DeclareUnicodeCharacter{2273}{\ensuremath{\gtrsim}} % ≳
         \DeclareUnicodeCharacter{22C5}{\ensuremath{\cdot}} % ⋅
         \DeclareUnicodeCharacter{27C2}{\ensuremath{\perp}} % ⟂
+        \DeclareUnicodeCharacter{2A7D}{\ensuremath{\leqslant}} % ⩽
+        \DeclareUnicodeCharacter{2A7E}{\ensuremath{\geqslant}} % ⩾
         % allow line break after underscore (some code doesn't fit otherwise)
         \renewcommand\_{\textunderscore\allowbreak}
         % table styling:

--- a/doc/transform_methods/comparison/fig_experiment/experiment.py
+++ b/doc/transform_methods/comparison/fig_experiment/experiment.py
@@ -54,9 +54,6 @@ for num, (ax, (label, transFunc, color), letter) in enumerate(zip(axs.ravel(),
     else:
         trans = transFunc(Q0, direction="inverse", **targs)
 
-    if label == 'linbasex':  # bugfix smoothing=0 transform offset by 1 pixel
-        trans[:, 1:] = trans[:, :-1]
-
     r, inten = abel.tools.vmi.angular_integration_3D(trans[::-1],
                                                      origin=(0, 0),
                                                      dr=0.1)

--- a/examples/example_GUI.py
+++ b/examples/example_GUI.py
@@ -404,8 +404,7 @@ class PyAbel:  # (tk.Tk):
             try:
                 if self.method == 'linbasex':
                     self.AIM = abel.Transform(
-                        self.IM, method=self.method, direction=self.fi,
-                        transform_options=dict(return_Beta=True))
+                        self.IM, method=self.method, direction=self.fi)
                 elif self.method == 'daun(nonneg)':
                     self.AIM = abel.Transform(
                         self.IM, method='daun', direction=self.fi,

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -39,8 +39,9 @@ ntrans = len(transforms)  # number of transforms
 imagefile = bz2.BZ2File('data/O2-ANU1024.txt.bz2')
 IM = np.loadtxt(imagefile)
 
-# recenter the image to mid-pixel (odd image width)
-IModd = abel.tools.center.center_image(IM, method="slice", odd_size=True)
+# recenter the image to mid-pixel (odd image width, square shape)
+IModd = abel.tools.center.center_image(IM, method="convolution",
+                                       odd_size=True, square=True)
 
 h, w = IModd.shape
 print("centered image 'data/O2-ANU2048.txt' shape = {:d}x{:d}".format(h, w))

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -53,7 +53,7 @@ Q0 = Q[0]
 Q0fresh = Q0.copy()    # keep clean copy
 print("quadrant shape {}".format(Q0.shape))
 
-# Intensity mask used for intensity normalization
+# Intensity mask used for intensity scale
 #   quadrant image region of bright pixels
 mask = np.zeros(Q0.shape, dtype=bool)
 mask[500:512, 358:365] = True
@@ -61,7 +61,9 @@ mask[500:512, 358:365] = True
 # process Q0 quadrant using each method --------------------
 
 iabelQ = []  # keep inverse Abel transformed image
+vmax = 0  # intensity scale
 sp = []  # speed distributions
+ymax = 0  # normalization
 meth = []  # methods
 
 for q, method in enumerate(sorted(transforms.keys())):
@@ -72,16 +74,16 @@ for q, method in enumerate(sorted(transforms.keys())):
     t0 = time()
 
     # inverse Abel transform using 'method'
-    IAQ0 = transforms[method](Q0, direction="inverse", dr=0.1)
+    IAQ0 = transforms[method](Q0, direction="inverse")
     print("                    {:.1f} s".format(time()-t0))
 
     # polar projection and speed profile
     radial, speed = abel.tools.vmi.angular_integration_3D(IAQ0, origin=(-1, 0),
                                                           dr=0.1)
 
-    # normalize image intensity and speed distribution
-    IAQ0 /= IAQ0[mask].max()
-    speed /= speed[radial > 50].max()
+    # update normalization
+    vmax = max(vmax, IAQ0[mask].max())
+    ymax = max(ymax, speed[radial > 50].max())
 
     # keep data for plots
     iabelQ.append(IAQ0)
@@ -91,15 +93,16 @@ for q, method in enumerate(sorted(transforms.keys())):
 # reassemble image, each quadrant a different method
 
 # plot inverse Abel transformed image slices, and respective speed distributions
+plt.figure(figsize=(12, 6))
 ax0 = plt.subplot2grid((1, 2), (0, 0))
 ax1 = plt.subplot2grid((1, 2), (0, 1))
 
 def ann_plt(quad, subquad, txt):
     # -ve because numpy coords from top
-    annot_angle = -(30+30*subquad+quad*90)*np.pi/180
+    annot_angle = -(22.5+45*subquad+quad*90)*np.pi/180
     annot_coord = (h/2+(h*0.8)*np.cos(annot_angle)/2,
                    w/2+(w*0.8)*np.sin(annot_angle)/2)
-    ax0.annotate(txt, annot_coord, color="yellow", ha='center')
+    ax0.annotate(txt, annot_coord, color="white", ha='center')
 
 # for < 4 images pad using a blank quadrant
 r, c = Q0.shape
@@ -110,12 +113,12 @@ iq = 0
 for q in range(4):
     Q[q] = iabelQ[iq].copy()
     ann_plt(q, 0, meth[iq])
-    ax1.plot(*(sp[iq]), label=meth[iq], alpha=0.5)
+    ax1.plot(sp[iq][0], sp[iq][1] / ymax, label=meth[iq], alpha=0.5)
     iq += 1
     if iq < len(transforms):
         (Q[q][::-1])[indx] = (iabelQ[iq][::-1])[indx]
         ann_plt(q, 1, meth[iq])
-        ax1.plot(*(sp[iq]), label=meth[iq], alpha=0.5)
+        ax1.plot(sp[iq][0], sp[iq][1] / ymax, label=meth[iq], alpha=0.5)
     iq += 1
 
 # reassemble image from transformed (part-)quadrants
@@ -124,10 +127,10 @@ im = abel.tools.symmetry.put_image_quadrants((Q[0], Q[1], Q[2], Q[3]),
 
 ax0.axis('off')
 ax0.set_title("inverse Abel transforms")
-ax0.imshow(im, vmin=0, vmax=0.8)
+ax0.imshow(im, vmin=0, vmax=0.8*vmax, interpolation='nearest')
 
 ax1.set_title("speed distribution")
-ax1.axis(ymin=-0.05, ymax=1.1, xmin=50, xmax=450)
+ax1.axis(xmin=50, xmax=450)
 ax1.legend(loc=0, labelspacing=0.1, fontsize=10, frameon=False)
 plt.tight_layout()
 

--- a/examples/example_all_O2.py
+++ b/examples/example_all_O2.py
@@ -98,7 +98,7 @@ def ann_plt(quad, subquad, txt):
     annot_angle = -(30+30*subquad+quad*90)*np.pi/180
     annot_coord = (h/2+(h*0.8)*np.cos(annot_angle)/2,
                    w/2+(w*0.8)*np.sin(annot_angle)/2)
-    ax0.annotate(txt, annot_coord, color="yellow", horizontalalignment='left')
+    ax0.annotate(txt, annot_coord, color="yellow", ha='center')
 
 # for < 4 images pad using a blank quadrant
 r, c = Q0.shape
@@ -112,7 +112,7 @@ for q in range(4):
     ax1.plot(*(sp[iq]), label=meth[iq], alpha=0.5)
     iq += 1
     if iq < len(transforms):
-        Q[q][indx] = np.triu(iabelQ[iq])[indx]
+        (Q[q][::-1])[indx] = (iabelQ[iq][::-1])[indx]
         ann_plt(q, 1, meth[iq])
         ax1.plot(*(sp[iq]), label=meth[iq], alpha=0.5)
     iq += 1

--- a/examples/example_anisotropy_parameter.py
+++ b/examples/example_anisotropy_parameter.py
@@ -30,9 +30,9 @@ clip = 0  # clip first vectors (smallest Newton spheres) to avoid singularities
 LIM = abel.Transform(IM, method='linbasex', origin='slice',
                      center_options=dict(square=True),
                      transform_options=dict(
-                         basis_dir=None, proj_angles=proj_angles,
+                         proj_angles=proj_angles,
                          radial_step=radial_step, smoothing=smoothing,
-                         threshold=threshold, clip=clip, return_Beta=True,
+                         threshold=threshold, clip=clip,
                          verbose=True))
 
 

--- a/examples/example_anisotropy_parameter.py
+++ b/examples/example_anisotropy_parameter.py
@@ -19,8 +19,7 @@ IM = np.loadtxt(imagefile)
 # use scipy.misc.imread(filename) to load image formats (.png, .jpg, etc)
 
 # === linbasex transform ===================================
-legendre_orders = [0, 2, 4]  # Legendre polynomial orders
-proj_angles = range(0, 180, 10)  # projection angles in 10 degree steps
+proj_angles = np.arange(0, 180, 10)/180*np.pi  # projection angles in 10° steps
 radial_step = 1  # pixel grid
 smoothing = 0.9  # smoothing 1/e-width for Gaussian convolution smoothing
 threshold = 0.2  # threshold for normalization of higher order Newton spheres

--- a/examples/example_linbasex.py
+++ b/examples/example_linbasex.py
@@ -25,7 +25,8 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 # for the online readthedocs.org
 
 # Image center should be mid-pixel and the image square,
-# `center=convolution` takes care of this
+# `origin="convolution"` takes care of this
+IM = abel.tools.center.center_image(IM, origin="convolution", square=True)
 
 un = [0, 2]  # spherical harmonic orders
 proj_angles = np.arange(0, 2*np.pi, np.pi/20)  # projection angles
@@ -37,8 +38,7 @@ radial_step = 1
 clip = 0
 
 # linbasex inverse Abel transform
-LIM = abel.Transform(IM, method="linbasex", origin="convolution",
-                     center_options=dict(square=True),
+LIM = abel.Transform(IM, method="linbasex",
                      transform_options=dict(basis_dir=None, return_Beta=True,
                                             legendre_orders=un,
                                             proj_angles=proj_angles,

--- a/examples/example_linbasex.py
+++ b/examples/example_linbasex.py
@@ -39,8 +39,7 @@ clip = 0
 
 # linbasex inverse Abel transform
 LIM = abel.Transform(IM, method="linbasex",
-                     transform_options=dict(basis_dir=None, return_Beta=True,
-                                            legendre_orders=un,
+                     transform_options=dict(legendre_orders=un,
                                             proj_angles=proj_angles,
                                             smoothing=smoothing,
                                             radial_step=radial_step, clip=clip,

--- a/examples/example_linbasex_hansenlaw.py
+++ b/examples/example_linbasex_hansenlaw.py
@@ -17,10 +17,9 @@ clip = 0  # clip first vectors (smallest Newton spheres) to avoid singularities
 LIM = abel.Transform(IM, method='linbasex', origin='convolution',
                      center_options=dict(square=True),
                      transform_options=dict(
-                         basis_dir=None, proj_angles=proj_angles,
+                         proj_angles=proj_angles,
                          radial_step=radial_step, smoothing=smoothing,
-                         threshold=threshold, clip=clip, return_Beta=True,
-                         verbose=True))
+                         threshold=threshold, clip=clip, verbose=True))
 
 # hansenlaw method - speed and anisotropy parameters evaluated by integration
 HIM = abel.Transform(IM, method="hansenlaw", origin='convolution',

--- a/examples/example_simple_GUI.py
+++ b/examples/example_simple_GUI.py
@@ -108,13 +108,8 @@ def _transform():
     canvas.draw()
 
     # inverse Abel transform of whole image
-    if method == 'linbasex':
-        AIM = abel.Transform(IM, method=method, direction="inverse",
-                             symmetry_axis=None,
-                             transform_options=dict(return_Beta=True))
-    else:
-        AIM = abel.Transform(IM, method=method, direction="inverse",
-                             symmetry_axis=None)
+    AIM = abel.Transform(IM, method=method, direction="inverse",
+                         symmetry_axis=None)
 
     f.clf()
     a = f.add_subplot(111)


### PR DESCRIPTION
These are the changes related to `linbasex` as discussed in #356, plus some other minor corrections (repair of `verbose` in `Transform()` and some corrections to the examples).

One thing that I'm not sure about is the docstring for `linbasex_transform()`. Previously it was shared with `linbasex_transform_full()` (see `_linbasex_parameter_docstring`), but there are in fact too many important differences for such mechanical treatment. Thus for `linbasex_transform()` I've simply documented its unique parameters and referred to the main function `linbasex_transform_full()` for the rest. But maybe every parameter must be documented for completeness? Or maybe it would be easier/better to replace them all with `**kwargs` and say that additional arguments are passed to `linbasex_transform_full()`, like we do in some other cases?