### PR TITLE
Control off-range beta in `anisotropy_parameter()`; avoid broken SciPy optimizer

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-13, macos-latest, windows-latest]
         python-version: ["3.7", "3.13"]
         ext: [cython, no-cython] # with/without Cython extension
         exclude:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,9 @@ Unreleased
   math.fit_gaussian() is changed to "trf" from the default "lm", which has a
   defective implementation in SciPy and could produce wrong error estimates or
   OptimizeWarning in some cases (PR #394).
-* New option beta_out for tools.vmi.anisotropy_parameter() to control its
-  behavior when beta is outside the physical range (PR #394).
+* New option "mode" for tools.vmi.anisotropy_parameter() to control its
+  behavior when beta is outside the physical range. For consistency,
+  radial_integration() now also accepts theta_ranges and mode (PR #394).
 
 v0.9.0 (2022-12-14)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+Unreleased
+----------
+* Minor updates for compatibility with recent Python, NumPy, SciPy and
+  Matplotlib versions (PR #373, #378).
+* Various documentation updates, corrections and improvements.
+* The optimization method in tools.vmi.anisotropy_parameter() and
+  math.fit_gaussian() is changed to "trf" from the default "lm", which has a
+  defective implementation in SciPy and could produce wrong error estimates or
+  OptimizeWarning in some cases (PR #394).
+* New option beta_out for tools.vmi.anisotropy_parameter() to control its
+  behavior when beta is outside the physical range (PR #394).
+
 v0.9.0 (2022-12-14)
 -------------------
 * Correct behavior of relative basis_dir in basex under Python 2 (PR #336).

--- a/abel/tests/test_tools_polynomial.py
+++ b/abel/tests/test_tools_polynomial.py
@@ -300,20 +300,20 @@ def test_angular():
     # Legendre, multiplication by number, subtraction
     Al = Angular.legendre([0] * 2 + [1])  # P₂
     Aref = 3/2 * Angular.cos(2) - Angular(1/2)
-    assert_allclose(Al.c, Aref.c, err_msg='-> P_2')
+    assert_allclose(Al.c, Aref.c, atol=1e-15, err_msg='-> P_2')
 
     Al = Angular.legendre([0] * 3 + [1])  # P₃
     Aref = 5/2 * Angular.cos(3) - 3/2 * Angular.cos(1)
-    assert_allclose(Al.c, Aref.c, err_msg='-> P_3')
+    assert_allclose(Al.c, Aref.c, atol=1e-15, err_msg='-> P_3')
 
     # Legendre as anisotropy parameters
     Al = Angular.legendre([1, 0, -1]) * 2/3  # β = −1 ⇒ sin²
     Aref = Angular.sin(2)
-    assert_allclose(Al.c, Aref.c, err_msg='-> sin^2')
+    assert_allclose(Al.c, Aref.c, atol=1e-15, err_msg='-> sin^2')
 
     Al = Angular.legendre([1, 0, +2]) * 1/3  # β = +2 ⇒ cos²
     Aref = Angular.cos(2)
-    assert_allclose(Al.c, Aref.c, err_msg='-> cos^2')
+    assert_allclose(Al.c, Aref.c, atol=1e-15, err_msg='-> cos^2')
 
     # division, addition, outer product
     c = [3, 0, -1] * (Angular.cos(4) + Angular.sin(4) / 2)

--- a/abel/tests/test_tools_vmi.py
+++ b/abel/tests/test_tools_vmi.py
@@ -161,7 +161,7 @@ def test_anisotropy_parameter():
 
     def check(name, ref, theta, intensity):
         beta, amplitude = vmi.anisotropy_parameter(theta, intensity)
-        assert_allclose((beta[0], amplitude[0]), ref, atol=1e-8,
+        assert_allclose((beta[0], amplitude[0]), ref, atol=1e-7,
                         err_msg='-> ' + name)
 
     check('ones', (0, 1), theta, ones)

--- a/abel/tests/test_tools_vmi.py
+++ b/abel/tests/test_tools_vmi.py
@@ -158,7 +158,9 @@ def test_anisotropy_parameter():
     ones = np.ones_like(theta)
     cos2 = np.cos(theta)**2
     sin2 = np.sin(theta)**2
+
     noise = 0.01 * (2 * (np.arange(n) % 2) - 1)
+    chi2 = 0.01 / np.sqrt(n - 2)  # reduced chi2 for "noise"
 
     def check(name, bref, aref, theta, intensity, beta_out='raw'):
         """
@@ -168,12 +170,11 @@ def test_anisotropy_parameter():
         """
         beta, amplitude = vmi.anisotropy_parameter(theta, intensity,
                                                    beta_out=beta_out)
-        norm = np.sqrt(n) / 0.01
         err_msg = '-> {}, {}'.format(name, beta_out)
         assert_allclose((beta[0], amplitude[0]), (bref[0], aref[0]), atol=2e-8,
                         err_msg=err_msg + ' (val)')
-        assert_allclose((beta[1] * norm, amplitude[1] * norm),
-                        (bref[1], aref[1]), atol=1e-8 * norm, rtol=0.02,
+        assert_allclose((beta[1] / chi2, amplitude[1] / chi2),
+                        (bref[1], aref[1]), atol=1e-8 / chi2, rtol=0.01,
                         err_msg=err_msg + ' (err)')
 
     # exact
@@ -183,10 +184,10 @@ def test_anisotropy_parameter():
     # noisy
     check('ones+noise', (0, 1.89), (1, 1.11), theta, ones + noise)
     # bad
-    check('cos2sin2', (0, 133), (1/8, 9.8), theta, cos2 * sin2)
-    check('cos4', (3.2, 198), (5/24, 9.8), theta, cos2 * cos2)
-    check('cos4', (np.nan, np.nan), (5/24, 9.8), theta, cos2 * cos2, 'nan')
-    check('cos4', (2, 143), (5/18, 12.7), theta, cos2 * cos2, 'bound')
+    check('cos2sin2', (0, 133), (1/8, 9.77), theta, cos2 * sin2)
+    check('cos4', (3.2, 198), (5/24, 9.77), theta, cos2 * cos2)
+    check('cos4', (np.nan, np.nan), (5/24, 9.77), theta, cos2 * cos2, 'nan')
+    check('cos4', (2, 142), (5/18, 12.6), theta, cos2 * cos2, 'bound')
 
 
 def test_radial_integration():

--- a/abel/tests/test_tools_vmi.py
+++ b/abel/tests/test_tools_vmi.py
@@ -162,15 +162,14 @@ def test_anisotropy_parameter():
     noise = 0.01 * (2 * (np.arange(n) % 2) - 1)
     chi2 = 0.01 / np.sqrt(n - 2)  # reduced chi2 for "noise"
 
-    def check(name, bref, aref, theta, intensity, beta_out='raw'):
+    def check(name, bref, aref, theta, intensity, mode='raw'):
         """
         Reference values:
             bref = (beta, error_beta / chi2)
             aref = (amplitude, error_amplitude / chi2)
         """
-        beta, amplitude = vmi.anisotropy_parameter(theta, intensity,
-                                                   beta_out=beta_out)
-        err_msg = '-> {}, {}'.format(name, beta_out)
+        beta, amplitude = vmi.anisotropy_parameter(theta, intensity, mode=mode)
+        err_msg = '-> {}, {}'.format(name, mode)
         assert_allclose((beta[0], amplitude[0]), (bref[0], aref[0]), atol=2e-8,
                         err_msg=err_msg + ' (val)')
         assert_allclose((beta[1] / chi2, amplitude[1] / chi2),
@@ -186,7 +185,7 @@ def test_anisotropy_parameter():
     # bad
     check('cos2sin2', (0, 133), (1/8, 9.77), theta, cos2 * sin2)
     check('cos4', (3.2, 198), (5/24, 9.77), theta, cos2 * cos2)
-    check('cos4', (np.nan, np.nan), (5/24, 9.77), theta, cos2 * cos2, 'nan')
+    check('cos4', (np.nan, np.nan), (5/24, 9.77), theta, cos2 * cos2, 'reject')
     check('cos4', (2, 142), (5/18, 12.6), theta, cos2 * cos2, 'bound')
 
 

--- a/abel/tools/math.py
+++ b/abel/tools/math.py
@@ -139,7 +139,8 @@ def fit_gaussian(x):
     out : tuple of float
         (a, mu, sigma, c)
     """
-    res = curve_fit(gaussian, np.arange(x.size), x, p0=guess_gaussian(x))
+    res = curve_fit(gaussian, np.arange(x.size), x, p0=guess_gaussian(x),
+                    method='trf')  # default 'lm' is broken, see Scipy #21995
     return res[0]  # extract optimal values
 
 

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -394,7 +394,8 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
 
     # fit angular intensity distribution
     try:
-        popt, pcov = curve_fit(PAD, theta, intensity)
+        # using 'trf' because default 'lm' is broken, see SciPy Issue #21995
+        popt, pcov = curve_fit(PAD, theta, intensity, method='trf')
         beta, amplitude = popt
         error_beta, error_amplitude = np.sqrt(np.diag(pcov))
         # physical range

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -399,8 +399,8 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None):
         beta, amplitude = popt
         error_beta, error_amplitude = np.sqrt(np.diag(pcov))
         # physical range
-        if beta > 2 or beta < -1:
-            beta, error_beta = np.nan, np.nan
+        #if beta > 2 or beta < -1:
+        #    beta, error_beta = np.nan, np.nan
     except:
         beta, error_beta = np.nan, np.nan
         amplitude, error_amplitude = np.nan, np.nan

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -338,7 +338,7 @@ def radial_integration(IM, origin=None, radial_ranges=None):
     return Beta, Amp, radial_midpt, Intensity_vs_theta, theta
 
 
-def anisotropy_parameter(theta, intensity, theta_ranges=None, beta_out='nan'):
+def anisotropy_parameter(theta, intensity, theta_ranges=None, mode='reject'):
     r"""
     Evaluate anisotropy parameter :math:`\beta`, for :math:`I` vs
     :math:`\theta` data:
@@ -368,18 +368,16 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None, beta_out='nan'):
         Allows data to be excluded from fit; default (``None``) is to include
         all data.
 
-    beta_out: str
-        behavior when the evaluated anisotropy parameter would be outside the
-        physical range :math:`-1 \leqslant \beta \leqslant 2`:
-
+    mode: str
         ``'raw'``
             return the results regardless of their values
-        ``'nan'`` (default)
-            return ``(nan, nan)`` in **beta** (useful for excluding such data
-            points from plots)
+        ``'reject'`` (default)
+            return ``(nan, nan)`` in **beta** if anisotropy parameter is
+            outside the physical range :math:`-1 \leqslant \beta \leqslant 2`
+            (useful for excluding such data points from plots)
         ``'bound'``
-            use constrained fitting with :math:`-2 \leqslant \beta \leqslant
-            1`; return **beta** and **amplitude** corresponding to the "best
+            use constrained fitting with :math:`-1 \leqslant \beta \leqslant
+            2`; return **beta** and **amplitude** corresponding to the "best
             fit" (useful for noisy data but could potentially hide severe
             problems)
 
@@ -408,7 +406,7 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None, beta_out='nan'):
         intensity = intensity[subtheta]
 
     # fit angular intensity distribution
-    if beta_out == 'bound':
+    if mode == 'bound':
         bounds = {'bounds': ([-1, -np.inf], [2, np.inf])}
     else:
         bounds = {}
@@ -417,7 +415,7 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None, beta_out='nan'):
         popt, pcov = curve_fit(PAD, theta, intensity, method='trf', **bounds)
         beta, amplitude = popt
         error_beta, error_amplitude = np.sqrt(np.diag(pcov))
-        if beta_out == 'nan':
+        if mode == 'reject':
             # physical range
             if beta > 2 or beta < -1:
                 beta, error_beta = np.nan, np.nan

--- a/abel/tools/vmi.py
+++ b/abel/tools/vmi.py
@@ -250,7 +250,8 @@ def average_radial_intensity(IM, **kwargs):
     return R, intensity
 
 
-def radial_integration(IM, origin=None, radial_ranges=None):
+def radial_integration(IM, origin=None, radial_ranges=None, theta_ranges=None,
+                       mode='reject'):
     r""" Intensity variation in the angular coordinate.
 
     This function is the :math:`\theta`-coordinate complement to
@@ -282,6 +283,16 @@ def radial_integration(IM, origin=None, radial_ranges=None):
             Evaluates the intensity vs angle for
             the whole radial range ``(0, step), (step, 2*step), ..``
 
+    theta_ranges : list of tuples or None
+        fit the data only within angular ranges
+        ``[(theta1, theta2), (theta3, theta4)]``,
+        allowing data to be excluded from fit; default (``None``) is to use all
+        angles.
+
+    mode : str
+        ``'raw'``/``'reject'``/``'bound'`` mode for evaluating and reporting
+        the angular dependence, see :func:`anisotropy_parameter` for details
+
     Returns
     -------
     Beta : list of tuples
@@ -295,10 +306,10 @@ def radial_integration(IM, origin=None, radial_ranges=None):
     Rmidpt : list of float
         radial mid-point of each radial range
 
-    Intensity_vs_theta: list of numpy.array
+    Intensity_vs_theta : list of numpy.array
         intensity vs angle distribution for each selected radial range
 
-    theta: 1D numpy.array
+    theta : 1D numpy.array
         angle coordinates, referenced to vertical direction
     """
     if origin is not None and not isinstance(origin, tuple):
@@ -331,7 +342,8 @@ def radial_integration(IM, origin=None, radial_ranges=None):
         Intensity_vs_theta.append(intensity_vs_theta_at_R)
         radial_midpt.append(np.mean(rr))
 
-        beta, amp = anisotropy_parameter(theta, intensity_vs_theta_at_R)
+        beta, amp = anisotropy_parameter(theta, intensity_vs_theta_at_R,
+                                         theta_ranges, mode)
         Beta.append(beta)
         Amp.append(amp)
 
@@ -362,13 +374,13 @@ def anisotropy_parameter(theta, intensity, theta_ranges=None, mode='reject'):
     intensity : 1D numpy array
         intensity variation with angle
 
-    theta_ranges: list of tuples or None
+    theta_ranges : list of tuples or None
         angular ranges over which to fit
         ``[(theta1, theta2), (theta3, theta4)]``.
         Allows data to be excluded from fit; default (``None``) is to include
         all data.
 
-    mode: str
+    mode : str
         ``'raw'``
             return the results regardless of their values
         ``'reject'`` (default)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,8 +45,7 @@ extensions = [
 templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-source_suffix = ['.rst']
+#source_suffix = {'.rst': 'restructuredtext'}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
Investigation of the spurious errors and warnings in CI tests (#391) revealed that:
1. New Apple's hardware (arm64) have larger floating-point errors.
2. The default method `'lm'` in `scipy.optimize.curve_fit()` is broken (see SciPy [#21995](https://github.com/scipy/scipy/issues/21995)) and thus was producing `OptimizeWarning` in _some_ testing environments; more importantly, it could produce wrong estimates for fitting errors.

So this PR changes the method in `curve_fit()` to a well-behaved `'trf'` and also adds tests to ensure that the error estimates returned by `anisotropy_parameter()` are correct. Some tolerances in the tests are also increased slightly to accommodate this change and the sloppier Apple's arm64 performance.

Now all the tests pass cleanly.

The `'trf'` method also supports constrained fitting, with is useful for keeping the anisotropy parameter in the physical range. Thus the `anisotropy_parameter()` function is extended here such that, instead of always reporting off-range results as `nan`, it also allows to return them as is or to use a constrained fit. By default, the old behavior (returning `nan`) is preserved.

`radial_integration()` is also extended to accept additional parameters and pass them to `anisotropy_parameter()`.
