### PR TITLE
Updates for NumPy 2 and Matplotlib 3.9

### DIFF
--- a/abel/direct.py
+++ b/abel/direct.py
@@ -5,6 +5,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+if hasattr(np, 'trapezoid'):  # numpy >= 2
+    trapezoid = np.trapezoid
+else:
+    trapezoid = np.trapz
 from .tools.math import gradient
 
 try:
@@ -53,7 +57,7 @@ def _construct_r_grid(n, dr=None, r=None):
 
 
 def direct_transform(fr, dr=None, r=None, direction='inverse',
-                     derivative=gradient, int_func=np.trapz,
+                     derivative=gradient, int_func=trapezoid,
                      correction=True, backend='C', **kwargs):
     """
     This algorithm performs a :doc:`direct computation
@@ -94,8 +98,8 @@ def direct_transform(fr, dr=None, r=None, direction='inverse',
         with respect to r. (only used in the inverse Abel transform).
     int_func : function
         This function is used to complete the integration. It should resemble
-        np.trapz, in that it must be callable using axis=, x=, and dx=
-        keyword arguments.
+        np.trapz/np.trapezoid, in that it must be callable using axis=, x=, and
+        dx= keyword arguments.
     correction : boolean
         If False the pixel where the weighting function has a singular value
         (where r==y) is simply skipped, causing a systematic under-estimation
@@ -155,7 +159,7 @@ def direct_transform(fr, dr=None, r=None, direction='inverse',
         return out
 
 
-def _pyabel_direct_integral(f, r, correction, int_func=np.trapz):
+def _pyabel_direct_integral(f, r, correction, int_func=trapezoid):
     """
     Calculation of the integral  used in Abel transform
     (both direct and inverse).

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -6,6 +6,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+if hasattr(np, 'trapezoid'):  # numpy >= 2
+    trapezoid = np.trapezoid
+else:
+    trapezoid = np.trapz
 from abel.tools.polar import reproject_image_into_polar
 from scipy.ndimage import map_coordinates, uniform_filter1d, shift
 from scipy.optimize import curve_fit
@@ -78,8 +82,8 @@ def radial_intensity(kind, IM, origin=None, dr=1, dt=None):
     # integrate over theta
     dt = T[0, 1] - T[0, 0]  # get the actual number, if dt=None was passed
     intensity = polarIM.sum(axis=1) * dt
-    # (np.trapz() doesn't know about periodic functions and thus underuses
-    # boundary points; direct Riemann sum is more accurate here)
+    # (np.trapz()/np.trapezoid() doesn't know about periodic functions and thus
+    # underuses boundary points; direct Riemann sum is more accurate here)
 
     return R[:, 0], intensity
 
@@ -197,7 +201,7 @@ def angular_integration(IM, origin=None, Jacobian=True, dr=1, dt=None):
     if Jacobian:  # × r sinθ
         polarIM *= R * np.abs(np.sin(T))
 
-    speeds = np.trapz(polarIM, axis=1, dx=dt)
+    speeds = trapezoid(polarIM, axis=1, dx=dt)
 
     n = speeds.shape[0]
 

--- a/doc/transform_methods/comparison/fig_benchmarks/throughput.py
+++ b/doc/transform_methods/comparison/fig_benchmarks/throughput.py
@@ -36,7 +36,7 @@ def plot(directory, xlim, ylim, va):
 
         # add an empty entry to end column 1 for more logical grouping
         if meth == 'daun(var)':
-            plt.plot(np.NaN, np.NaN, 'o-', color='none', label=' ')
+            plt.plot(np.nan, np.nan, 'o-', color='none', label=' ')
 
     plt.xlabel('Image size ($n$, pixels)')
     plt.xscale('log')

--- a/doc/transform_methods/comparison/fig_experiment/experiment.py
+++ b/doc/transform_methods/comparison/fig_experiment/experiment.py
@@ -73,7 +73,7 @@ for num, (ax, (label, transFunc, color), letter) in enumerate(zip(axs.ravel(),
 
 
 axc = fig.add_axes([0.93, 0.05, 0.01, 0.94])
-cbar = plt.colorbar(im, orientation="vertical", cax=axc, label='Intensity')
+cbar = fig.colorbar(im, orientation="vertical", cax=axc, label='Intensity')
 cbar.ax.xaxis.set_ticks_position('top')
 cbar.ax.xaxis.set_label_position('top')
 


### PR DESCRIPTION
NumPy is planning to release v2.0 soon (conda already wanted to rebuild for it, see https://github.com/conda-forge/pyabel-feedstock/pull/27). I've tested locally with `numpy 2.0.0rc2` (from PyPI) and found that small modifications are needed to ensure compatibility with it:
* `numpy.trapz()` was renamed to `numpy.trapezoid()`, so we'll need to use the one that is available (`numpy.trapezoid()` isn't available in current versions, so we can't just switch to it; `scipy.integrate.trapezoid()` wasn't present in `scipy 1.2` — the last available for Python 2).
* `numpy.NaN` (used only in one documentation figure) was removed, so `numpy.nan` should be used instead.

The newest Matplotlib (v3.6.0) also complains about `plt.colorbar()` called from wrong axes (in another documentation figure), so this is also corrected here.

The rest still looks fine.

I suspect that when `numpy 2.0.0` is released, we'll also have to make a minor maintenance release...