### PR TITLE
Fix PEP8 import order in benchmark.py

### DIFF
--- a/abel/benchmark.py
+++ b/abel/benchmark.py
@@ -1,5 +1,10 @@
+from timeit import default_timer as timer
+import itertools
+import sys
+
 import numpy as np
 import abel
+
 from . import basex
 from . import dasch
 from . import daun
@@ -9,10 +14,6 @@ from . import linbasex
 from . import onion_bordas
 from . import rbasex
 from . import tools
-
-from timeit import default_timer as timer
-import itertools
-import sys
 
 
 def _ensure_list(x):


### PR DESCRIPTION
## Summary
Fixed PEP8 import order violations in `abel/benchmark.py` by moving standard library imports to the top of the file.

## Changes
- Moved `from timeit import default_timer as timer`, `import itertools`, and `import sys` from lines 13-15 to the top of the file (before third-party imports)
- Organized imports according to PEP8 conventions:
  1. Standard library imports
  2. Third-party imports (numpy, abel)
  3. Local imports (from . import ...)

## Impact
- Addresses a small portion of issue #294 ("Make old code PEP8 compliant")
- No functional changes, only style improvements
- Improves code readability and maintainability

## Testing
No functional changes, so existing tests continue to pass. This is a pure code style fix.