### PR TITLE
GitHub Actions to run pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,68 @@
+# See https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  FORCE_COLOR: 1 # colored output where possible
+
+jobs:
+  pytest:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        python-version: ["3.7", "3.13"]
+        ext: [cython, no-cython] # with/without Cython extension
+        exclude:
+          - os: macos-latest
+            python-version: "3.7" # not available
+          - os: macos-13
+            python-version: "3.13" # to save resources
+          # skip no-cython on slower systems
+          - os: macos-13
+            ext: no-cython
+          - os: macos-latest
+            ext: no-cython
+          - os: windows-latest
+            ext: no-cython
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: "pip"
+        cache-dependency-path: setup.py
+    - name: Update setup
+      run: python -m pip install --upgrade pip setuptools wheel
+    - name: Install Cython
+      if: matrix.ext != 'no-cython'
+      # numpy and scipy must be preinstalled for building Cython extension
+      run: python -m pip install numpy scipy cython
+    - name: Install pytest
+      run: python -m pip install pytest pytest-cov
+    - name: Install PyAbel
+      run: python -m pip install . -v
+    - name: Information
+      # (ugly but portable and with clean output)
+      run: >
+        python3 -c "import platform, sys, os, numpy, scipy;
+        print('Platorm:', platform.platform());
+        print('Python:', sys.version);
+        print('NumPy:', numpy.version.full_version);
+        print('SciPy:', scipy.version.full_version, flush=True);
+        os.system('cython -V 2>cython.err') and print('Cython not found')"
+    - name: Run tests
+      # "cd .." for coverage of installed abel instead of ./abel subdir
+      run: |
+        cd ..
+        pytest -v --cov=abel --pyargs abel

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,9 +4,9 @@ name: Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 env:
   FORCE_COLOR: 1 # colored output where possible


### PR DESCRIPTION
Here is the first step to address #365 — using GitHub Actions to run the unit tests on Linux, macOS and Windows (regular Python instead of Anaconda).
* As I understand, this [should be free for public projects](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions), but even in the worst case we should be allowed 2000 minutes per month (not too much, taking into account that macOS counts at 10× rate, but probably enough).
* Python 2.7 is not tested because it's apparently not available (and we should get rid of it anyway), but it's still covered by AppVeyor.
* For Python 3, only the lowest (3.7) and highest (3.13) versions form “PyAbel requires Python 3.7–3.13” are tested. I think, this should be enough, but more can be added later if needed.
* Only 64-bit systems (amd64, plus arm64 for the new macOS) are tested. AppVeyor still covers 32-bit Anaconda for Windows.
* To be sure, installations with and without Cython extensions are tested, but only in Linux, which is probably enough.

If this work fine, the next step will be to abandon Travis CI completely and implement PyPI deployment from GitHub Actions (hopefully, with compiled wheels again, for all the platforms).