### PR TITLE
Minor documentation updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,13 @@ PyAbel provides efficient implementations of several Abel transform algorithms, 
 Transform Methods
 -----------------
 
-The outcome of the numerical Abel transform depends on the exact method used. So far, PyAbel includes the following `transform methods <https://pyabel.readthedocs.io/en/latest/transform_methods.html>`__:
+.. begin-github-only3
+
+.. |methods| replace:: `transform methods <https://pyabel.readthedocs.io/en/latest/transform_methods.html>`__
+
+.. end-github-only3
+
+The outcome of the numerical Abel transform depends on the exact method used. So far, PyAbel includes the following |methods|:
 
 1. ``basex`` – Gaussian basis set expansion of Dribinski and co-workers.
 
@@ -125,14 +131,14 @@ The results can then be plotted using Matplotlib:
 
 Output:
 
-.. begin-github-only3
+.. begin-github-only4
 
 .. image:: https://pyabel.readthedocs.io/en/latest/_images/readme_link-1.svg
     :alt: example Abel transform
 
 .. |examples| replace:: on the `PyAbel examples <https://pyabel.readthedocs.io/en/latest/examples.html>`__ page
 
-.. end-github-only3
+.. end-github-only4
 
 .. note:: Additional examples can be viewed |examples|, and even more are found in the `PyAbel/examples <https://github.com/PyAbel/PyAbel/tree/master/examples>`__ directory.
 
@@ -198,11 +204,11 @@ We welcome suggestions for improvement, together with any interesting images tha
 
 Either open a new `issue <https://github.com/PyAbel/PyAbel/issues>`__ or make a `pull request <https://github.com/PyAbel/PyAbel/pulls>`__.
 
-.. begin-github-only4
+.. begin-github-only5
 
 .. |CONTRIBUTING| replace:: `CONTRIBUTING.rst <https://github.com/PyAbel/PyAbel/blob/master/CONTRIBUTING.rst>`__
 
-.. end-github-only4
+.. end-github-only5
 
 |CONTRIBUTING| has more information on how to contribute, such as how to run the unit tests and how to build the documentation.
 
@@ -222,12 +228,12 @@ First and foremost, please cite the paper(s) corresponding to the implementation
 
 If you find PyAbel useful in you work, it would bring us great joy if you would cite the project. You can find the DOI for the lastest verison at `Zenodo <https://dx.doi.org/10.5281/zenodo.594858>`__.
 
-.. begin-github-only5
+.. begin-github-only6
 
 .. image:: https://zenodo.org/badge/30170345.svg
     :target: https://zenodo.org/badge/latestdoi/30170345
 
-.. end-github-only5
+.. end-github-only6
 
 Additionally, we have written a scientific paper comparing various Abel transform methods. You can find the manuscript at the Review of Scientific Instruments (DOI: `10.1063/1.5092635 <https://doi.org/10.1063/1.5092635>`__) or on arxiv (`arxiv.org/abs/1902.09007 <https://arxiv.org/abs/1902.09007>`__).
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyAbel'
-copyright = u'2016–2024, PyAbel team'
+copyright = u'2016–2025, PyAbel team'
 author = 'PyAbel team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/conf/mathjax.py
+++ b/doc/conf/mathjax.py
@@ -5,7 +5,7 @@ Helper script for HTML builds: try to download MathJax and use its local copy
 
 if any('html' in arg for arg in sys.argv):  # any argument has substring 'html'
     # URL (most complete standalone script, ~2 MB)
-    mj_url = 'https://github.com/mathjax/MathJax/raw/master/es5/tex-svg-full.js'
+    mj_url = 'https://cdn.jsdelivr.net/npm/mathjax@4/tex-svg.js'
     # local file name
     mj_file = 'mathjax.js'
     # relative file path in source tree

--- a/doc/readme_link.rst
+++ b/doc/readme_link.rst
@@ -15,6 +15,12 @@
     :start-after: end-github-only2
     :end-before: begin-github-only3
 
+.. |methods| replace:: :doc:`transform methods <transform_methods>`
+
+.. include:: ../README.rst
+    :start-after: end-github-only3
+    :end-before: begin-github-only4
+
 .. plot::
 
     import abel
@@ -40,14 +46,14 @@
 .. |examples| replace:: in :doc:`PyAbel examples <examples>`
 
 .. include:: ../README.rst
-    :start-after: end-github-only3
-    :end-before: begin-github-only4
+    :start-after: end-github-only4
+    :end-before: begin-github-only5
 
 .. |CONTRIBUTING| replace:: :doc:`Contributing to PyAbel <contributing_link>`
 
 .. include:: ../README.rst
-    :start-after: end-github-only4
-    :end-before: begin-github-only5
+    :start-after: end-github-only5
+    :end-before: begin-github-only6
 
 .. include:: ../README.rst
-    :start-after: end-github-only5
+    :start-after: end-github-only6

--- a/doc/tools/polynomial.rst
+++ b/doc/tools/polynomial.rst
@@ -319,7 +319,7 @@ The Gaussian function
 is useful for representing peaks in simulated data but does not have an
 analytical Abel transform unless :math:`r_0 = 0`. However, it can be
 approximated by piecewise polynomials to any accuracy, and these polynomials
-can be Able-transformed analytically, as shown above, thus providing an
+can be Abel-transformed analytically, as shown above, thus providing an
 arbitrarily accurate approximation to the Abel transform of the initial
 Gaussian function.
 


### PR DESCRIPTION
In preparation for the new release (#401), here are corrections to some problems noticed in the docs:
1. “Able-transformed” → “Abel-transformed” (a common typo, but seems to be the only occurrence in the repository).
2. “PyAbel includes the following transform methods” in README was always linking to the _latest_ RTD version, even for other RTD versions and when built locally. Now it is replaced in `doc/readme_link.rst` accordingly, like other such links.
3. The MathJax download link stopped working, so it had to be updated.