### PR TITLE
Specify requirements for Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,8 +6,8 @@
 version: 2
 
 python:
- # enable access to preinstalled modules (numpy, scipy, matplotlib)
- system_packages: true
+  install:
+    - requirements: doc/requirements.txt
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,10 +65,9 @@ Note that this requires that you have `pytest <https://docs.pytest.org/en/latest
 Documentation
 -------------
 
-PyAbel uses Sphinx and `Napoleon <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html>`__ to process Numpy-style docstrings and is synchronized to `pyabel.readthedocs.io <https://pyabel.readthedocs.io>`__. To build the documentation locally, you will need `Sphinx <https://www.sphinx-doc.org/>`__, the `recommonmark <https://github.com/readthedocs/recommonmark>`__ package, and the `sphinx_rtd_theme <https://github.com/readthedocs/sphinx_rtd_theme>`__. You can install them using ::
+PyAbel uses Sphinx and `Napoleon <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html>`__ to process Numpy-style docstrings and is synchronized to `pyabel.readthedocs.io <https://pyabel.readthedocs.io>`__. To build the documentation locally, you will need `Sphinx <https://www.sphinx-doc.org/>`__ and the `sphinx_rtd_theme <https://github.com/readthedocs/sphinx_rtd_theme>`__. You can install them using ::
 
     pip install sphinx
-    pip install recommonmark
     pip install sphinx_rtd_theme
 
 Once you have these packages installed, you can build the documentation using ::

--- a/abel/tools/center.py
+++ b/abel/tools/center.py
@@ -613,7 +613,7 @@ def find_origin_by_slice(IM, axes=(0, 1), slice_width=10, radial_range=(0, -1),
         fit = minimize(_align, initial_shift, args=(top, bottom),
                        bounds=((-50, 50), ), tol=0.1)
         if fit["success"]:
-            xyoffset[0] = -float(fit['x']) / 2  # x1/2 for image shift
+            xyoffset[0] = -fit['x'][0] / 2  # x1/2 for image shift
         else:
             raise RuntimeError("fit failure: axis 0, zero shift set", fit)
 
@@ -622,7 +622,7 @@ def find_origin_by_slice(IM, axes=(0, 1), slice_width=10, radial_range=(0, -1),
         fit = minimize(_align, initial_shift, args=(left, right),
                        bounds=((-50, 50), ), tol=0.1)
         if fit["success"]:
-            xyoffset[1] = -float(fit['x']) / 2  # x1/2 for image shift
+            xyoffset[1] = -fit['x'][0] / 2  # x1/2 for image shift
         else:
             raise RuntimeError("fit failure: axis 1, zero shift set", fit)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,35 +20,11 @@ import shlex
 
 import sphinx_rtd_theme
 
-from recommonmark.parser import CommonMarkParser
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../'))
 
-# Scipy and Numpy packages cannot be installed in on readthedocs.io
-# https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
-if six.PY3:
-    from unittest.mock import MagicMock
-else:
-    from mock import Mock as MagicMock
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return Mock()
-
-# MOCK_MODULES = ['numpy', 'scipy', 'scipy.special', 'numpy.linalg',
-#                 'scipy.ndimage', 'scipy.ndimage', 'scipy.linalg',
-#                 'scipy.integrate', 'scipy.optimize']
-MOCK_MODULES = []
-
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -70,7 +46,7 @@ templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-source_suffix = ['.rst', '.md']
+source_suffix = ['.rst']
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
@@ -363,9 +339,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'PyAbel', 'PyAbel Documentation',
-   author, 'PyAbel', 'One line description of project.',
-   'Miscellaneous'),
+    (master_doc, 'PyAbel', 'PyAbel Documentation', author,
+     'PyAbel', 'A Python package for forward and inverse Abel transforms.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,3 @@
+numpy >= 1.16      # last for Python 2
+scipy >= 1.2       # last for Python 2
 matplotlib >= 2.2  # last for Python 2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib >= 2.2  # last for Python 2

--- a/doc/transform_methods/rbasex-coord.py
+++ b/doc/transform_methods/rbasex-coord.py
@@ -14,7 +14,7 @@ an = 11  # angle arc segments
 anc = an // 2  # index of central point
 
 fig = plt.figure(figsize=(3, 3), frameon=False)
-ax = fig.gca(projection='3d')
+ax = plt.subplot(projection='3d')
 ax.set_proj_type('ortho')
 ax.view_init(elev=30, azim=45)
 ax.set_axis_off()


### PR DESCRIPTION
I've got an email from Read the Docs that they'll soon deprecate the “use system packages” feature, which for us means that `matplotlib` will not be available preinstalled, so we need to install it explicitly. This also applies to `numpy` and `scipy`, but these are already listed as dependencies for `pyabel` itself and hopefully will be installed as needed...