### PR TITLE
Update docs: remove misleading notation surrounding quadrant averaging

### DIFF
--- a/abel/transform.py
+++ b/abel/transform.py
@@ -199,13 +199,19 @@ class Transform(object):
         1) symmetry_axis = 0 (vertical)::
 
             Combine:  Q01:
-                        = average(Q0, Q1) if use_quadrants[0] is True and use_quadrants[1] is True
-                        = Q0 if use_quadrants[0] is True and use_quadrants[1] is False
-                        = Q1 if use_quadrants[0] is False and use_quadrants[1] is True
+                        = average(Q0, Q1) if use_quadrants[0] is True 
+                            and use_quadrants[1] is True
+                        = Q0 if use_quadrants[0] is True 
+                            and use_quadrants[1] is False
+                        = Q1 if use_quadrants[0] is False 
+                            and use_quadrants[1] is True
                       Q23: 
-                        = average(Q2, Q3) if use_quadrants[2] is True and use_quadrants[3] is True
-                        = Q2 if use_quadrants[2] is True and use_quadrants[3] is False
-                        = Q3 if use_quadrants[2] is False and use_quadrants[3] is True
+                        = average(Q2, Q3) if use_quadrants[2] is True 
+                            and use_quadrants[3] is True
+                        = Q2 if use_quadrants[2] is True 
+                            and use_quadrants[3] is False
+                        = Q3 if use_quadrants[2] is False 
+                            and use_quadrants[3] is True
             inverse image   AQ01 | AQ01
                             -----o----- (left and right sides equivalent)
                             AQ23 | AQ23
@@ -214,13 +220,19 @@ class Transform(object):
         2) symmetry_axis = 1 (horizontal)::
 
             Combine: Q12
-                       = average(Q1, Q2) if use_quadrants[1] is True and use_quadrants[2] is True
-                       = Q1 if use_quadrants[1] is True and use_quadrants[2] is False
-                       = Q2 if use_quadrants[1] is False and use_quadrants[2] is True
+                       = average(Q1, Q2) if use_quadrants[1] is True 
+                           and use_quadrants[2] is True
+                       = Q1 if use_quadrants[1] is True 
+                           and use_quadrants[2] is False
+                       = Q2 if use_quadrants[1] is False 
+                           and use_quadrants[2] is True
                      Q03
-                       = average(Q0, Q3) if use_quadrants[0] is True and use_quadrants[3] is True
-                       = Q0 if use_quadrants[0] is True and use_quadrants[3] is False
-                       = Q3 if use_quadrants[0] is False and use_quadrants[3] is True
+                       = average(Q0, Q3) if use_quadrants[0] is True 
+                           and use_quadrants[3] is True
+                       = Q0 if use_quadrants[0] is True 
+                           and use_quadrants[3] is False
+                       = Q3 if use_quadrants[0] is False 
+                           and use_quadrants[3] is True
             inverse image   AQ12 | AQ03
                             -----o----- (top and bottom equivalent)
                             AQ12 | AQ03
@@ -228,7 +240,8 @@ class Transform(object):
 
         3) symmetry_axis = (0, 1) (both)::
 
-            Combine: Q = average of all the quadrants specified by the use_quadrants parameter.
+            Combine: Q = average of all the quadrants specified 
+                            by the use_quadrants parameter.
             inverse image   AQ | AQ
                             ---o---  (all quadrants equivalent)
                             AQ | AQ

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -200,8 +200,8 @@ class Transform(object):
 
         1) symmetry_axis = 0 (vertical)::
 
-            Combine:  Q01 = average of ``use_quadrants``-included quadrants in the list [Q0,Q1].
-                      Q23 = average of ``use_quadrants``-included quadrants in the list [Q2,Q3].
+            Combine:  Q01 = average of use_quadrants-included quadrants in the list [Q0,Q1].
+                      Q23 = average of use_quadrants-included quadrants in the list [Q2,Q3].
             inverse image   AQ01 | AQ01
                             -----o----- (left and right sides equivalent)
                             AQ23 | AQ23
@@ -209,8 +209,8 @@ class Transform(object):
 
         2) symmetry_axis = 1 (horizontal)::
 
-            Combine: Q12 = average of ``use_quadrants``-included quadrants in the list [Q1,Q2].
-                     Q03 = average of ``use_quadrants``-included quadrants in the list [Q0,Q3].
+            Combine: Q12 = average of use_quadrants-included quadrants in the list [Q1,Q2].
+                     Q03 = average of use_quadrants-included quadrants in the list [Q0,Q3].
             inverse image   AQ12 | AQ03
                             -----o----- (top and bottom equivalent)
                             AQ12 | AQ03
@@ -218,7 +218,7 @@ class Transform(object):
 
         3) symmetry_axis = (0, 1) (both)::
 
-            Combine: Q = average of all the quadrants included by the ``use_quadrants`` parameter.
+            Combine: Q = average of all the quadrants included by the use_quadrants parameter.
             inverse image   AQ | AQ
                             ---o---  (all quadrants equivalent)
                             AQ | AQ

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -198,7 +198,14 @@ class Transform(object):
 
         1) symmetry_axis = 0 (vertical)::
 
-            Combine:  Q01 = Q0 + Q1, Q23 = Q2 + Q3
+            Combine:  Q01:
+                        = average(Q0, Q1) if use_quadrants[0] is True and use_quadrants[1] is True
+                        = Q0 if use_quadrants[0] is True and use_quadrants[1] is False
+                        = Q1 if use_quadrants[0] is False and use_quadrants[1] is True
+                      Q23: 
+                        = average(Q2, Q3) if use_quadrants[2] is True and use_quadrants[3] is True
+                        = Q2 if use_quadrants[2] is True and use_quadrants[3] is False
+                        = Q3 if use_quadrants[2] is False and use_quadrants[3] is True
             inverse image   AQ01 | AQ01
                             -----o----- (left and right sides equivalent)
                             AQ23 | AQ23
@@ -206,7 +213,14 @@ class Transform(object):
 
         2) symmetry_axis = 1 (horizontal)::
 
-            Combine: Q12 = Q1 + Q2, Q03 = Q0 + Q3
+            Combine: Q12
+                       = average(Q1, Q2) if use_quadrants[1] is True and use_quadrants[2] is True
+                       = Q1 if use_quadrants[1] is True and use_quadrants[2] is False
+                       = Q2 if use_quadrants[1] is False and use_quadrants[2] is True
+                     Q03
+                       = average(Q0, Q3) if use_quadrants[0] is True and use_quadrants[3] is True
+                       = Q0 if use_quadrants[0] is True and use_quadrants[3] is False
+                       = Q3 if use_quadrants[0] is False and use_quadrants[3] is True
             inverse image   AQ12 | AQ03
                             -----o----- (top and bottom equivalent)
                             AQ12 | AQ03
@@ -214,7 +228,7 @@ class Transform(object):
 
         3) symmetry_axis = (0, 1) (both)::
 
-            Combine: Q = Q0 + Q1 + Q2 + Q3
+            Combine: Q = average of all the quadrants specified by the use_quadrants parameter.
             inverse image   AQ | AQ
                             ---o---  (all quadrants equivalent)
                             AQ | AQ

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -199,18 +199,18 @@ class Transform(object):
         1) symmetry_axis = 0 (vertical)::
 
             Combine:  Q01:
-                        = average(Q0, Q1) if use_quadrants[0] is True 
+                        = average(Q0, Q1) if use_quadrants[0] is True
                             and use_quadrants[1] is True
-                        = Q0 if use_quadrants[0] is True 
+                        = Q0 if use_quadrants[0] is True
                             and use_quadrants[1] is False
-                        = Q1 if use_quadrants[0] is False 
+                        = Q1 if use_quadrants[0] is False
                             and use_quadrants[1] is True
-                      Q23: 
-                        = average(Q2, Q3) if use_quadrants[2] is True 
+                      Q23:
+                        = average(Q2, Q3) if use_quadrants[2] is True
                             and use_quadrants[3] is True
-                        = Q2 if use_quadrants[2] is True 
+                        = Q2 if use_quadrants[2] is True
                             and use_quadrants[3] is False
-                        = Q3 if use_quadrants[2] is False 
+                        = Q3 if use_quadrants[2] is False
                             and use_quadrants[3] is True
             inverse image   AQ01 | AQ01
                             -----o----- (left and right sides equivalent)
@@ -220,18 +220,18 @@ class Transform(object):
         2) symmetry_axis = 1 (horizontal)::
 
             Combine: Q12
-                       = average(Q1, Q2) if use_quadrants[1] is True 
+                       = average(Q1, Q2) if use_quadrants[1] is True
                            and use_quadrants[2] is True
-                       = Q1 if use_quadrants[1] is True 
+                       = Q1 if use_quadrants[1] is True
                            and use_quadrants[2] is False
-                       = Q2 if use_quadrants[1] is False 
+                       = Q2 if use_quadrants[1] is False
                            and use_quadrants[2] is True
                      Q03
-                       = average(Q0, Q3) if use_quadrants[0] is True 
+                       = average(Q0, Q3) if use_quadrants[0] is True
                            and use_quadrants[3] is True
-                       = Q0 if use_quadrants[0] is True 
+                       = Q0 if use_quadrants[0] is True
                            and use_quadrants[3] is False
-                       = Q3 if use_quadrants[0] is False 
+                       = Q3 if use_quadrants[0] is False
                            and use_quadrants[3] is True
             inverse image   AQ12 | AQ03
                             -----o----- (top and bottom equivalent)
@@ -240,7 +240,7 @@ class Transform(object):
 
         3) symmetry_axis = (0, 1) (both)::
 
-            Combine: Q = average of all the quadrants specified 
+            Combine: Q = average of all the quadrants specified
                             by the use_quadrants parameter.
             inverse image   AQ | AQ
                             ---o---  (all quadrants equivalent)

--- a/abel/transform.py
+++ b/abel/transform.py
@@ -179,7 +179,9 @@ class Transform(object):
     .. note::
         Quadrant combining:
         The quadrants can be combined (averaged) using the ``use_quadrants``
-        keyword in order to provide better data quality.
+        keyword in order to provide better data quality. If a quadrant is 
+        excluded by ``use_quadrants``, the averaging only occurs over the 
+        remaining quadrants.
 
         The quadrants are numbered starting from Q0 in the upper right and
         proceeding counter-clockwise::
@@ -198,20 +200,8 @@ class Transform(object):
 
         1) symmetry_axis = 0 (vertical)::
 
-            Combine:  Q01:
-                        = average(Q0, Q1) if use_quadrants[0] is True
-                            and use_quadrants[1] is True
-                        = Q0 if use_quadrants[0] is True
-                            and use_quadrants[1] is False
-                        = Q1 if use_quadrants[0] is False
-                            and use_quadrants[1] is True
-                      Q23:
-                        = average(Q2, Q3) if use_quadrants[2] is True
-                            and use_quadrants[3] is True
-                        = Q2 if use_quadrants[2] is True
-                            and use_quadrants[3] is False
-                        = Q3 if use_quadrants[2] is False
-                            and use_quadrants[3] is True
+            Combine:  Q01 = average of ``use_quadrants``-included quadrants in the list [Q0,Q1].
+                      Q23 = average of ``use_quadrants``-included quadrants in the list [Q2,Q3].
             inverse image   AQ01 | AQ01
                             -----o----- (left and right sides equivalent)
                             AQ23 | AQ23
@@ -219,20 +209,8 @@ class Transform(object):
 
         2) symmetry_axis = 1 (horizontal)::
 
-            Combine: Q12
-                       = average(Q1, Q2) if use_quadrants[1] is True
-                           and use_quadrants[2] is True
-                       = Q1 if use_quadrants[1] is True
-                           and use_quadrants[2] is False
-                       = Q2 if use_quadrants[1] is False
-                           and use_quadrants[2] is True
-                     Q03
-                       = average(Q0, Q3) if use_quadrants[0] is True
-                           and use_quadrants[3] is True
-                       = Q0 if use_quadrants[0] is True
-                           and use_quadrants[3] is False
-                       = Q3 if use_quadrants[0] is False
-                           and use_quadrants[3] is True
+            Combine: Q12 = average of ``use_quadrants``-included quadrants in the list [Q1,Q2].
+                     Q03 = average of ``use_quadrants``-included quadrants in the list [Q0,Q3].
             inverse image   AQ12 | AQ03
                             -----o----- (top and bottom equivalent)
                             AQ12 | AQ03
@@ -240,8 +218,7 @@ class Transform(object):
 
         3) symmetry_axis = (0, 1) (both)::
 
-            Combine: Q = average of all the quadrants specified
-                            by the use_quadrants parameter.
+            Combine: Q = average of all the quadrants included by the ``use_quadrants`` parameter.
             inverse image   AQ | AQ
                             ---o---  (all quadrants equivalent)
                             AQ | AQ


### PR DESCRIPTION
The current documentation notation describing how the symmetrize_method=="average" function works, is misleading. It says things like "Q01 = Q0 + Q1", indicating that the combination is a summation of Q0 and Q1. Instead it is either or, if only one of the quadrants is specified by use_quadrants, or it is the average of the two quadrants is specified. This commit expands the documentation to eliminate the misleading language.