### PR TITLE
Preparations for v0.9.0rc2 release (v0.9.0 pre-release)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,18 @@ jobs:
   include:
     - dist: jammy
       python: 3.11
+      # give RTD enough time to build the docs before the PyPI deployment
+      before_deploy: sleep 5m
+      deploy:
+        provider: pypi
+        username: DanHickstein
+        password:
+          secure: RlJ41NowzFZ57pzbCQNTnm2OY5tSoCocbassn03GEzWrUqDnVG/jtvqWxf5bKdJ5T1WrFmjeI6/GWGx9Xk5HXAfWQLJjtmtrN/SYerBtdUAEyyV0s//o/Wd2qEB3tj8FCtUAx+mf5Q9ck3mRCFuYqK9rApXXxeUOqCE3R6pnEf/Ubpg7NYqMphziZA65qClqJNl1RFxBRD8mVoik99IrLitka6UnctFMBMWhchuGP80FTG5kyl6sIvVn1cwQISSF3Yr+IVqiKQGL1syRnef4FzOhn5sY4tZwR50cEF1CdAAZQU5GqiFwMKTjmocT/YIMVViJm6/SukJUzPeZNC7YuQBb9ZGroF257PgYyrnGkEK6qs3i3qexRI2c2uLmq19H0FbBtNo1ZHYUF6kzmga+7dW9brzd7zLU2em+nqN7w09JO1Z9gFfHIC5XD276bkwtIK5qT0r7SjNY/HdO/HYaSCLI+FR4R/XpTzC+vWIkhpdv3WZ5IpdIFn9f1SW3Uq4hyro0wlojb26TUyidSIzHDYgPepxLVy5YPuT8Css0kqMh5j9uZeTCqMkyeeSrTBOF64NO6w7RH5cLTYGXMixMNudzHY8yZfH9NaynG+dRwwyy7okFg5D8qKT4zMJfn3yvzg1DAENqz2/cNL38epDEXRruTR99qGnN+xMG2WE/WRs=
+        distributions: sdist bdist_wheel
+        skip_existing: true
+        on:
+          tags: true
+          repo: PyAbel/PyAbel
     # SciPy fails to install for current 3.10.8
     #- dist: jammy
     #  python: 3.10
@@ -26,16 +38,6 @@ install:
   - pip install --upgrade coveralls pytest pytest-cov
   - pip install . -v
 script:
-  - cd /tmp; pytest -v --cov=abel --pyargs abel
-# give RTD enough time to build the docs before strating the PyPI deployment
-before_deploy: sleep 5m
-deploy:
-  provider: pypi
-  username: DanHickstein
-  password:
-    secure: RlJ41NowzFZ57pzbCQNTnm2OY5tSoCocbassn03GEzWrUqDnVG/jtvqWxf5bKdJ5T1WrFmjeI6/GWGx9Xk5HXAfWQLJjtmtrN/SYerBtdUAEyyV0s//o/Wd2qEB3tj8FCtUAx+mf5Q9ck3mRCFuYqK9rApXXxeUOqCE3R6pnEf/Ubpg7NYqMphziZA65qClqJNl1RFxBRD8mVoik99IrLitka6UnctFMBMWhchuGP80FTG5kyl6sIvVn1cwQISSF3Yr+IVqiKQGL1syRnef4FzOhn5sY4tZwR50cEF1CdAAZQU5GqiFwMKTjmocT/YIMVViJm6/SukJUzPeZNC7YuQBb9ZGroF257PgYyrnGkEK6qs3i3qexRI2c2uLmq19H0FbBtNo1ZHYUF6kzmga+7dW9brzd7zLU2em+nqN7w09JO1Z9gFfHIC5XD276bkwtIK5qT0r7SjNY/HdO/HYaSCLI+FR4R/XpTzC+vWIkhpdv3WZ5IpdIFn9f1SW3Uq4hyro0wlojb26TUyidSIzHDYgPepxLVy5YPuT8Css0kqMh5j9uZeTCqMkyeeSrTBOF64NO6w7RH5cLTYGXMixMNudzHY8yZfH9NaynG+dRwwyy7okFg5D8qKT4zMJfn3yvzg1DAENqz2/cNL38epDEXRruTR99qGnN+xMG2WE/WRs=
-  distributions: sdist bdist_wheel
-  skip_existing: true
-  on:
-    tags: true
-    repo: PyAbel/PyAbel
+  # test in /tmp to use the installed package and get meaningful coverage info,
+  # then return to the source dir for the deployment step
+  - pushd /tmp; pytest -v --cov=abel --pyargs abel; popd

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v0.9.0rc1 (2022-12-05)
+v0.9.0rc2 (2022-12-07)
 ----------------------
 * Correct behavior of relative basis_dir in basex under Python 2 (PR #336).
 * Improvements in tools.analytical.SampleImage class: more consistent and
@@ -23,6 +23,10 @@ v0.9.0rc1 (2022-12-05)
 * Transform() with method='linbasex' now always stores the radial, Beta and
   projection attributes, so there is no need to pass return_Beta=True
   in transform_options (PR #357).
+
+v0.9.0rc1 (2022-12-05)
+----------------------
+First release candidate for 0.9.0.
 
 v0.8.5 (2022-01-21)
 -------------------

--- a/abel/_version.py
+++ b/abel/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.0rc1"
+__version__ = "0.9.0rc2"


### PR DESCRIPTION
OK, another attempt, with the Travis config corrected (also moving `deploy:` to just the latest Python version, since otherwise `before_deploy: sleep 5m` was uselessly executed for each build).

The release noted will be moved from #364.