### PR TITLE
Update for Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,10 +16,11 @@ python:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
- # treat warnings as build errors
- fail_on_warning: true
+  configuration: doc/conf.py
+  # treat warnings as build errors
+  fail_on_warning: true
 
 # Also build downloadable PDF
 formats:
- - pdf
- - htmlzip
+  - pdf
+  - htmlzip


### PR DESCRIPTION
I've got an email from Read the Docs about
> deprecation of projects using Sphinx or MkDocs without an explicit configuration

(see [here](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) for details).

So here is the explicit configuration.
Plus normalized indentation.