### PR TITLE
GitHub actions to build sdist and wheels

### DIFF
--- a/.github/workflows/info.py
+++ b/.github/workflows/info.py
@@ -1,0 +1,27 @@
+"""
+Print summary information about current OS, Python, and required packages.
+"""
+import platform
+import sys
+import os
+
+print('Platorm:', platform.platform())
+print('Python:', sys.version)
+
+try:
+    import numpy
+    print('NumPy:', numpy.version.full_version)
+except ImportError:
+    print('NumPy not found')
+
+try:
+    import scipy
+    print('SciPy:', scipy.version.full_version)
+except ImportError:
+    print('SciPy not found')
+
+try:
+    import Cython
+    print('Cython:', Cython.__version__)
+except ImportError:
+    print('Cython not found')

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13, macos-latest, windows-latest]
-        python-version: ["3.7", "3.13"]
+        py-ver: ["3.7", "3.13"]
         ext: [cython, no-cython] # with/without Cython extension
         exclude:
           - os: macos-latest
-            python-version: "3.7" # not available
+            py-ver: "3.7" # not available
           - os: macos-13
-            python-version: "3.13" # to save resources
+            py-ver: "3.13" # to save resources
           # skip no-cython on slower systems
           - os: macos-13
             ext: no-cython
@@ -36,32 +36,25 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.py-ver }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.py-ver }}
         cache: "pip"
         cache-dependency-path: setup.py
     - name: Update setup
       run: python -m pip install --upgrade pip setuptools wheel
     - name: Install Cython
       if: matrix.ext != 'no-cython'
-      # numpy and scipy must be preinstalled for building Cython extension
-      run: python -m pip install numpy scipy cython
+      # NumPy and Cython must be preinstalled for building Cython extension
+      run: python -m pip install numpy cython
     - name: Install pytest
       run: python -m pip install pytest pytest-cov
     - name: Install PyAbel
       run: python -m pip install . -v
     - name: Information
-      # (ugly but portable and with clean output)
-      run: >
-        python3 -c "import platform, sys, os, numpy, scipy;
-        print('Platorm:', platform.platform());
-        print('Python:', sys.version);
-        print('NumPy:', numpy.version.full_version);
-        print('SciPy:', scipy.version.full_version, flush=True);
-        os.system('cython -V 2>cython.err') and print('Cython not found')"
-    - name: Run tests
+      run: python .github/workflows/info.py
+    - name: TESTS
       # "cd .." for coverage of installed abel instead of ./abel subdir
       run: |
         cd ..

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -1,0 +1,63 @@
+name: Build sdist
+
+on: [workflow_dispatch, workflow_call]
+
+env:
+  FORCE_COLOR: 1 # colored output where possible
+
+jobs:
+  sdist:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12" # only for setuptools
+    - name: Update setup
+      run: python -m pip install --upgrade pip setuptools
+    - name: Create source distribution
+      run: python setup.py sdist
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sdist-${{ github.ref_name }}
+        path: ./dist/*
+
+  sdist-test:
+    needs: sdist
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        py-ver: ["3.7", "3.13"]
+        ext: [cython, no-cython] # with/without Cython extension
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github/workflows/info.py
+        sparse-checkout-cone-mode: false
+    - uses: actions/download-artifact@v4
+      with:
+        name: sdist-${{ github.ref_name }}
+    - run: rm -rf .git; ls -Al
+    - name: Set up Python ${{ matrix.py-ver }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.py-ver }}
+    - name: Update setup
+      run: python -m pip install --upgrade pip setuptools wheel
+    - name: Install Cython
+      if: matrix.ext != 'no-cython'
+      # NumPy and Cython must be preinstalled for building Cython extension
+      run: python -m pip install numpy cython
+    - name: Information
+      run: python .github/workflows/info.py
+    - name: Install PyAbel from source distribution
+      run: python -m pip install -v *.tar.gz
+    - name: Information
+      run: python .github/workflows/info.py
+    - name: Install pytest
+      run: python -m pip install pytest
+    - name: TESTS
+      run: python -m pytest -v --pyargs abel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,49 @@
+name: Build wheels
+
+on: [workflow_dispatch, workflow_call]
+
+jobs:
+  wheels:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-13, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12" # for cibuildwheel itself
+    - name: Install cibuildwheel
+      run: python -m pip install cibuildwheel==2.22.0
+    - name: Build wheels
+      env:
+        CIBW_BUILD_VERBOSITY: 1
+        # Linux also tries to build i686 (for which NumPy has no binary packages)
+        CIBW_ARCHS: "native"
+        # "manylinux" should be enough
+        CIBW_SKIP: "*musllinux*"
+        # build only for Python versions with full support
+        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.12"
+        # preinstall packages required to build with Cython extension
+        CIBW_BEFORE_BUILD: "python -m pip install setuptools numpy cython"
+        # set env variables for build and test:
+        # colored output where possible;
+        # don't try to compile NumPy and SciPy from source;
+        # disable PEP 517 build isolation, instead use already installed packages
+        # (weirdly, must be set to 0, see https://github.com/pypa/pip/issues/5735)
+        CIBW_ENVIRONMENT: >
+          FORCE_COLOR=1
+          PIP_ONLY_BINARY=":all:"
+          PIP_NO_BUILD_ISOLATION=0
+
+        CIBW_TEST_REQUIRES: "pytest"
+        # calling pytest directly uses wrong python;
+        # results can be copied to output (with meaningful name) only manually
+        CIBW_TEST_COMMAND: python -m pytest --pyargs abel
+      run: python -m cibuildwheel --output-dir wheels
+    - uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ github.ref_name }}-${{ matrix.os }}
+        path: ./wheels/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include README.rst
 include LICENSE.txt
-recursive-include abel *.py
-recursive-include abel *.gz
+recursive-include abel *.py *.pyx
 recursive-include examples *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst
 include LICENSE.txt
 recursive-include abel *.py *.pyx
-recursive-include examples *.py
+recursive-include examples *.py *.txt

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,4 +1,7 @@
-Some example scripts provided here must be run from this directory, since they
-need the "data" subdirectory with the example data files. If you wish to copy
-or run such scripts elsewhere, please make sure that this path is available or
-modify it accordingly.
+Some example scripts provided here require example data files in the "data"
+subdirectory. If you wish to copy or run such scripts elsewhere, please make
+sure that this path is available or modify it accordingly.
+
+Note: PyAbel distribution packages do not include the "data" directory, please
+download its contents from the PyAbel repository
+https://github.com/PyAbel/PyAbel/tree/master/examples/data

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if _cython_installed:  # if Cython is installed, we will try to build direct-C
         extra_compile_args = ['/Ox', '/fp:fast']
         libraries = []
     else:
-        extra_compile_args = ['-Ofast']
+        extra_compile_args = ['-Ofast', '-g0']
         libraries = ["m"]
 
     # Optional compilation of Cython modules adapted from


### PR DESCRIPTION
Here is the next step in moving from Travis CI to GitHub Actions (#365):
* Building the source distribution (sdist) and also testing that it can be installed with and without Cython.
* Building binary distributions (wheels, with the Cython extension) again, but now for
   * Linux (amd64),
   * macOS (amd64 and arm64),
   * Windows (amd64).

The wheels are built using [cibuildwheel](https://github.com/pypa/cibuildwheel) (apparently the official tool), as [suggested](https://github.com/PyAbel/PyAbel/issues/365#issuecomment-1336233250) by @rth. Although it supports more platforms, not all are actually provided (for free) by GitHub Actions, plus NumPy and SciPy themselves don't have binary packages for everything (x86 Linux is an example), so probably covering the most popular ones will be good enough.

An advantage over Travis is that these builds can be triggered manually (right now — only manually, just in case) and also for any branch, so we will be able to test them before releasing and, if needed, build and test distributions for other configurations without affecting the master branch.

No upload to PyPI is implemented yet (to avoid possible errors and because I haven't looked at that yet).

These actions will appear in the [Actions](https://github.com/PyAbel/PyAbel/actions) tab as “Build sdist” and “Build wheels”. The results will be available as downloadable workflow run artifacts.