### PR TITLE
Cylindrical axis orientation in README; refreshed external URLs, RTD config, Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env: DEPS="numpy scipy cython"
 jobs:
   include:
     - dist: jammy
-      python: 3.11
+      python: 3.13
       # give RTD enough time to build the docs before the PyPI deployment
       before_deploy: sleep 5m
       deploy:
@@ -17,10 +17,10 @@ jobs:
         on:
           tags: true
           repo: PyAbel/PyAbel
+    - python: 3.12
     # SciPy fails to install for current 3.10.8
     #- dist: jammy
     #  python: 3.10
-    - python: 3.9
     - python: 3.8
     - python: 2.7
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,15 @@ jobs:
         on:
           tags: true
           repo: PyAbel/PyAbel
-    - python: 3.12
+    - dist: jammy
+      python: 3.12
     # SciPy fails to install for current 3.10.8
     #- dist: jammy
     #  python: 3.10
-    - python: 3.8
-    - python: 2.7
+    - dist: jammy
+      python: 3.8
+    - dist: xenial
+      python: 2.7
     - os: osx
       language: generic
       osx_image: xcode10.1

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,6 @@
 Contributing to PyAbel
 ======================
 
-
 PyAbel is an open-source project, and we welcome improvements! Please let us know about any issues with the software, even if's just a typo. The easiest way to get started is to open a `new issue <https://github.com/PyAbel/PyAbel/issues>`__.
 
 If you would like to make a `pull request <https://github.com/PyAbel/PyAbel/pulls>`__, the following information may be useful.
@@ -10,7 +9,7 @@ If you would like to make a `pull request <https://github.com/PyAbel/PyAbel/pull
 Rebasing
 --------
 
-If possible, before submitting your pull request please rebase your fork on the last master on PyAbel. This could be done `as explained in this post <https://stackoverflow.com/questions/7244321/how-do-i-update-or-sync-a-forked-repository-on-github>`__::
+If possible, before submitting your pull request please `rebase <https://git-scm.com/book/en/v2/Git-Branching-Rebasing>`__ your fork on the last master on PyAbel::
 
     # Add the remote, call it "upstream" (only the fist time)
     git remote add upstream https://github.com/PyAbel/PyAbel.git
@@ -34,8 +33,6 @@ If possible, before submitting your pull request please rebase your fork on the 
     # push the changes to your fork
 
     git push -f
-
-See `this wiki <https://github.com/openedx/edx-platform/wiki/How-to-Rebase-a-Pull-Request>`__ for more information.
 
 
 Code style

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ The outcome of the numerical Abel transform depends on the exact method used. So
 Installation
 ------------
 
-PyAbel requires Python 3.7–3.12. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://numpy.org/>`__ and `SciPy <https://scipy.org/>`__ are also required, and `Matplotlib <https://matplotlib.org/>`__ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.anaconda.com/download>`__, which is available for free.
+PyAbel requires Python 3.7–3.13. (Note: PyAbel is also currently tested to work with Python 2.7, but Python 2 support will be removed soon.) `NumPy <https://numpy.org/>`__ and `SciPy <https://scipy.org/>`__ are also required, and `Matplotlib <https://matplotlib.org/>`__ is required to run the examples. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.anaconda.com/download>`__, which is available for free.
 
 The latest release can be installed from `PyPI <https://pypi.org/project/PyAbel/>`__ with ::
 

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ Conventions
 The PyAbel code adheres to the following conventions:
 
 -
-    **Image orientation:** PyAbel adopts the "television" convention, where ``IM[0, 0]`` refers to the **upper** left corner of the image. (This means that ``plt.imshow(IM)`` should display the image in the proper orientation, without the need to use the ``origin='lower'`` keyword.) Image coordinates are in the (row, column) format, consistent with NumPy array indexing, and negative values are interpreted as relative to the end of the corresponding axis. For example, ``(-1, 0)`` refers to the lower left corner (last row, 0th column). Cartesian coordinates can also be generated if needed. For example, the x, y grid for a centered 5×5 image:
+    **Image orientation:** The cylindrical symmetry axis in PyAbel is always **vertical**; if your data is instead symmetric around the horizontal axis, the image must be transposed or rotated by 90° before applying any Abel transform (and then back, to recover the original orientation). PyAbel adopts the "television" convention, where ``IM[0, 0]`` refers to the **upper** left corner of the image. (This means that ``plt.imshow(IM)`` should display the image in the proper orientation, without the need to use the ``origin='lower'`` keyword.) Image coordinates are in the (row, column) format, consistent with NumPy array indexing, and negative values are interpreted as relative to the end of the corresponding axis. For example, ``(-1, 0)`` refers to the lower left corner (last row, 0th column). Cartesian coordinates can also be generated if needed. For example, the x, y grid for a centered 5×5 image:
 
     .. code-block:: python
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
     - PYTHON_VERSION: 3.7
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
-    - PYTHON_VERSION: 3.11
+    - PYTHON_VERSION: 3.13
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,7 +132,7 @@ html_theme = 'sphinx_rtd_theme'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+#html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyAbel'
-copyright = u'2016–2023, PyAbel team'
+copyright = u'2016–2024, PyAbel team'
 author = 'PyAbel team'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -373,3 +373,18 @@ from docutils.utils import get_source_line
 #        self._warnfunc(msg, '%s:%s' % get_source_line(node))
 
 #sphinx.environment.BuildEnvironment.warn_node = _warn_node
+
+
+# -- Options for the linkcheck builder ------------------------------------
+
+# as of Jun 2024, default is 'Mozilla/5.0', but some websites don't like it
+# and forbid access; thus using UA from a recent Chromium browser
+# (still doesn't work for Science and Wiley, but OK for the rest)
+user_agent = 'Chromium/125.0.6422.60 Linux'
+
+# also avoid multiple parallel requests
+linkcheck_workers = 1  # default is 5
+
+# and reduce time-outs
+linkcheck_timeout = 10
+linkcheck_rate_limit_timeout = 70.0  # default is 300 s = 5 min

--- a/doc/transform_methods/comparison/fig_benchmarks/benchmarks.rst
+++ b/doc/transform_methods/comparison/fig_benchmarks/benchmarks.rst
@@ -18,7 +18,8 @@ Intel i7-9700 (Linux)
 ---------------------
 
 :CPU:
-    `Intel Core i7-9700 <https://ark.intel.com/content/www/us/en/ark/products/191792/intel-core-i79700-processor-12m-cache-up-to-4-70-ghz.html>`_ (8 cores, 8 threads; 3.0 GHz base, 4.7 GHz max)
+    `Intel Core i7-9700 <https://ark.intel.com/content/www/us/en/ark/products/191792/intel-core-i7-9700-processor-12m-cache-up-to-4-70-ghz.html>`_
+    (8 cores, 8 threads; 3.0 GHz base, 4.7 GHz max)
 
 :RAM:
     32 GB DDR4-2666
@@ -61,7 +62,8 @@ Intel i7-6700 (Linux)
 ---------------------
 
 :CPU:
-    `Intel Core i7-6700 <https://ark.intel.com/content/www/us/en/ark/products/88196/intel-core-i76700-processor-8m-cache-up-to-4-00-ghz.html>`_ (4 cores, 8 threads; 3.4 GHz base, 4.0 GHz max)
+    `Intel Core i7-6700 <https://ark.intel.com/content/www/us/en/ark/products/88196/intel-core-i7-6700-processor-8m-cache-up-to-4-00-ghz.html>`_
+    (4 cores, 8 threads; 3.4 GHz base, 4.0 GHz max)
 
 :RAM:
     32 GB DDR4-2133
@@ -104,7 +106,8 @@ AMD Ryzen 5 5600G (Linux)
 -------------------------
 
 :CPU:
-    `AMD Ryzen 5 5600G <https://www.amd.com/en/products/apu/amd-ryzen-5-5600g>`_ (6 cores, 12 threads; 3.9 GHz base, 4.4 GHz max)
+    `AMD Ryzen 5 5600G <https://www.amd.com/en/support/downloads/drivers.html/processors/ryzen/ryzen-5000-series/amd-ryzen-5-5600g.html#amd_support_product_spec>`_
+    (6 cores, 12 threads; 3.9 GHz base, 4.4 GHz max)
 
 :RAM:
     32 GB DDR4-3200
@@ -146,7 +149,8 @@ AMD Ryzen 5 5600G (Windows)
 ---------------------------
 
 :CPU:
-    `AMD Ryzen 5 5600G <https://www.amd.com/en/products/apu/amd-ryzen-5-5600g>`_ (6 cores, 12 threads; 3.9 GHz base, 4.4 GHz max)
+    `AMD Ryzen 5 5600G <https://www.amd.com/en/support/downloads/drivers.html/processors/ryzen/ryzen-5000-series/amd-ryzen-5-5600g.html#amd_support_product_spec>`_
+    (6 cores, 12 threads; 3.9 GHz base, 4.4 GHz max)
 
 :RAM:
     32 GB DDR4-3200
@@ -188,7 +192,8 @@ Raspberry Pi 4B (Linux)
 -----------------------
 
 :CPU:
-    `Broadcom BCM2711 <https://www.raspberrypi.com/documentation/computers/processors.html#bcm2711>`_ (4 cores; 1.5 GHz)
+    `Broadcom BCM2711 <https://www.raspberrypi.com/documentation/computers/processors.html#bcm2711>`_
+    (4 cores; 1.5 GHz)
 
 :RAM:
     4 GB LPDDR4-3200

--- a/doc/transform_methods/three_point.rst
+++ b/doc/transform_methods/three_point.rst
@@ -56,7 +56,7 @@ Citation
 
 .. |ref1| replace:: \ C. J. Dasch, "One-dimensional tomography: a comparison of Abel, onion-peeling, and filtered backprojection methods", `Appl. Opt. 31, 1146–1152 (1992) <https://doi.org/10.1364/AO.31.001146>`__.
 
-.. |ref2| replace:: \ K. Martin, PhD Thesis: "Acoustic Modification of Sooting Combustion", University of Texas at Austin (2002) (`record <https://repositories.lib.utexas.edu/handle/2152/1654>`__, `PDF <https://repositories.lib.utexas.edu/bitstream/handle/2152/1654/martinkm07836.pdf>`__).
+.. |ref2| replace:: \ K. Martin, PhD Thesis: "Acoustic Modification of Sooting Combustion", University of Texas at Austin (2002) (`record <https://repositories.lib.utexas.edu/items/53b5dc6d-df47-41a0-a5b7-0552a3f0bf8b>`__, `PDF <https://repositories.lib.utexas.edu/server/api/core/bitstreams/f5a54b91-cb02-47f3-9cf7-c1189184b2ff/content>`__).
 
 .. [1] |ref1|
 

--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,7 @@ setup(name='PyAbel',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
           'Programming Language :: Python :: 3.12',
+          'Programming Language :: Python :: 3.13',
           ],
       **setup_args
       )


### PR DESCRIPTION
Let's say explicitly in README that the cylindrical axis for all Abel transforms is vertical, as this is not immediately obvious and keeps confusing some users (for example, #388, #383, #362, and several times before).

There also was a warning in a recent Read the Docs buid (for #387):
> WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.

treated as a build error (due to ``fail_on_warning: true``), so I've just removed that ``get_html_theme_path()``, as suggested.

The supported Python versions are also updated up to 3.13 (released this month) — the tests pass locally on my system, and hopefully are already supported by Travis and AppVeyor.

And, last but not least, I've updated the rotten/moved external links in the documentation.