### PR TITLE
Update installation commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,23 +65,17 @@ Installation
 
 PyAbel requires Python 3.7–3.11. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://numpy.org/>`__ and `SciPy <https://scipy.org/>`__ are also required, and `Matplotlib <https://matplotlib.org/>`__ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.anaconda.com/products/individual>`__, which is available for free.
 
-With pip
-~~~~~~~~
-
 The latest release can be installed from PyPI with ::
 
     pip install PyAbel
 
-With setuptools
-~~~~~~~~~~~~~~~
-
 If you prefer the development version from GitHub, download it `here <https://github.com/PyAbel/PyAbel/tree/master>`__, ``cd`` to the PyAbel directory, and use ::
 
-    python setup.py install
+    pip install .
 
 Or, if you wish to edit the PyAbel source code without re-installing each time ::
 
-    python setup.py develop
+    pip install -e .
 
 Before uninstalling
 ~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ The latest release can be installed from `PyPI <https://pypi.org/project/PyAbel/
 
     pip install PyAbel
 
-If you prefer the development version from GitHub, download it `here <https://github.com/PyAbel/PyAbel/tree/master>`__ (clicking the :guilabel:`Code ▾` button), ``cd`` to the PyAbel directory, and use ::
+If you prefer the development version from GitHub, download it `here <https://github.com/PyAbel/PyAbel/tree/master>`__ (clicking the [Code ▾] button), ``cd`` to the PyAbel directory, and use ::
 
     pip install .
 

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Installation
 
 PyAbel requires Python 3.7–3.11. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://numpy.org/>`__ and `SciPy <https://scipy.org/>`__ are also required, and `Matplotlib <https://matplotlib.org/>`__ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.anaconda.com/products/individual>`__, which is available for free.
 
-The latest release can be installed from PyPI with ::
+The latest release can be installed from `PyPI <https://pypi.org/project/PyAbel/>`__ with ::
 
     pip install PyAbel
 
@@ -73,7 +73,7 @@ If you prefer the development version from GitHub, download it `here <https://gi
 
     pip install .
 
-Or, if you wish to edit the PyAbel source code without re-installing each time ::
+Or, if you wish to edit the PyAbel source code without re-installing each time, ::
 
     pip install -e .
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ The latest release can be installed from `PyPI <https://pypi.org/project/PyAbel/
 
     pip install PyAbel
 
-If you prefer the development version from GitHub, download it `here <https://github.com/PyAbel/PyAbel/tree/master>`__, ``cd`` to the PyAbel directory, and use ::
+If you prefer the development version from GitHub, download it `here <https://github.com/PyAbel/PyAbel/tree/master>`__ (clicking the :guilabel:`Code ▾` button), ``cd`` to the PyAbel directory, and use ::
 
     pip install .
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -308,8 +308,6 @@ latex_elements = {
             \setlength{\arrayrulewidth}{0pt}
             % increase row separation
             \def\arraystretch{1.5}
-        % GUI labels like in HTML
-        \def\sphinxguilabel#1{\fbox{#1}}
         % override hyphenation
         \hyphenation{BASEX Py-Abel}
         ''',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyAbel'
-copyright = u'2016–2022, PyAbel team'
+copyright = u'2016–2023, PyAbel team'
 author = 'PyAbel team'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -101,7 +101,7 @@ exec(open('conf/doi.py').read())
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -295,6 +295,7 @@ latex_elements = {
         \DeclareUnicodeCharacter{2272}{\ensuremath{\lesssim}} % ≲
         \DeclareUnicodeCharacter{2273}{\ensuremath{\gtrsim}} % ≳
         \DeclareUnicodeCharacter{22C5}{\ensuremath{\cdot}} % ⋅
+        \DeclareUnicodeCharacter{25BE}{\ensuremath{\blacktriangledown}} % ▾
         \DeclareUnicodeCharacter{27C2}{\ensuremath{\perp}} % ⟂
         \DeclareUnicodeCharacter{2A7D}{\ensuremath{\leqslant}} % ⩽
         \DeclareUnicodeCharacter{2A7E}{\ensuremath{\geqslant}} % ⩾
@@ -307,6 +308,8 @@ latex_elements = {
             \setlength{\arrayrulewidth}{0pt}
             % increase row separation
             \def\arraystretch{1.5}
+        % GUI labels like in HTML
+        \def\sphinxguilabel#1{\fbox{#1}}
         % override hyphenation
         \hyphenation{BASEX Py-Abel}
         ''',


### PR DESCRIPTION
To address #371, the deprecated `python setup.py` instructions are replaced with the recommended `pip install .`.

(My local Sphinx now also complains about `language = None`, so I've put the actual `'en'` there, as it suggested.)