### PR TITLE
Preparations for v0.9.1rc2 release (v0.9.1 pre-release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+v0.9.1rc2 (2025-09-17)
+----------------------
 * Minor updates for compatibility with recent Python, NumPy, SciPy and
   Matplotlib versions (PR #373, #378).
 * Various documentation updates, corrections and improvements.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Unreleased
 * New option "mode" for tools.vmi.anisotropy_parameter() to control its
   behavior when beta is outside the physical range. For consistency,
   radial_integration() now also accepts theta_ranges and mode (PR #394).
+* Building and publishing AMD64 and ARM64 wheels for Linux, macOS, and Windows
+  (PR #395, #403).
 
 v0.9.0 (2022-12-14)
 -------------------

--- a/abel/_version.py
+++ b/abel/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.1rc1"
+__version__ = "0.9.1rc2"


### PR DESCRIPTION
Well, TestPyPI (like the real PyPI) will not allow uploading the same version even after deleting the existing release from there, so since I've uploaded 0.9.1rc1 from my fork, we’ll need to increment the rc version to be able to test it...

I've also updated the changelog, and here is a draft of the release notes:
```
Release candidate for v0.9.1.

Reliability and consistency improvements to tools.vmi methods.
Otherwise this is mostly a maintenance release with improvements to
documentation, code updates to ensure compatibility with recent versions of
Python and underlying libraries (most notably NumPy 2.x), as well as making
binary distributions (wheels) for the latest Python versions on most common
platforms available on PyPI.

This is the last PyAbel version with Python 2 support.

Here is a full list of changes in v0.9.1:
* Minor updates for compatibility with recent Python, NumPy, SciPy and
  Matplotlib versions (PR #373, #378).
* Various documentation updates, corrections and improvements.
* The optimization method in tools.vmi.anisotropy_parameter() and
  math.fit_gaussian() is changed to "trf" from the default "lm", which has a
  defective implementation in SciPy and could produce wrong error estimates or
  OptimizeWarning in some cases (PR #394).
* New option "mode" for tools.vmi.anisotropy_parameter() to control its
  behavior when beta is outside the physical range. For consistency,
  radial_integration() now also accepts theta_ranges and mode (PR #394).
* Building and publishing AMD64 and ARM64 wheels for Linux, macOS, and Windows
  (PR #395, #403).
```
