### PR TITLE
Testing: Python 3.10 and transfrom pairs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 jobs:
   include:
     - os: linux
+      dist: jammy
+      python: 3.10
+      env: DEPS="numpy scipy cython"
+    - os: linux
       python: 3.9
       env: TOXENV=py39, DEPS="numpy scipy cython"
     - os: linux

--- a/abel/tests/test_tools_transform_pairs.py
+++ b/abel/tests/test_tools_transform_pairs.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from numpy.testing import assert_allclose
+
+from abel.tools.analytical import TransformPair
+from abel.daun import daun_transform
+
+
+def test_transform_pairs():
+    """
+    Test analytical Abel-transform pairs.
+    """
+    n = 101  # dr = 0.01
+
+    for i in range(1, 8):
+        pair = TransformPair(n, profile=i)
+        proj = daun_transform(pair.func, degree=3, direction='forward',
+                              dr=pair.dr, verbose=False)
+
+        clip = None
+        tol = 3e-6
+        if i == 4:  # has small discontinuity
+            tol = 3e-4
+        elif i == 5:  # harsh
+            tol = 0.05
+            clip = -2
+
+        assert_allclose(pair.abel[:clip], proj[:clip], atol=tol,
+                        err_msg='-> ' + pair.label)
+
+
+if __name__ == "__main__":
+    test_transform_pairs()

--- a/abel/tools/math.py
+++ b/abel/tools/math.py
@@ -3,6 +3,8 @@ from scipy.linalg import circulant
 from scipy.optimize import curve_fit, brentq
 from scipy.interpolate import interp1d
 
+from abel import _deprecate
+
 
 def gradient(f, x=None, dx=1, axis=-1):
     """
@@ -89,7 +91,7 @@ def gaussian(x, a, mu, sigma, c):
     return a * np.exp(-((x - mu) ** 2) / 2 / sigma ** 2) + c
 
 
-def guss_gaussian(x):
+def guess_gaussian(x):
     """
     Find a set of better starting parameters for Gaussian function fitting
 
@@ -113,11 +115,11 @@ def guss_gaussian(x):
 
     try:
         sigma_l_guess = brentq(_, 0, mu_guess)
-    except:
+    except ValueError:
         sigma_l_guess = len(x) / 4
     try:
         sigma_r_guess = brentq(_, mu_guess, len(x) - 1)
-    except:
+    except ValueError:
         sigma_r_guess = 3 * len(x) / 4
     return a_guess, mu_guess, (sigma_r_guess -
                                sigma_l_guess) / 2.35482, c_guess
@@ -137,5 +139,12 @@ def fit_gaussian(x):
     out : tuple of float
         (a, mu, sigma, c)
     """
-    p, q = curve_fit(gaussian, list(range(x.size)), x, p0=guss_gaussian(x))
-    return p
+    res = curve_fit(gaussian, np.arange(x.size), x, p0=guess_gaussian(x))
+    return res[0]  # extract optimal values
+
+
+def guss_gaussian(x):
+    """Deprecated function. Use :func:`guess_gaussian` instead."""
+    _deprecate('abel.tools.math.guss_gaussian() is renamed to '
+               '...guess_gaussian(), please update your code.')
+    return guess_gaussian(x)

--- a/abel/tools/transform_pairs.py
+++ b/abel/tools/transform_pairs.py
@@ -271,6 +271,8 @@ def profile4(r):
     <https://doi.org/10.1016/S0584-8547(02)00087-3>`_, Eq. (10).
 
     Note:
+        This profile has a small discontinuity at :math:`r = 0.7`.
+
         Published projection has misprints
         (“19\ **3**\ .30083” instead of “19\ **6**\ .30083” in both cases).
 
@@ -379,6 +381,12 @@ def profile5(r):
     M. L. Brake,
     `J. Quant. Spectrosc. Radiat. Transf. 55, 231–243 (1996)
     <https://doi.org/10.1016/0022-4073(95)00149-2>`_, Table 1, № 1.
+
+    Note:
+        This profile is discontinuous (and its projection is not smooth) at
+        :math:`r = 1`, which can cause different problems in different methods,
+        in particular, depending on their assumptions where the singularity is
+        located within the last pixel.
 
     .. math::
 

--- a/setup.py
+++ b/setup.py
@@ -130,10 +130,10 @@ setup(name='PyAbel',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
           ],
       **setup_args
       )


### PR DESCRIPTION
I've noticed that we don't have CI tests with Python 3.10 (the current version, released almost a year ago), so this PR adds it for Travis testing (3.10 should now also be available at AppVeyor, but it's working so slowly that I'm not sure whether having more jobs there would be justified).

The testing coverage report, repaired in #357, also showed that transform pairs are not tested at all, so I've made basic tests for them. This also highlighted potential problems with the profiles that have discontinuities, so I've also added some notes to their descriptions.

And another small clean-up inspired by type-hinting exercises: `guss_gaussian()` from `tools.math` is renamed to `guess_gaussian()` — I suspect that “guss” was an accidental misprint rather than something meaningful.
